### PR TITLE
Fix infinite loop and broken list rendering

### DIFF
--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -140,22 +140,21 @@
     {:else if type === 'list'}
         {#if ordered}
             <renderers.list {ordered} {...rest}>
-                {@const items = rest.items as Props[]}
+                {@const { items, ...parserRest }: {items: Props[]} = rest}
                 {#each items as item}
                     {@const OrderedListComponent = renderers.orderedlistitem || renderers.listitem}
                     <OrderedListComponent {...item}>
-                        <Parser tokens={item.tokens} {renderers} />
+                        <Parser tokens={item.tokens} {renderers} {...parserRest} />
                     </OrderedListComponent>
                 {/each}
             </renderers.list>
         {:else}
             <renderers.list {ordered} {...rest}>
-                {@const items = rest.items as Props[]}
+                {@const { items, ...parserRest }: {items: Props[]} = rest}
                 {#each items as item}
-                    {@const UnorderedListComponent =
-                        renderers.unorderedlistitem || renderers.listitem}
-                    <UnorderedListComponent {...item} {...rest}>
-                        <Parser tokens={item.tokens} {renderers} {...rest} />
+                    {@const UnorderedListComponent = renderers.unorderedlistitem || renderers.listitem}
+                    <UnorderedListComponent {...item}>
+                        <Parser tokens={item.tokens} {renderers} {...parserRest} />
                     </UnorderedListComponent>
                 {/each}
             </renderers.list>

--- a/tests/SvelteMarkdown.test.ts
+++ b/tests/SvelteMarkdown.test.ts
@@ -69,4 +69,59 @@ test.describe('SvelteMarkdown', () => {
         await expect(page.locator('em')).toHaveText('italic text')
         await expect(page.locator('a')).toHaveAttribute('href', 'https://example.com')
     })
+
+    test('should handle unordered nested lists', async ({ page }) => {
+        await page.goto('/test/reactivity')
+        const textarea = page.getByTestId('markdown-input')
+
+        // Test with more complex markdown
+        const complexMarkdown = `
+- List item 1
+  - List item 2
+        `.trim()
+
+        await textarea.clear()
+        await textarea.fill(complexMarkdown)
+
+        // Verify complex markdown rendering
+        await expect(page.locator('.preview>ul>li')).toHaveCount(1)
+        await expect(page.locator('.preview>ul>li>ul>li')).toHaveCount(1)
+        await expect(page.locator('ul li')).toHaveCount(2)
+    })
+    test('should handle ordered nested lists', async ({ page }) => {
+        await page.goto('/test/reactivity')
+        const textarea = page.getByTestId('markdown-input')
+
+        // Test with more complex markdown
+        const complexMarkdown = `
+1. List item 1
+   1. List item 2
+        `.trim()
+
+        await textarea.clear()
+        await textarea.fill(complexMarkdown)
+
+        // Verify complex markdown rendering
+        await expect(page.locator('.preview>ol>li')).toHaveCount(1)
+        await expect(page.locator('.preview>ol>li>ol>li')).toHaveCount(1)
+        await expect(page.locator('ol li')).toHaveCount(2)
+    })
+    test('should handle mixed nested lists', async ({ page }) => {
+        await page.goto('/test/reactivity')
+        const textarea = page.getByTestId('markdown-input')
+
+        // Test with more complex markdown
+        const complexMarkdown = `
+- List item 1
+   1. List item 2
+        `.trim()
+
+        await textarea.clear()
+        await textarea.fill(complexMarkdown)
+
+        // Verify complex markdown rendering
+        await expect(page.locator('.preview>ul>li')).toHaveCount(1)
+        await expect(page.locator('.preview>ul>li>ol>li')).toHaveCount(1)
+        await expect(page.locator('li')).toHaveCount(2)
+    })
 })


### PR DESCRIPTION
In our use of SvelteMarkdown I ran into a couple of weird issues:
1. Some lists would render wrong, by repeating their contents. e.g. 
![image](https://github.com/user-attachments/assets/035d4e74-84a5-4c3c-b389-e855f769336c)

2. Others would crash with a message like: `Uncaught (in promise) RangeError: Maximum call stack size exceeded` when given a simple nested list.
![image](https://github.com/user-attachments/assets/cfe320b0-c81e-462f-b212-c44bbf32aa17) 

I've tracked both issues down to the Parser component where the recursive call would receive `...rest` instead of a more limited set of parameters like `...parserRest` like it is done in other places in the component.

I've adapted both of the list related calls to only pass on the more limited set of parameters and extended the tests to cover both types of nested lists and a mixed usage case.