### PR TITLE
Bug: Issue 206 - add component truthy checks to prevent rendering null/undefined components

### DIFF
--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -83,73 +83,78 @@
         {/each}
     {/if}
 {:else if type in renderers}
-    {#if type === 'table' && renderers.table && renderers.tablerow && renderers.tablecell}
-        <renderers.table {...rest}>
-            {#if renderers.tablehead}
-                <renderers.tablehead {...rest}>
-                    <renderers.tablerow {...rest}>
-                        {#each header ?? [] as headerItem, i (i)}
-                            {@const { align: _align, ...cellRest } = rest}
-                            <renderers.tablecell
-                                header={true}
-                                align={(rest.align as string[])[i]}
-                                {...cellRest}
-                            >
-                                <Parser tokens={headerItem.tokens} {renderers} />
-                            </renderers.tablecell>
-                        {/each}
-                    </renderers.tablerow>
-                </renderers.tablehead>
-            {/if}
-            {#if renderers.tablebody}
-                <renderers.tablebody {...rest}>
-                    {#each rows ?? [] as row, i (i)}
+    {#if type === 'table'}
+        {#if renderers.table && renderers.tablerow && renderers.tablecell}
+            <renderers.table {...rest}>
+                {#if renderers.tablehead}
+                    <renderers.tablehead {...rest}>
                         <renderers.tablerow {...rest}>
-                            {#each row ?? [] as cells, i (i)}
+                            {#each header ?? [] as headerItem, i (i)}
                                 {@const { align: _align, ...cellRest } = rest}
                                 <renderers.tablecell
-                                    header={false}
+                                    header={true}
                                     align={(rest.align as string[])[i]}
                                     {...cellRest}
                                 >
-                                    {#if cells.tokens?.[0]?.type === 'html'}
-                                        {@const token = cells.tokens[0] as Token & {
-                                            tag: string
-                                            tokens?: Token[]
-                                        }}
-                                        {@const { tag, ...localRest } = token}
-                                        {@const htmlTag = tag as keyof typeof Html}
-                                        {#if renderers.html && htmlTag in renderers.html}
-                                            {@const HtmlComponent =
-                                                renderers.html[
-                                                    htmlTag as keyof typeof renderers.html
-                                                ]}
-                                            {#if HtmlComponent}
-                                                <HtmlComponent {...token}>
-                                                    {#if token.tokens?.length}
-                                                        <Parser
-                                                            tokens={token.tokens}
-                                                            {renderers}
-                                                            {...Object.fromEntries(
-                                                                Object.entries(localRest).filter(
-                                                                    ([key]) => key !== 'attributes'
-                                                                )
-                                                            )}
-                                                        />
-                                                    {/if}
-                                                </HtmlComponent>
-                                            {/if}
-                                        {/if}
-                                    {:else}
-                                        <Parser tokens={cells.tokens} {renderers} />
-                                    {/if}
+                                    <Parser tokens={headerItem.tokens} {renderers} />
                                 </renderers.tablecell>
                             {/each}
                         </renderers.tablerow>
-                    {/each}
-                </renderers.tablebody>
-            {/if}
-        </renderers.table>
+                    </renderers.tablehead>
+                {/if}
+                {#if renderers.tablebody}
+                    <renderers.tablebody {...rest}>
+                        {#each rows ?? [] as row, i (i)}
+                            <renderers.tablerow {...rest}>
+                                {#each row ?? [] as cells, i (i)}
+                                    {@const { align: _align, ...cellRest } = rest}
+                                    <renderers.tablecell
+                                        header={false}
+                                        align={(rest.align as string[])[i]}
+                                        {...cellRest}
+                                    >
+                                        {#if cells.tokens?.[0]?.type === 'html'}
+                                            {@const token = cells.tokens[0] as Token & {
+                                                tag: string
+                                                tokens?: Token[]
+                                            }}
+                                            {@const { tag, ...localRest } = token}
+                                            {@const htmlTag = tag as keyof typeof Html}
+                                            {#if renderers.html && htmlTag in renderers.html}
+                                                {@const HtmlComponent =
+                                                    renderers.html[
+                                                        htmlTag as keyof typeof renderers.html
+                                                    ]}
+                                                {#if HtmlComponent}
+                                                    <HtmlComponent {...token}>
+                                                        {#if token.tokens?.length}
+                                                            <Parser
+                                                                tokens={token.tokens}
+                                                                {renderers}
+                                                                {...Object.fromEntries(
+                                                                    Object.entries(
+                                                                        localRest
+                                                                    ).filter(
+                                                                        ([key]) =>
+                                                                            key !== 'attributes'
+                                                                    )
+                                                                )}
+                                                            />
+                                                        {/if}
+                                                    </HtmlComponent>
+                                                {/if}
+                                            {/if}
+                                        {:else}
+                                            <Parser tokens={cells.tokens} {renderers} />
+                                        {/if}
+                                    </renderers.tablecell>
+                                {/each}
+                            </renderers.tablerow>
+                        {/each}
+                    </renderers.tablebody>
+                {/if}
+            </renderers.table>
+        {/if}
     {:else if type === 'list' && renderers.list}
         {#if ordered}
             <renderers.list {ordered} {...rest}>

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -83,68 +83,74 @@
         {/each}
     {/if}
 {:else if type in renderers}
-    {#if type === 'table'}
+    {#if type === 'table' && renderers.table && renderers.tablerow && renderers.tablecell}
         <renderers.table {...rest}>
-            <renderers.tablehead {...rest}>
-                <renderers.tablerow {...rest}>
-                    {#each header ?? [] as headerItem, i (i)}
-                        {@const { align: _align, ...cellRest } = rest}
-                        <renderers.tablecell
-                            header={true}
-                            align={(rest.align as string[])[i]}
-                            {...cellRest}
-                        >
-                            <Parser tokens={headerItem.tokens} {renderers} />
-                        </renderers.tablecell>
-                    {/each}
-                </renderers.tablerow>
-            </renderers.tablehead>
-            <renderers.tablebody {...rest}>
-                {#each rows ?? [] as row, i (i)}
+            {#if renderers.tablehead}
+                <renderers.tablehead {...rest}>
                     <renderers.tablerow {...rest}>
-                        {#each row ?? [] as cells, i (i)}
+                        {#each header ?? [] as headerItem, i (i)}
                             {@const { align: _align, ...cellRest } = rest}
                             <renderers.tablecell
-                                header={false}
+                                header={true}
                                 align={(rest.align as string[])[i]}
                                 {...cellRest}
                             >
-                                {#if cells.tokens?.[0]?.type === 'html'}
-                                    {@const token = cells.tokens[0] as Token & {
-                                        tag: string
-                                        tokens?: Token[]
-                                    }}
-                                    {@const { tag, ...localRest } = token}
-                                    {@const htmlTag = tag as keyof typeof Html}
-                                    {#if renderers.html && htmlTag in renderers.html}
-                                        {@const HtmlComponent =
-                                            renderers.html[htmlTag as keyof typeof renderers.html]}
-                                        {#if HtmlComponent}
-                                            <HtmlComponent {...token}>
-                                                {#if token.tokens?.length}
-                                                    <Parser
-                                                        tokens={token.tokens}
-                                                        {renderers}
-                                                        {...Object.fromEntries(
-                                                            Object.entries(localRest).filter(
-                                                                ([key]) => key !== 'attributes'
-                                                            )
-                                                        )}
-                                                    />
-                                                {/if}
-                                            </HtmlComponent>
-                                        {/if}
-                                    {/if}
-                                {:else}
-                                    <Parser tokens={cells.tokens} {renderers} />
-                                {/if}
+                                <Parser tokens={headerItem.tokens} {renderers} />
                             </renderers.tablecell>
                         {/each}
                     </renderers.tablerow>
-                {/each}
-            </renderers.tablebody>
+                </renderers.tablehead>
+            {/if}
+            {#if renderers.tablebody}
+                <renderers.tablebody {...rest}>
+                    {#each rows ?? [] as row, i (i)}
+                        <renderers.tablerow {...rest}>
+                            {#each row ?? [] as cells, i (i)}
+                                {@const { align: _align, ...cellRest } = rest}
+                                <renderers.tablecell
+                                    header={false}
+                                    align={(rest.align as string[])[i]}
+                                    {...cellRest}
+                                >
+                                    {#if cells.tokens?.[0]?.type === 'html'}
+                                        {@const token = cells.tokens[0] as Token & {
+                                            tag: string
+                                            tokens?: Token[]
+                                        }}
+                                        {@const { tag, ...localRest } = token}
+                                        {@const htmlTag = tag as keyof typeof Html}
+                                        {#if renderers.html && htmlTag in renderers.html}
+                                            {@const HtmlComponent =
+                                                renderers.html[
+                                                    htmlTag as keyof typeof renderers.html
+                                                ]}
+                                            {#if HtmlComponent}
+                                                <HtmlComponent {...token}>
+                                                    {#if token.tokens?.length}
+                                                        <Parser
+                                                            tokens={token.tokens}
+                                                            {renderers}
+                                                            {...Object.fromEntries(
+                                                                Object.entries(localRest).filter(
+                                                                    ([key]) => key !== 'attributes'
+                                                                )
+                                                            )}
+                                                        />
+                                                    {/if}
+                                                </HtmlComponent>
+                                            {/if}
+                                        {/if}
+                                    {:else}
+                                        <Parser tokens={cells.tokens} {renderers} />
+                                    {/if}
+                                </renderers.tablecell>
+                            {/each}
+                        </renderers.tablerow>
+                    {/each}
+                </renderers.tablebody>
+            {/if}
         </renderers.table>
-    {:else if type === 'list'}
+    {:else if type === 'list' && renderers.list}
         {#if ordered}
             <renderers.list {ordered} {...rest}>
                 {@const { items, ...parserRest }: {items: Props[]} = rest}

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -119,19 +119,21 @@
                                     {#if renderers.html && htmlTag in renderers.html}
                                         {@const HtmlComponent =
                                             renderers.html[htmlTag as keyof typeof renderers.html]}
-                                        <HtmlComponent {...token}>
-                                            {#if token.tokens?.length}
-                                                <Parser
-                                                    tokens={token.tokens}
-                                                    {renderers}
-                                                    {...Object.fromEntries(
-                                                        Object.entries(localRest).filter(
-                                                            ([key]) => key !== 'attributes'
-                                                        )
-                                                    )}
-                                                />
-                                            {/if}
-                                        </HtmlComponent>
+                                        {#if HtmlComponent}
+                                            <HtmlComponent {...token}>
+                                                {#if token.tokens?.length}
+                                                    <Parser
+                                                        tokens={token.tokens}
+                                                        {renderers}
+                                                        {...Object.fromEntries(
+                                                            Object.entries(localRest).filter(
+                                                                ([key]) => key !== 'attributes'
+                                                            )
+                                                        )}
+                                                    />
+                                                {/if}
+                                            </HtmlComponent>
+                                        {/if}
                                     {/if}
                                 {:else}
                                     <Parser tokens={cells.tokens} {renderers} />
@@ -148,9 +150,11 @@
                 {@const { items, ...parserRest }: {items: Props[]} = rest}
                 {#each items as item, index (index)}
                     {@const OrderedListComponent = renderers.orderedlistitem || renderers.listitem}
-                    <OrderedListComponent {...item}>
-                        <Parser {...parserRest} tokens={item.tokens} {renderers} />
-                    </OrderedListComponent>
+                    {#if OrderedListComponent}
+                        <OrderedListComponent {...item}>
+                            <Parser {...parserRest} tokens={item.tokens} {renderers} />
+                        </OrderedListComponent>
+                    {/if}
                 {/each}
             </renderers.list>
         {:else}
@@ -159,9 +163,11 @@
                 {#each items as item, index (index)}
                     {@const UnorderedListComponent =
                         renderers.unorderedlistitem || renderers.listitem}
-                    <UnorderedListComponent {...item}>
-                        <Parser {...parserRest} tokens={item.tokens} {renderers} />
-                    </UnorderedListComponent>
+                    {#if UnorderedListComponent}
+                        <UnorderedListComponent {...item}>
+                            <Parser {...parserRest} tokens={item.tokens} {renderers} />
+                        </UnorderedListComponent>
+                    {/if}
                 {/each}
             </renderers.list>
         {/if}
@@ -170,18 +176,20 @@
         {@const htmlTag = rest.tag as keyof typeof Html}
         {#if renderers.html && htmlTag in renderers.html}
             {@const HtmlComponent = renderers.html[htmlTag as keyof typeof renderers.html]}
-            {@const tokens = (rest.tokens as Token[]) ?? ([] as Token[])}
-            <HtmlComponent {...rest}>
-                {#if tokens.length}
-                    <Parser
-                        {tokens}
-                        {renderers}
-                        {...Object.fromEntries(
-                            Object.entries(localRest).filter(([key]) => key !== 'attributes')
-                        )}
-                    />
-                {/if}
-            </HtmlComponent>
+            {#if HtmlComponent}
+                {@const tokens = (rest.tokens as Token[]) ?? ([] as Token[])}
+                <HtmlComponent {...rest}>
+                    {#if tokens.length}
+                        <Parser
+                            {tokens}
+                            {renderers}
+                            {...Object.fromEntries(
+                                Object.entries(localRest).filter(([key]) => key !== 'attributes')
+                            )}
+                        />
+                    {/if}
+                </HtmlComponent>
+            {/if}
         {:else}
             <Parser
                 tokens={(rest.tokens as Token[]) ?? ([] as Token[])}
@@ -191,13 +199,15 @@
         {/if}
     {:else}
         {@const GeneralComponent = renderers[type as keyof typeof renderers] as RendererComponent}
-        <GeneralComponent {...rest}>
-            {#if tokens}
-                {@const { text: _text, raw: _raw, ...parserRest } = rest}
-                <Parser {...parserRest} {tokens} {renderers} />
-            {:else}
-                <renderers.rawtext text={rest.raw} />
-            {/if}
-        </GeneralComponent>
+        {#if GeneralComponent}
+            <GeneralComponent {...rest}>
+                {#if tokens}
+                    {@const { text: _text, raw: _raw, ...parserRest } = rest}
+                    <Parser {...parserRest} {tokens} {renderers} />
+                {:else}
+                    <renderers.rawtext text={rest.raw} />
+                {/if}
+            </GeneralComponent>
+        {/if}
     {/if}
 {/if}

--- a/src/routes/test/issue-206/+page.svelte
+++ b/src/routes/test/issue-206/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+    import SvelteMarkdown, { type Renderers, type Token, type TokensList } from '$lib/index.js'
+
+    let source = `
+# This should be the only text.
+
+![image](https://avatars.githubusercontent.com/u/162604590?s=64&u=548f358e716a223731ab372776a09723cf815f4d&v=4)
+
+<del>This is hidden.</del>
+
+- Hello.
+
+1. World.
+`
+
+    const parsed = async (parsedTokens: Token[] | TokensList) => {
+        console.log('displaying tokens', parsedTokens)
+    }
+
+    const renderers: Partial<Renderers> = {
+        image: null,
+        html: {
+            del: null
+        },
+        listitem: null,
+        orderedlistitem: null,
+        unorderedlistitem: null
+    }
+</script>
+
+<div class="container">
+    <textarea bind:value={source} placeholder="Enter markdown here" data-testid="markdown-input">
+    </textarea>
+    <div class="preview">
+        <SvelteMarkdown {source} {renderers} {parsed} />
+    </div>
+</div>
+
+<style>
+    .container {
+        display: flex;
+        gap: 1rem;
+        width: 100%;
+    }
+
+    textarea {
+        width: 50%;
+        min-height: 300px;
+        padding: 1rem;
+        font-family: monospace;
+    }
+
+    .preview {
+        width: 50%;
+        padding: 1rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+    }
+</style>

--- a/src/routes/test/issue-206/+page.svelte
+++ b/src/routes/test/issue-206/+page.svelte
@@ -11,6 +11,10 @@
 - Hello.
 
 1. World.
+
+| Table |
+|-------|
+| Cell |
 `
 
     const parsed = async (parsedTokens: Token[] | TokensList) => {
@@ -23,8 +27,7 @@
             del: null
         },
         listitem: null,
-        orderedlistitem: null,
-        unorderedlistitem: null
+        tablecell: null
     }
 </script>
 


### PR DESCRIPTION
fixes humanspeak/svelte-markdown#206

In previous versions of svelte, the component would be passed to `<svelte:component>` where if falsy, no component is rendered. In svelte 5, components are functions as as such `null` or `undefined` would attempt to be called throwing an error. This functionality was used to block specific components (for example, images) from rendering and was still included in the `renderers` typing.

The check is just manually implemented before attempting to render any user-passed components.

For tables, if any of the core components (`table`, `tablerow`, `tablecell`) are disabled it will prevent the entire table from rendering as otherwise there would be no or an invalid output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a live markdown editor and preview interface with customizable renderers and real-time token logging.

- **Bug Fixes**
  - Improved stability by ensuring components are only rendered if their corresponding renderer exists, preventing potential runtime errors in markdown rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->