### PR TITLE
Invoke options.walkTokens after parsing tokens

### DIFF
--- a/src/lib/utils/parse-and-cache.test.ts
+++ b/src/lib/utils/parse-and-cache.test.ts
@@ -1,5 +1,5 @@
 import type { SvelteMarkdownOptions } from '$lib/types.js'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { parseAndCacheTokens } from './parse-and-cache.js'
 import { tokenCache } from './token-cache.js'
 
@@ -278,6 +278,16 @@ console.log('code');
 
             expect(tokens).toBeDefined()
             expect(tokens.length).toBeGreaterThan(0)
+        })
+
+        it('should invoke options.walkTokens if defined', () => {
+            const source = '# Test'
+            const walkTokens = vi.fn(() => {})
+            const options: SvelteMarkdownOptions = { walkTokens }
+
+            parseAndCacheTokens(source, options, false)
+
+            expect(walkTokens).toHaveBeenCalled()
         })
     })
 

--- a/src/lib/utils/parse-and-cache.ts
+++ b/src/lib/utils/parse-and-cache.ts
@@ -50,6 +50,10 @@ export function parseAndCacheTokens(
 
     const cleanedTokens = shrinkHtmlTokens(parsedTokens) as Token[]
 
+    if (typeof options.walkTokens === 'function') {
+        cleanedTokens.forEach(options.walkTokens)
+    }
+
     // Cache the cleaned tokens for next time
     tokenCache.setTokens(source, options, cleanedTokens)
 


### PR DESCRIPTION
https://github.com/humanspeak/svelte-markdown/issues/228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional callback support for custom token processing, letting users run custom logic on tokens during parsing/caching.

* **Tests**
  * Added tests verifying the new token-walk callback is invoked when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->