### PR TITLE
chore: code quality, performance, and test coverage improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ pnpm format           # Format code with prettier
 - **Prettier** with svelte, organize-imports, and tailwindcss plugins
 - **Husky** pre-commit hooks run `trunk fmt` before commits
 - Code style enforces camelCase, prefer-const, no-var
-- **Never use `eslint-disable` comments.** Use Trunk's inline ignore syntax instead: `// trunk-ignore(eslint/rule-name)`
+- **Never use `eslint-disable` comments** (e.g., `eslint-disable-line`, `eslint-disable-next-line`). Always use Trunk's inline ignore syntax instead: `// trunk-ignore(eslint/rule-name)`. This applies to all files including tests.
 
 ## Testing
 

--- a/src/lib/SvelteMarkdown.svelte
+++ b/src/lib/SvelteMarkdown.svelte
@@ -71,7 +71,7 @@
         [key: string]: unknown
     } = $props()
 
-    const combinedOptions = { ...defaultOptions, ...options }
+    const combinedOptions = $derived({ ...defaultOptions, ...options })
     const slugger = new Slugger()
 
     const tokens = $derived.by(() => {
@@ -94,7 +94,7 @@
         parsed(tokens)
     })
 
-    const combinedRenderers = {
+    const combinedRenderers = $derived({
         ...defaultRenderers,
         ...renderers,
         html: renderers.html
@@ -103,7 +103,7 @@
                   ...renderers.html
               }
             : defaultRenderers.html
-    }
+    })
 </script>
 
 <Parser

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,21 @@
-// Reexport your entry components here
+/**
+ * Public API for `@humanspeak/svelte-markdown`.
+ *
+ * This module re-exports every symbol that consumers of the package can
+ * import.  Exports are organized into the following groups:
+ *
+ * - **Default export** — the main `SvelteMarkdown` component
+ * - **Component helpers** — `Html`, `Unsupported`, and `UnsupportedHTML`
+ * - **Filter utilities** — allow/deny helpers for HTML tags and renderers
+ * - **Constants** — `defaultRenderers`, `rendererKeys`, `htmlRendererKeys`
+ * - **Cache utilities** — `MemoryCache`, `TokenCache`, `tokenCache`
+ * - **Types** — `HtmlRenderers`, `Renderers`, `RendererComponent`,
+ *   `SvelteMarkdownProps`, `SvelteMarkdownOptions`, `Token`, `TokensList`
+ *
+ * @see {@link https://markdown.svelte.page} — documentation site
+ * @module @humanspeak/svelte-markdown
+ */
+
 import { type HtmlRenderers } from '$lib/renderers/html/index.js'
 import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
 import type { SvelteMarkdownOptions, SvelteMarkdownProps } from '$lib/types.js'
@@ -10,28 +27,66 @@ import {
     type TokensList
 } from '$lib/utils/markdown-parser.js'
 
+/** The primary markdown rendering component. */
 export default SvelteMarkdown
+
+/** Default HTML tag-to-component map and the unsupported-tag placeholder. */
 export { default as Html, UnsupportedHTML } from '$lib/renderers/html/index.js'
+
+/** Placeholder component rendered for blocked markdown token types. */
 export { Unsupported } from '$lib/renderers/index.js'
+
+/**
+ * Filter utilities for restricting which HTML tags are rendered.
+ *
+ * - `allowHtmlOnly`   — allow *only* the listed tags
+ * - `excludeHtmlOnly` — block specific tags, allow the rest
+ * - `buildUnsupportedHTML` — block every HTML tag
+ */
 export {
     allowHtmlOnly,
     buildUnsupportedHTML,
     excludeHtmlOnly
 } from '$lib/utils/unsupportedHtmlRenderers.js'
+
+/**
+ * Filter utilities for restricting which markdown renderers are active.
+ *
+ * - `allowRenderersOnly`      — allow *only* the listed renderers
+ * - `excludeRenderersOnly`    — block specific renderers, allow the rest
+ * - `buildUnsupportedRenderers` — block every markdown renderer
+ */
 export {
     allowRenderersOnly,
     buildUnsupportedRenderers,
     excludeRenderersOnly
 } from '$lib/utils/unsupportedRenderers.js'
+
+/** Built-in renderer map used when no custom `renderers` prop is provided. */
 export { defaultRenderers }
-// Canonical key lists (public API names)
+
+/**
+ * Canonical key lists enumerating every valid renderer/HTML tag name.
+ *
+ * - `rendererKeys`     — markdown renderer keys (excludes `html`)
+ * - `htmlRendererKeys`  — supported HTML tag names
+ */
 export {
     htmlRendererKeysInternal as htmlRendererKeys,
     rendererKeysInternal as rendererKeys
 } from '$lib/utils/rendererKeys.js'
-// Cache utilities
+
+/**
+ * Cache utilities for parsed markdown tokens.
+ *
+ * - `MemoryCache` — generic LRU cache
+ * - `TokenCache`  — LRU cache specialized for parsed token arrays
+ * - `tokenCache`  — shared singleton `TokenCache` instance
+ */
 export { MemoryCache } from '$lib/utils/cache.js'
 export { TokenCache, tokenCache } from '$lib/utils/token-cache.js'
+
+/** Re-exported types for consumer convenience. */
 export type {
     HtmlRenderers,
     RendererComponent,

--- a/src/lib/renderers/Blockquote.svelte
+++ b/src/lib/renderers/Blockquote.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown blockquote (`>`) as a `<blockquote>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/Br.svelte
+++ b/src/lib/renderers/Br.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown line break as a `<br />` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/Code.svelte
+++ b/src/lib/renderers/Code.svelte
@@ -1,3 +1,11 @@
+<!--
+@component
+Renders a fenced code block as a `<pre><code>` element. The language identifier
+is applied as a CSS class on the `<pre>` for use with syntax highlighting libraries.
+
+@prop {string} lang - Language identifier from the code fence (e.g. `"js"`, `"typescript"`).
+@prop {string} text - Raw text content of the code block.
+-->
 <script lang="ts">
     interface Props {
         lang: string

--- a/src/lib/renderers/Codespan.svelte
+++ b/src/lib/renderers/Codespan.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an inline code span (`` `code` ``) as a `<code>` element.
+-->
 <script lang="ts">
     interface Props {
         raw: string

--- a/src/lib/renderers/Del.svelte
+++ b/src/lib/renderers/Del.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown strikethrough (`~~text~~`) as a `<del>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/Em.svelte
+++ b/src/lib/renderers/Em.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders markdown emphasis (`*text*` or `_text_`) as an `<em>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/Escape.svelte
+++ b/src/lib/renderers/Escape.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown escape sequence (e.g. `\*`) as plain text.
+-->
 <script lang="ts">
     interface Props {
         text?: string

--- a/src/lib/renderers/Heading.svelte
+++ b/src/lib/renderers/Heading.svelte
@@ -1,3 +1,17 @@
+<!--
+@component
+Renders a markdown heading (`# … ######`) as an `<h1>` through `<h6>` element.
+
+When `options.headerIds` is `true`, an `id` attribute is generated from the
+heading text via `github-slugger`, optionally prefixed by `options.headerPrefix`.
+
+@prop {number} depth - Heading level (1–6).
+@prop {string} raw - Original markdown source of the heading line.
+@prop {string} text - Plain-text content used for slug generation.
+@prop {SvelteMarkdownOptions} options - Parser options (controls ID generation).
+@prop {(val: string) => string} slug - Slugger function for generating heading IDs.
+@prop {Snippet} [children] - Rendered inline content of the heading.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
     import type { SvelteMarkdownOptions } from '$lib/types.js'

--- a/src/lib/renderers/Heading.svelte
+++ b/src/lib/renderers/Heading.svelte
@@ -21,7 +21,7 @@ heading text via `github-slugger`, optionally prefixed by `options.headerPrefix`
         raw: string
         text: string
         options: SvelteMarkdownOptions
-        slug: (val: string) => string // eslint-disable-line no-unused-vars
+        slug: (val: string) => string // trunk-ignore(eslint/no-unused-vars)
         children?: Snippet
     }
 

--- a/src/lib/renderers/Hr.svelte
+++ b/src/lib/renderers/Hr.svelte
@@ -1,1 +1,5 @@
+<!--
+@component
+Renders a markdown thematic break (`---`, `***`, or `___`) as an `<hr />` element.
+-->
 <hr />

--- a/src/lib/renderers/Image.svelte
+++ b/src/lib/renderers/Image.svelte
@@ -1,3 +1,18 @@
+<!--
+@component
+Renders a markdown image (`![alt](src "title")`) as an `<img>` element with
+optional lazy loading and fade-in animation.
+
+Uses `IntersectionObserver` to defer loading until the image scrolls near the
+viewport (configurable via `lazy`).  On load the image fades in; on error it
+is displayed with reduced opacity and a grayscale filter.
+
+@prop {string} [href=''] - Image source URL.
+@prop {string} [title] - Tooltip text for the image.
+@prop {string} [text=''] - Alt text for accessibility.
+@prop {boolean} [lazy=true] - Enable lazy loading via IntersectionObserver.
+@prop {boolean} [fadeIn=true] - Enable a CSS fade-in transition on load.
+-->
 <script lang="ts">
     import { onMount } from 'svelte'
 

--- a/src/lib/renderers/Link.svelte
+++ b/src/lib/renderers/Link.svelte
@@ -1,3 +1,11 @@
+<!--
+@component
+Renders a markdown link (`[text](url "title")`) as an `<a>` element.
+
+@prop {string} [href=''] - Link destination URL.
+@prop {string} [title] - Tooltip text displayed on hover.
+@prop {Snippet} [children] - Rendered inline content of the link.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/List.svelte
+++ b/src/lib/renderers/List.svelte
@@ -1,3 +1,11 @@
+<!--
+@component
+Renders a markdown list as either an `<ol>` (ordered) or `<ul>` (unordered) element.
+
+@prop {boolean} [ordered=false] - When `true`, renders an ordered `<ol>` list.
+@prop {number} [start=1] - Starting number for ordered lists (the `start` attribute).
+@prop {Snippet} [children] - List item content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/ListItem.svelte
+++ b/src/lib/renderers/ListItem.svelte
@@ -1,3 +1,10 @@
+<!--
+@component
+Renders a single list item as an `<li>` element.
+
+@prop {Snippet} [children] - Content of the list item.
+@prop {number} [listItemIndex] - Zero-based index of this item within its parent list.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/Paragraph.svelte
+++ b/src/lib/renderers/Paragraph.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown paragraph as a `<p>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/RawText.svelte
+++ b/src/lib/renderers/RawText.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders raw text content without any wrapping HTML element.
+-->
 <script lang="ts">
     interface Props {
         text?: string

--- a/src/lib/renderers/Strong.svelte
+++ b/src/lib/renderers/Strong.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders markdown strong emphasis (`**text**` or `__text__`) as a `<strong>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/Table.svelte
+++ b/src/lib/renderers/Table.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown table as a `<table>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/TableBody.svelte
+++ b/src/lib/renderers/TableBody.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown table body section as a `<tbody>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/TableCell.svelte
+++ b/src/lib/renderers/TableCell.svelte
@@ -1,3 +1,12 @@
+<!--
+@component
+Renders a table cell as either `<th>` (header) or `<td>` (data), with optional
+text alignment applied as an inline `text-align` style.
+
+@prop {boolean} header - When `true`, renders a `<th>`; otherwise renders a `<td>`.
+@prop {'left'|'center'|'right'|'justify'|'char'|null|undefined} align - Column alignment.
+@prop {Snippet} [children] - Cell content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/TableHead.svelte
+++ b/src/lib/renderers/TableHead.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown table header section as a `<thead>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/TableRow.svelte
+++ b/src/lib/renderers/TableRow.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown table row as a `<tr>` element.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/Text.svelte
+++ b/src/lib/renderers/Text.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a markdown text token by rendering its child content.
+-->
 <script lang="ts">
     import { type Snippet } from 'svelte'
 

--- a/src/lib/renderers/_Unsupported.svelte
+++ b/src/lib/renderers/_Unsupported.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Placeholder renderer for blocked markdown token types. Displays the raw source text.
+-->
 <script lang="ts">
     const { raw } = $props()
 </script>

--- a/src/lib/renderers/html/A.svelte
+++ b/src/lib/renderers/html/A.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<a>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/A.svelte
+++ b/src/lib/renderers/html/A.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<a>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Abbr.svelte
+++ b/src/lib/renderers/html/Abbr.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<abbr>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Abbr.svelte
+++ b/src/lib/renderers/html/Abbr.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<abbr>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Address.svelte
+++ b/src/lib/renderers/html/Address.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<address>` element. Accepts optional attributes and child conte
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Address.svelte
+++ b/src/lib/renderers/html/Address.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<address>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Article.svelte
+++ b/src/lib/renderers/html/Article.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<article>` element. Accepts optional attributes and child conte
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Article.svelte
+++ b/src/lib/renderers/html/Article.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<article>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Aside.svelte
+++ b/src/lib/renderers/html/Aside.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<aside>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Aside.svelte
+++ b/src/lib/renderers/html/Aside.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<aside>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Audio.svelte
+++ b/src/lib/renderers/html/Audio.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<audio>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Audio.svelte
+++ b/src/lib/renderers/html/Audio.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<audio>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/B.svelte
+++ b/src/lib/renderers/html/B.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<b>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/B.svelte
+++ b/src/lib/renderers/html/B.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<b>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Bdi.svelte
+++ b/src/lib/renderers/html/Bdi.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<bdi>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Bdi.svelte
+++ b/src/lib/renderers/html/Bdi.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<bdi>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Bdo.svelte
+++ b/src/lib/renderers/html/Bdo.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<bdo>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Bdo.svelte
+++ b/src/lib/renderers/html/Bdo.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<bdo>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Blockquote.svelte
+++ b/src/lib/renderers/html/Blockquote.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<blockquote>` element. Accepts optional attributes and child co
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Blockquote.svelte
+++ b/src/lib/renderers/html/Blockquote.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<blockquote>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Br.svelte
+++ b/src/lib/renderers/html/Br.svelte
@@ -4,7 +4,7 @@ Renders a self-closing HTML `<br>` element. Accepts optional attributes.
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes = {} }: Props = $props()

--- a/src/lib/renderers/html/Br.svelte
+++ b/src/lib/renderers/html/Br.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a self-closing HTML `<br>` element. Accepts optional attributes.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/Button.svelte
+++ b/src/lib/renderers/html/Button.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<button>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Button.svelte
+++ b/src/lib/renderers/html/Button.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<button>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Canvas.svelte
+++ b/src/lib/renderers/html/Canvas.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<canvas>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Canvas.svelte
+++ b/src/lib/renderers/html/Canvas.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<canvas>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Cite.svelte
+++ b/src/lib/renderers/html/Cite.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<cite>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Cite.svelte
+++ b/src/lib/renderers/html/Cite.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<cite>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Code.svelte
+++ b/src/lib/renderers/html/Code.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<code>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Code.svelte
+++ b/src/lib/renderers/html/Code.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<code>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Datalist.svelte
+++ b/src/lib/renderers/html/Datalist.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<datalist>` element. Accepts optional attributes and child cont
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Datalist.svelte
+++ b/src/lib/renderers/html/Datalist.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<datalist>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Dd.svelte
+++ b/src/lib/renderers/html/Dd.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<dd>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Dd.svelte
+++ b/src/lib/renderers/html/Dd.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<dd>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Del.svelte
+++ b/src/lib/renderers/html/Del.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<del>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Del.svelte
+++ b/src/lib/renderers/html/Del.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<del>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Details.svelte
+++ b/src/lib/renderers/html/Details.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<details>` element. Accepts optional attributes and child conte
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Details.svelte
+++ b/src/lib/renderers/html/Details.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<details>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Dfn.svelte
+++ b/src/lib/renderers/html/Dfn.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<dfn>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Dfn.svelte
+++ b/src/lib/renderers/html/Dfn.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<dfn>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Dialog.svelte
+++ b/src/lib/renderers/html/Dialog.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<dialog>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Dialog.svelte
+++ b/src/lib/renderers/html/Dialog.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<dialog>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Div.svelte
+++ b/src/lib/renderers/html/Div.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<div>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Div.svelte
+++ b/src/lib/renderers/html/Div.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<div>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Dl.svelte
+++ b/src/lib/renderers/html/Dl.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<dl>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Dl.svelte
+++ b/src/lib/renderers/html/Dl.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<dl>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Dt.svelte
+++ b/src/lib/renderers/html/Dt.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<dt>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Dt.svelte
+++ b/src/lib/renderers/html/Dt.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<dt>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Em.svelte
+++ b/src/lib/renderers/html/Em.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<em>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Em.svelte
+++ b/src/lib/renderers/html/Em.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<em>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Embed.svelte
+++ b/src/lib/renderers/html/Embed.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a self-closing HTML `<embed>` element. Accepts optional attributes.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/Embed.svelte
+++ b/src/lib/renderers/html/Embed.svelte
@@ -4,7 +4,7 @@ Renders a self-closing HTML `<embed>` element. Accepts optional attributes.
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes }: Props = $props()

--- a/src/lib/renderers/html/Fieldset.svelte
+++ b/src/lib/renderers/html/Fieldset.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<fieldset>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Fieldset.svelte
+++ b/src/lib/renderers/html/Fieldset.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<fieldset>` element. Accepts optional attributes and child cont
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Footer.svelte
+++ b/src/lib/renderers/html/Footer.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<footer>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Footer.svelte
+++ b/src/lib/renderers/html/Footer.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<footer>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Form.svelte
+++ b/src/lib/renderers/html/Form.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<form>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Form.svelte
+++ b/src/lib/renderers/html/Form.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<form>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/H1.svelte
+++ b/src/lib/renderers/html/H1.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<h1>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/H1.svelte
+++ b/src/lib/renderers/html/H1.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<h1>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/H2.svelte
+++ b/src/lib/renderers/html/H2.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<h2>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/H2.svelte
+++ b/src/lib/renderers/html/H2.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<h2>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/H3.svelte
+++ b/src/lib/renderers/html/H3.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<h3>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/H3.svelte
+++ b/src/lib/renderers/html/H3.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<h3>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/H4.svelte
+++ b/src/lib/renderers/html/H4.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<h4>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/H4.svelte
+++ b/src/lib/renderers/html/H4.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<h4>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/H5.svelte
+++ b/src/lib/renderers/html/H5.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<h5>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/H5.svelte
+++ b/src/lib/renderers/html/H5.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<h5>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/H6.svelte
+++ b/src/lib/renderers/html/H6.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<h6>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/H6.svelte
+++ b/src/lib/renderers/html/H6.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<h6>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Header.svelte
+++ b/src/lib/renderers/html/Header.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<header>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Header.svelte
+++ b/src/lib/renderers/html/Header.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<header>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Hgroup.svelte
+++ b/src/lib/renderers/html/Hgroup.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<hgroup>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Hgroup.svelte
+++ b/src/lib/renderers/html/Hgroup.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<hgroup>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Hr.svelte
+++ b/src/lib/renderers/html/Hr.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a self-closing HTML `<hr>` element. Accepts optional attributes.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/Hr.svelte
+++ b/src/lib/renderers/html/Hr.svelte
@@ -4,7 +4,7 @@ Renders a self-closing HTML `<hr>` element. Accepts optional attributes.
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes }: Props = $props()

--- a/src/lib/renderers/html/I.svelte
+++ b/src/lib/renderers/html/I.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<i>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/I.svelte
+++ b/src/lib/renderers/html/I.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<i>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Iframe.svelte
+++ b/src/lib/renderers/html/Iframe.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<iframe>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Iframe.svelte
+++ b/src/lib/renderers/html/Iframe.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<iframe>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Img.svelte
+++ b/src/lib/renderers/html/Img.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a self-closing HTML `<img>` element. Accepts optional attributes.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/Img.svelte
+++ b/src/lib/renderers/html/Img.svelte
@@ -4,7 +4,7 @@ Renders a self-closing HTML `<img>` element. Accepts optional attributes.
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes }: Props = $props()

--- a/src/lib/renderers/html/Input.svelte
+++ b/src/lib/renderers/html/Input.svelte
@@ -4,7 +4,7 @@ Renders a self-closing HTML `<input>` element. Accepts optional attributes.
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes }: Props = $props()

--- a/src/lib/renderers/html/Input.svelte
+++ b/src/lib/renderers/html/Input.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a self-closing HTML `<input>` element. Accepts optional attributes.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/Kbd.svelte
+++ b/src/lib/renderers/html/Kbd.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<kbd>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Kbd.svelte
+++ b/src/lib/renderers/html/Kbd.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<kbd>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Label.svelte
+++ b/src/lib/renderers/html/Label.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<label>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Label.svelte
+++ b/src/lib/renderers/html/Label.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<label>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Legend.svelte
+++ b/src/lib/renderers/html/Legend.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<legend>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Legend.svelte
+++ b/src/lib/renderers/html/Legend.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<legend>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Li.svelte
+++ b/src/lib/renderers/html/Li.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<li>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Li.svelte
+++ b/src/lib/renderers/html/Li.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<li>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Main.svelte
+++ b/src/lib/renderers/html/Main.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<main>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Main.svelte
+++ b/src/lib/renderers/html/Main.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<main>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Mark.svelte
+++ b/src/lib/renderers/html/Mark.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<mark>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Mark.svelte
+++ b/src/lib/renderers/html/Mark.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<mark>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Menu.svelte
+++ b/src/lib/renderers/html/Menu.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<menu>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Menu.svelte
+++ b/src/lib/renderers/html/Menu.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<menu>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Meter.svelte
+++ b/src/lib/renderers/html/Meter.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<meter>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Meter.svelte
+++ b/src/lib/renderers/html/Meter.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<meter>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Nav.svelte
+++ b/src/lib/renderers/html/Nav.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<nav>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Nav.svelte
+++ b/src/lib/renderers/html/Nav.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<nav>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Ol.svelte
+++ b/src/lib/renderers/html/Ol.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<ol>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Ol.svelte
+++ b/src/lib/renderers/html/Ol.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<ol>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Optgroup.svelte
+++ b/src/lib/renderers/html/Optgroup.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<optgroup>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Optgroup.svelte
+++ b/src/lib/renderers/html/Optgroup.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<optgroup>` element. Accepts optional attributes and child cont
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Option.svelte
+++ b/src/lib/renderers/html/Option.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<option>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Option.svelte
+++ b/src/lib/renderers/html/Option.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<option>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Output.svelte
+++ b/src/lib/renderers/html/Output.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<output>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Output.svelte
+++ b/src/lib/renderers/html/Output.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<output>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/P.svelte
+++ b/src/lib/renderers/html/P.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<p>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/P.svelte
+++ b/src/lib/renderers/html/P.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<p>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Param.svelte
+++ b/src/lib/renderers/html/Param.svelte
@@ -4,7 +4,7 @@ Renders a self-closing HTML `<param>` element. Accepts optional attributes.
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes }: Props = $props()

--- a/src/lib/renderers/html/Param.svelte
+++ b/src/lib/renderers/html/Param.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a self-closing HTML `<param>` element. Accepts optional attributes.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/Picture.svelte
+++ b/src/lib/renderers/html/Picture.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<picture>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Picture.svelte
+++ b/src/lib/renderers/html/Picture.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<picture>` element. Accepts optional attributes and child conte
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Pre.svelte
+++ b/src/lib/renderers/html/Pre.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<pre>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Pre.svelte
+++ b/src/lib/renderers/html/Pre.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<pre>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Progress.svelte
+++ b/src/lib/renderers/html/Progress.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<progress>` element. Accepts optional attributes and child cont
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Progress.svelte
+++ b/src/lib/renderers/html/Progress.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<progress>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/S.svelte
+++ b/src/lib/renderers/html/S.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<s>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/S.svelte
+++ b/src/lib/renderers/html/S.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<s>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Samp.svelte
+++ b/src/lib/renderers/html/Samp.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<samp>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Samp.svelte
+++ b/src/lib/renderers/html/Samp.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<samp>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Section.svelte
+++ b/src/lib/renderers/html/Section.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<section>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Section.svelte
+++ b/src/lib/renderers/html/Section.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<section>` element. Accepts optional attributes and child conte
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Select.svelte
+++ b/src/lib/renderers/html/Select.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<select>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Select.svelte
+++ b/src/lib/renderers/html/Select.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<select>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Small.svelte
+++ b/src/lib/renderers/html/Small.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<small>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Small.svelte
+++ b/src/lib/renderers/html/Small.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<small>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Source.svelte
+++ b/src/lib/renderers/html/Source.svelte
@@ -4,7 +4,7 @@ Renders a self-closing HTML `<source>` element. Accepts optional attributes.
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes }: Props = $props()

--- a/src/lib/renderers/html/Source.svelte
+++ b/src/lib/renderers/html/Source.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a self-closing HTML `<source>` element. Accepts optional attributes.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/Span.svelte
+++ b/src/lib/renderers/html/Span.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<span>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Span.svelte
+++ b/src/lib/renderers/html/Span.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<span>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Strong.svelte
+++ b/src/lib/renderers/html/Strong.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<strong>` element. Accepts optional attributes and child conten
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Strong.svelte
+++ b/src/lib/renderers/html/Strong.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<strong>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Sub.svelte
+++ b/src/lib/renderers/html/Sub.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<sub>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Sub.svelte
+++ b/src/lib/renderers/html/Sub.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<sub>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Summary.svelte
+++ b/src/lib/renderers/html/Summary.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<summary>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Summary.svelte
+++ b/src/lib/renderers/html/Summary.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<summary>` element. Accepts optional attributes and child conte
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Sup.svelte
+++ b/src/lib/renderers/html/Sup.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<sup>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Table.svelte
+++ b/src/lib/renderers/html/Table.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<table>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Table.svelte
+++ b/src/lib/renderers/html/Table.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<table>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Tbody.svelte
+++ b/src/lib/renderers/html/Tbody.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<tbody>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Tbody.svelte
+++ b/src/lib/renderers/html/Tbody.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<tbody>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Td.svelte
+++ b/src/lib/renderers/html/Td.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<td>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Td.svelte
+++ b/src/lib/renderers/html/Td.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<td>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Textarea.svelte
+++ b/src/lib/renderers/html/Textarea.svelte
@@ -4,7 +4,7 @@ Renders an HTML `<textarea>` element. Accepts optional attributes and child cont
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes }: Props = $props()

--- a/src/lib/renderers/html/Textarea.svelte
+++ b/src/lib/renderers/html/Textarea.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<textarea>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/Tfoot.svelte
+++ b/src/lib/renderers/html/Tfoot.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<tfoot>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Tfoot.svelte
+++ b/src/lib/renderers/html/Tfoot.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<tfoot>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Th.svelte
+++ b/src/lib/renderers/html/Th.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<th>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Th.svelte
+++ b/src/lib/renderers/html/Th.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<th>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Thead.svelte
+++ b/src/lib/renderers/html/Thead.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<thead>` element. Accepts optional attributes and child content
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Thead.svelte
+++ b/src/lib/renderers/html/Thead.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<thead>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Tr.svelte
+++ b/src/lib/renderers/html/Tr.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<tr>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Tr.svelte
+++ b/src/lib/renderers/html/Tr.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<tr>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Track.svelte
+++ b/src/lib/renderers/html/Track.svelte
@@ -4,7 +4,7 @@ Renders a self-closing HTML `<track>` element. Accepts optional attributes.
 -->
 <script lang="ts">
     interface Props {
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { attributes }: Props = $props()

--- a/src/lib/renderers/html/Track.svelte
+++ b/src/lib/renderers/html/Track.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders a self-closing HTML `<track>` element. Accepts optional attributes.
+-->
 <script lang="ts">
     interface Props {
         attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/renderers/html/U.svelte
+++ b/src/lib/renderers/html/U.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<u>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/U.svelte
+++ b/src/lib/renderers/html/U.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<u>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Ul.svelte
+++ b/src/lib/renderers/html/Ul.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<ul>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/Ul.svelte
+++ b/src/lib/renderers/html/Ul.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<ul>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Var.svelte
+++ b/src/lib/renderers/html/Var.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders an HTML `<var>` element. Accepts optional attributes and child content.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/Var.svelte
+++ b/src/lib/renderers/html/Var.svelte
@@ -7,7 +7,7 @@ Renders an HTML `<var>` element. Accepts optional attributes and child content.
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/renderers/html/_UnsupportedHTML.svelte
+++ b/src/lib/renderers/html/_UnsupportedHTML.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Placeholder component rendered for blocked HTML tags. Displays the tag and content as escaped text.
+-->
 <script lang="ts">
     import type { Snippet } from 'svelte'
 

--- a/src/lib/renderers/html/index.ts
+++ b/src/lib/renderers/html/index.ts
@@ -1,3 +1,16 @@
+/**
+ * Default HTML tag renderer registry.
+ *
+ * Maps every supported HTML tag name (e.g. `'div'`, `'span'`) to its
+ * corresponding Svelte component.  The map is used by `SvelteMarkdown`
+ * when rendering raw HTML blocks embedded in markdown.
+ *
+ * Use the `allowHtmlOnly` / `excludeHtmlOnly` helpers (or replace
+ * individual entries with `null`) to restrict which tags are rendered.
+ *
+ * @module
+ */
+
 import type { Component } from 'svelte'
 import A from './A.svelte'
 import Abbr from './Abbr.svelte'
@@ -84,10 +97,22 @@ import Ul from './Ul.svelte'
 import Var from './Var.svelte'
 import UnsupportedHTML from './_UnsupportedHTML.svelte'
 
+/**
+ * Record type mapping HTML tag names to their Svelte renderer components.
+ *
+ * A `null` value means the tag is explicitly blocked and will not be
+ * rendered.  This interface is used by the allow/deny filter utilities.
+ */
 export interface HtmlRenderers {
     [key: string]: Component<any, any, any> | null // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
+/**
+ * Default map of every supported HTML tag to its renderer component.
+ *
+ * Passed as the `html` key of `defaultRenderers`.  Override individual
+ * entries via the `renderers.html` prop on `SvelteMarkdown`.
+ */
 export const Html: HtmlRenderers = {
     a: A,
     abbr: Abbr,
@@ -175,4 +200,12 @@ export const Html: HtmlRenderers = {
 }
 
 export default Html
+
+/**
+ * Placeholder component rendered in place of HTML tags that have been
+ * blocked via `excludeHtmlOnly`, `allowHtmlOnly`, or `buildUnsupportedHTML`.
+ *
+ * Renders the tag name and content as plain, escaped text so the user can
+ * see that a tag was present but intentionally suppressed.
+ */
 export { UnsupportedHTML }

--- a/src/lib/renderers/html/index.ts
+++ b/src/lib/renderers/html/index.ts
@@ -104,7 +104,7 @@ import UnsupportedHTML from './_UnsupportedHTML.svelte'
  * rendered.  This interface is used by the allow/deny filter utilities.
  */
 export interface HtmlRenderers {
-    [key: string]: Component<any, any, any> | null // eslint-disable-line @typescript-eslint/no-explicit-any
+    [key: string]: Component<any, any, any> | null // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
 }
 
 /**

--- a/src/lib/renderers/index.ts
+++ b/src/lib/renderers/index.ts
@@ -1,3 +1,17 @@
+/**
+ * Barrel export for all built-in markdown renderer components.
+ *
+ * Each export corresponds to a key in the {@link Renderers} type and maps
+ * one-to-one with a markdown token type produced by the `marked` lexer.
+ *
+ * @module
+ */
+
+/**
+ * Placeholder component rendered for markdown token types that have been
+ * blocked via `excludeRenderersOnly`, `allowRenderersOnly`, or
+ * `buildUnsupportedRenderers`.
+ */
 export { default as Unsupported } from '$lib/renderers/_Unsupported.svelte'
 export { default as Blockquote } from '$lib/renderers/Blockquote.svelte'
 export { default as Br } from '$lib/renderers/Br.svelte'

--- a/src/lib/test/extendability/A.svelte
+++ b/src/lib/test/extendability/A.svelte
@@ -3,7 +3,7 @@
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
         text?: string
     }
 

--- a/src/lib/test/extendability/Div.svelte
+++ b/src/lib/test/extendability/Div.svelte
@@ -3,7 +3,7 @@
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/test/extendability/H1.svelte
+++ b/src/lib/test/extendability/H1.svelte
@@ -3,7 +3,7 @@
 
     interface Props {
         children?: Snippet
-        attributes?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        attributes?: Record<string, any> // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
     }
 
     const { children, attributes }: Props = $props()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,7 +61,7 @@ export type SvelteMarkdownProps<T extends Renderers = Renderers> = {
      *
      * @param tokens - The parsed token array or `TokensList`.
      */
-    parsed?: (tokens: Token[] | TokensList) => void // eslint-disable-line no-unused-vars
+    parsed?: (tokens: Token[] | TokensList) => void // trunk-ignore(eslint/no-unused-vars)
 }
 
 export interface SvelteMarkdownOptions extends MarkedOptions {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,14 +22,61 @@ import type { Token, TokensList } from 'marked'
 import type { MarkedOptions, Renderers } from './utils/markdown-parser.js'
 
 export type SvelteMarkdownProps<T extends Renderers = Renderers> = {
+    /**
+     * Markdown content to render.
+     *
+     * Pass a `string` for raw markdown that will be parsed, or a pre-parsed
+     * `Token[]` array to skip parsing entirely. An empty string renders nothing.
+     */
     source: Token[] | string
+
+    /**
+     * Partial map of renderer overrides merged with the built-in defaults.
+     *
+     * Only the keys you provide are replaced — all others keep their default
+     * component.  Use the `allowRenderersOnly` / `excludeRenderersOnly`
+     * helpers to disable entire categories of renderers.
+     */
     renderers?: Partial<T>
+
+    /**
+     * Options forwarded to the `marked` lexer, extended with header-ID
+     * generation settings.  Merged with {@link defaultOptions}.
+     */
     options?: Partial<SvelteMarkdownOptions>
+
+    /**
+     * When `true`, the source is parsed with `Lexer.lexInline()` instead of
+     * `Lexer.lex()`, producing only inline tokens (no block elements).
+     *
+     * @defaultValue `false`
+     */
     isInline?: boolean
+
+    /**
+     * Callback invoked after the source has been parsed into tokens.
+     *
+     * Receives the full token array before rendering begins. Useful for
+     * inspecting or transforming the parsed AST.
+     *
+     * @param tokens - The parsed token array or `TokensList`.
+     */
     parsed?: (tokens: Token[] | TokensList) => void // eslint-disable-line no-unused-vars
 }
 
 export interface SvelteMarkdownOptions extends MarkedOptions {
+    /**
+     * When `true`, an `id` attribute is generated for every heading element
+     * using `github-slugger`.
+     *
+     * @defaultValue `true`
+     */
     headerIds?: boolean
+
+    /**
+     * String prepended to every generated heading `id`.
+     *
+     * @defaultValue `''`
+     */
     headerPrefix?: string
 }

--- a/src/lib/utils/createFilterUtilities.ts
+++ b/src/lib/utils/createFilterUtilities.ts
@@ -4,7 +4,7 @@ import type { Component } from 'svelte'
  * Generic component type for filter utilities.
  * Allows Component, undefined, or null values.
  */
-type FilterComponent = Component<any, any, any> | undefined | null // eslint-disable-line @typescript-eslint/no-explicit-any
+type FilterComponent = Component<any, any, any> | undefined | null // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
 
 /**
  * Creates a set of filter utility functions for renderer maps.

--- a/src/lib/utils/markdown-parser.test.ts
+++ b/src/lib/utils/markdown-parser.test.ts
@@ -1,0 +1,217 @@
+import Html from '$lib/renderers/html/index.js'
+import {
+    Blockquote,
+    Br,
+    Code,
+    Codespan,
+    Del,
+    Em,
+    Escape,
+    Heading,
+    Hr,
+    Image,
+    Link,
+    List,
+    ListItem,
+    Paragraph,
+    RawText,
+    Strong,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+    Text
+} from '$lib/renderers/index.js'
+import {
+    defaultOptions,
+    defaultRenderers,
+    Lexer,
+    Slugger,
+    type Renderers
+} from '$lib/utils/markdown-parser.js'
+import { describe, expect, it } from 'vitest'
+
+describe('defaultRenderers', () => {
+    it('has all expected keys from the Renderers type', () => {
+        const expectedKeys: (keyof Renderers)[] = [
+            'html',
+            'rawtext',
+            'escape',
+            'heading',
+            'paragraph',
+            'blockquote',
+            'code',
+            'list',
+            'listitem',
+            'hr',
+            'table',
+            'tablehead',
+            'tablebody',
+            'tablerow',
+            'tablecell',
+            'text',
+            'link',
+            'image',
+            'em',
+            'strong',
+            'codespan',
+            'br',
+            'del',
+            'orderedlistitem',
+            'unorderedlistitem'
+        ]
+        for (const key of expectedKeys) {
+            expect(defaultRenderers).toHaveProperty(key)
+        }
+    })
+
+    it('has exactly 25 keys (all Renderers type keys)', () => {
+        expect(Object.keys(defaultRenderers)).toHaveLength(25)
+    })
+
+    it('maps heading to the Heading component', () => {
+        expect(defaultRenderers.heading).toBe(Heading)
+    })
+
+    it('maps paragraph to the Paragraph component', () => {
+        expect(defaultRenderers.paragraph).toBe(Paragraph)
+    })
+
+    it('maps code to the Code component', () => {
+        expect(defaultRenderers.code).toBe(Code)
+    })
+
+    it('maps list to the List component', () => {
+        expect(defaultRenderers.list).toBe(List)
+    })
+
+    it('maps link to the Link component', () => {
+        expect(defaultRenderers.link).toBe(Link)
+    })
+
+    it('maps image to the Image component', () => {
+        expect(defaultRenderers.image).toBe(Image)
+    })
+
+    it('maps html to the Html tag-to-component map (not a single component)', () => {
+        expect(defaultRenderers.html).toBe(Html)
+        expect(typeof defaultRenderers.html).toBe('object')
+        expect(defaultRenderers.html).toHaveProperty('div')
+        expect(defaultRenderers.html).toHaveProperty('span')
+    })
+
+    it('maps orderedlistitem and unorderedlistitem to null', () => {
+        expect(defaultRenderers.orderedlistitem).toBeNull()
+        expect(defaultRenderers.unorderedlistitem).toBeNull()
+    })
+
+    it('maps all non-null keys to truthy components', () => {
+        for (const [key, value] of Object.entries(defaultRenderers)) {
+            if (key === 'orderedlistitem' || key === 'unorderedlistitem') continue
+            expect(value, `${key} should be truthy`).toBeTruthy()
+        }
+    })
+
+    it('has no extra keys beyond what Renderers defines', () => {
+        const definedKeys: (keyof Renderers)[] = [
+            'html',
+            'rawtext',
+            'escape',
+            'heading',
+            'paragraph',
+            'blockquote',
+            'code',
+            'list',
+            'listitem',
+            'hr',
+            'table',
+            'tablehead',
+            'tablebody',
+            'tablerow',
+            'tablecell',
+            'text',
+            'link',
+            'image',
+            'em',
+            'strong',
+            'codespan',
+            'br',
+            'del',
+            'orderedlistitem',
+            'unorderedlistitem'
+        ]
+        for (const key of Object.keys(defaultRenderers)) {
+            expect(definedKeys).toContain(key)
+        }
+    })
+
+    it('spot-checks remaining renderer mappings', () => {
+        expect(defaultRenderers.text).toBe(Text)
+        expect(defaultRenderers.em).toBe(Em)
+        expect(defaultRenderers.strong).toBe(Strong)
+        expect(defaultRenderers.codespan).toBe(Codespan)
+        expect(defaultRenderers.del).toBe(Del)
+        expect(defaultRenderers.br).toBe(Br)
+        expect(defaultRenderers.hr).toBe(Hr)
+        expect(defaultRenderers.blockquote).toBe(Blockquote)
+        expect(defaultRenderers.escape).toBe(Escape)
+        expect(defaultRenderers.rawtext).toBe(RawText)
+        expect(defaultRenderers.listitem).toBe(ListItem)
+        expect(defaultRenderers.table).toBe(Table)
+        expect(defaultRenderers.tablehead).toBe(TableHead)
+        expect(defaultRenderers.tablebody).toBe(TableBody)
+        expect(defaultRenderers.tablerow).toBe(TableRow)
+        expect(defaultRenderers.tablecell).toBe(TableCell)
+    })
+})
+
+describe('defaultOptions', () => {
+    it('has correct standard marked defaults', () => {
+        expect(defaultOptions.gfm).toBe(true)
+        expect(defaultOptions.breaks).toBe(false)
+        expect(defaultOptions.pedantic).toBe(false)
+        expect(defaultOptions.async).toBe(false)
+        expect(defaultOptions.silent).toBe(false)
+    })
+
+    it('has correct custom options', () => {
+        expect(defaultOptions.headerIds).toBe(true)
+        expect(defaultOptions.headerPrefix).toBe('')
+    })
+
+    it('has null for renderer, tokenizer, and walkTokens', () => {
+        expect(defaultOptions.renderer).toBeNull()
+        expect(defaultOptions.tokenizer).toBeNull()
+        expect(defaultOptions.walkTokens).toBeNull()
+    })
+
+    it('has headerPrefix as empty string, not undefined', () => {
+        expect(defaultOptions.headerPrefix).toBeDefined()
+        expect(typeof defaultOptions.headerPrefix).toBe('string')
+        expect(defaultOptions.headerPrefix).toBe('')
+    })
+})
+
+describe('re-exports', () => {
+    it('Slugger is a constructor that can be instantiated', () => {
+        const slugger = new Slugger()
+        expect(slugger).toBeDefined()
+        expect(typeof slugger.slug).toBe('function')
+    })
+
+    it('Slugger.slug() produces a slug from a string', () => {
+        const slugger = new Slugger()
+        expect(slugger.slug('Hello World')).toBe('hello-world')
+    })
+
+    it('Lexer is a class with a static lex method', () => {
+        expect(typeof Lexer.lex).toBe('function')
+    })
+
+    it('Lexer.lex() produces a non-empty token array from simple markdown', () => {
+        const tokens = Lexer.lex('# Hello\n\nWorld')
+        expect(Array.isArray(tokens)).toBe(true)
+        expect(tokens.length).toBeGreaterThan(0)
+    })
+})

--- a/src/lib/utils/markdown-parser.ts
+++ b/src/lib/utils/markdown-parser.ts
@@ -1,4 +1,17 @@
+/**
+ * Markdown parsing utilities and default renderer configuration.
+ *
+ * Re-exports key symbols from `marked` and `github-slugger`, defines the
+ * {@link Renderers} type and {@link defaultRenderers} map, and provides
+ * the default parser options used by `SvelteMarkdown`.
+ *
+ * @module
+ */
+
+/** Slugger instance used to generate GitHub-style heading IDs. */
 export { default as Slugger } from 'github-slugger'
+
+/** Core `marked` exports used for lexing and type definitions. */
 export { Lexer, type MarkedOptions, type Token, type Tokens, type TokensList } from 'marked'
 import { type HtmlRenderers } from '$lib/renderers/html/index.js'
 import type { Component } from 'svelte'

--- a/src/lib/utils/markdown-parser.ts
+++ b/src/lib/utils/markdown-parser.ts
@@ -49,7 +49,7 @@ import type { SvelteMarkdownOptions } from '$lib/types.js'
  *
  * @typedef {Component<any, any, any> | undefined | null} RendererComponent
  */
-export type RendererComponent = Component<any, any, any> | undefined | null // eslint-disable-line @typescript-eslint/no-explicit-any
+export type RendererComponent = Component<any, any, any> | undefined | null // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
 
 /**
  * Comprehensive mapping of markdown elements to their renderer components.

--- a/src/lib/utils/parse-html-block.test.ts
+++ b/src/lib/utils/parse-html-block.test.ts
@@ -70,7 +70,6 @@ describe('parseHtmlBlock', () => {
         const html = '<div style="color: red; margin: 10px" data-test="value">Content</div>'
         const tokens = parseHtmlBlock(html)
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((tokens[0] as any).attributes).toEqual({
             style: 'color: red; margin: 10px',
             'data-test': 'value'

--- a/src/lib/utils/process-html-tokens.test.ts
+++ b/src/lib/utils/process-html-tokens.test.ts
@@ -30,11 +30,11 @@ describe('processHtmlTokens', () => {
 
         const result = processHtmlTokens(tokens)
         expect(result).toHaveLength(1)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[0] as any).tag).toBe('div')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[0] as any).tokens?.[0].tag).toBe('span')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[0] as any).tokens?.[0].tokens?.[0].text).toBe('nested')
     })
 
@@ -49,9 +49,9 @@ describe('processHtmlTokens', () => {
 
         const result = processHtmlTokens(tokens)
         expect(result).toHaveLength(1)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[0] as any).attributes).toEqual({ class: 'wrapper' })
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[0] as any).tokens?.[0].attributes).toEqual({ style: 'color: red' })
     })
 
@@ -77,9 +77,9 @@ describe('processHtmlTokens', () => {
 
         const result = processHtmlTokens(tokens)
         expect(result).toHaveLength(2)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[0] as any).tag).toBe('div')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[1] as any).tag).toBe('span')
     })
 
@@ -101,9 +101,9 @@ describe('processHtmlTokens', () => {
 
         const result = processHtmlTokens(tokens)
         expect(result).toHaveLength(1)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[0] as any).tag).toBe('div')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         expect((result[0] as any).tokens?.[0].tokens?.[0].tag).toBe('em')
     })
 

--- a/src/lib/utils/rendererKeys.test.ts
+++ b/src/lib/utils/rendererKeys.test.ts
@@ -24,6 +24,70 @@ describe('rendererKeys internals', () => {
         expect(publicRendererKeys).toEqual(rendererKeysInternal)
         expect(publicHtmlKeys).toEqual(htmlRendererKeysInternal)
     })
+})
 
-    // index.js exports public names (without "Internal"). Public should equal internals
+describe('rendererKeysInternal boundary and validation', () => {
+    it('has no duplicate keys', () => {
+        const unique = new Set(rendererKeysInternal)
+        expect(unique.size).toBe(rendererKeysInternal.length)
+    })
+
+    it('all keys are non-empty strings', () => {
+        for (const key of rendererKeysInternal) {
+            expect(typeof key).toBe('string')
+            expect(key.length).toBeGreaterThan(0)
+        }
+    })
+
+    it('does not include the html key', () => {
+        expect(rendererKeysInternal).not.toContain('html')
+    })
+
+    it('has a reasonable minimum length (>= 20)', () => {
+        expect(rendererKeysInternal.length).toBeGreaterThanOrEqual(20)
+    })
+})
+
+describe('htmlRendererKeysInternal boundary and validation', () => {
+    it('has no duplicate keys', () => {
+        const unique = new Set(htmlRendererKeysInternal)
+        expect(unique.size).toBe(htmlRendererKeysInternal.length)
+    })
+
+    it('all keys are non-empty strings', () => {
+        for (const key of htmlRendererKeysInternal) {
+            expect(typeof key).toBe('string')
+            expect(key.length).toBeGreaterThan(0)
+        }
+    })
+
+    it('has a reasonable minimum length (>= 70)', () => {
+        expect(htmlRendererKeysInternal.length).toBeGreaterThanOrEqual(70)
+    })
+})
+
+describe('spot-check expected keys', () => {
+    it('rendererKeysInternal contains core markdown keys', () => {
+        const coreKeys = [
+            'heading',
+            'paragraph',
+            'text',
+            'link',
+            'code',
+            'list',
+            'table',
+            'hr',
+            'br'
+        ]
+        for (const key of coreKeys) {
+            expect(rendererKeysInternal).toContain(key)
+        }
+    })
+
+    it('htmlRendererKeysInternal contains core HTML tags', () => {
+        const coreTags = ['div', 'span', 'a', 'p', 'h1', 'input', 'table', 'ul']
+        for (const tag of coreTags) {
+            expect(htmlRendererKeysInternal).toContain(tag)
+        }
+    })
 })

--- a/src/lib/utils/rendererKeys.ts
+++ b/src/lib/utils/rendererKeys.ts
@@ -1,10 +1,41 @@
+/**
+ * Canonical key lists for markdown renderers and HTML tag renderers.
+ *
+ * These arrays and types drive the allow/deny filter utilities and serve as
+ * the single source of truth for which renderer and HTML tag names the
+ * library recognizes.
+ *
+ * @module
+ */
+
 import Html from '$lib/renderers/html/index.js'
 import { defaultRenderers, type Renderers } from '$lib/utils/markdown-parser.js'
 
+/**
+ * Union type of every valid markdown renderer key (excludes `'html'`).
+ *
+ * Derived from the {@link Renderers} interface at the type level.
+ */
 export type RendererKey = Exclude<keyof Renderers, 'html'>
+
+/**
+ * Canonical array of every markdown renderer key.
+ *
+ * Re-exported publicly as `rendererKeys`. Built at runtime from
+ * `defaultRenderers` (filtering out the special `html` key).
+ */
 export const rendererKeysInternal = Object.keys(defaultRenderers).filter(
     (k) => k !== 'html'
 ) as RendererKey[]
 
+/**
+ * Union type of every supported HTML tag name that has a dedicated renderer.
+ */
 export type HtmlKey = keyof typeof Html & string
+
+/**
+ * Canonical array of every HTML tag name with a built-in renderer.
+ *
+ * Re-exported publicly as `htmlRendererKeys`.
+ */
 export const htmlRendererKeysInternal = Object.keys(Html) as HtmlKey[]

--- a/src/lib/utils/token-cache.ts
+++ b/src/lib/utils/token-cache.ts
@@ -71,25 +71,28 @@ function hashString(str: string): string {
  * console.log(key1 !== key2) // true - different options = different key
  * ```
  */
+const optionsHashCache = new WeakMap<object, string>()
+
 function getCacheKey(source: string, options: SvelteMarkdownOptions): string {
     const sourceHash = hashString(source)
 
-    // Safely serialize all options including functions and objects
-    const seen = new WeakSet<object>()
-    const optionsHash = hashString(
-        JSON.stringify(options, (_, value) => {
-            // Serialize functions by their name or source code
-            if (typeof value === 'function') {
-                return value.name || value.toString()
-            }
-            // Handle circular references
-            if (value && typeof value === 'object') {
-                if (seen.has(value)) return '[Circular]'
-                seen.add(value)
-            }
-            return value
-        })
-    )
+    let optionsHash = optionsHashCache.get(options)
+    if (!optionsHash) {
+        const seen = new WeakSet<object>()
+        optionsHash = hashString(
+            JSON.stringify(options, (_, value) => {
+                if (typeof value === 'function') {
+                    return value.name || value.toString()
+                }
+                if (value && typeof value === 'object') {
+                    if (seen.has(value)) return '[Circular]'
+                    seen.add(value)
+                }
+                return value
+            })
+        )
+        optionsHashCache.set(options, optionsHash)
+    }
 
     return `${sourceHash}:${optionsHash}`
 }

--- a/src/lib/utils/token-cache.ts
+++ b/src/lib/utils/token-cache.ts
@@ -71,6 +71,12 @@ function hashString(str: string): string {
  * console.log(key1 !== key2) // true - different options = different key
  * ```
  */
+// Memoizes the serialized hash of options objects by reference.
+// Assumes options objects are treated as immutable — if a caller mutates
+// an options object after it has been cached here, the stale hash will be
+// returned and the token cache may serve incorrect results. Svelte 5's
+// reactivity system creates new objects on prop changes ($derived), so
+// this is safe for all internal usage paths.
 const optionsHashCache = new WeakMap<object, string>()
 
 function getCacheKey(source: string, options: SvelteMarkdownOptions): string {

--- a/src/lib/utils/token-cleanup.test.ts
+++ b/src/lib/utils/token-cleanup.test.ts
@@ -61,9 +61,9 @@ describe('Token Cleanup Utilities', () => {
 
             const result = shrinkHtmlTokens(tokens)
             expect(result).toHaveLength(1)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens).toHaveLength(1)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens?.[0].tokens).toHaveLength(1)
         })
 
@@ -78,9 +78,9 @@ describe('Token Cleanup Utilities', () => {
 
             const result = shrinkHtmlTokens(tokens)
             expect(result).toHaveLength(1)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens).toHaveLength(1)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens?.[0].tokens).toHaveLength(1)
         })
 
@@ -97,7 +97,6 @@ describe('Token Cleanup Utilities', () => {
             const result = shrinkHtmlTokens(tokens)
             expect(result).toHaveLength(2)
             result.forEach((token) => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 expect((token as any).tokens).toHaveLength(1)
             })
         })
@@ -120,9 +119,9 @@ describe('Token Cleanup Utilities', () => {
 
             const result = shrinkHtmlTokens(tokens)
             expect(result).toHaveLength(1)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tag).toBe('div')
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens).toHaveLength(2)
         })
 
@@ -178,11 +177,11 @@ describe('Token Cleanup Utilities', () => {
             const result = shrinkHtmlTokens(tokens)
 
             expect(result).toHaveLength(1)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens).toHaveLength(2)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens[1].attributes).toEqual({ style: 'color: hotpink' })
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens[1].tag).toEqual('span')
         })
 
@@ -199,9 +198,9 @@ describe('Token Cleanup Utilities', () => {
 
             const result = shrinkHtmlTokens(tokens)
             expect(result).toHaveLength(1)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tag).toEqual('details')
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).tokens).toHaveLength(2)
         })
 
@@ -270,9 +269,9 @@ describe('Token Cleanup Utilities', () => {
 
             const result = shrinkHtmlTokens(tokens)
             expect(result).toHaveLength(1)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).rows[0][0].tokens[0].type).toBe('html')
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             expect((result[0] as any).rows[0][0].tokens[0].tag).toBe('strong')
         })
 

--- a/src/lib/utils/unsupportedHtmlRenderers.test.ts
+++ b/src/lib/utils/unsupportedHtmlRenderers.test.ts
@@ -56,14 +56,14 @@ describe('unsupported HTML negative tests', () => {
     })
 
     it('allowHtmlOnly with all invalid tags maps every key to UnsupportedHTML', () => {
-        const map = allowHtmlOnly(['fake-tag-1', 'fake-tag-2'] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        const map = allowHtmlOnly(['fake-tag-1', 'fake-tag-2'] as any)
         for (const key of htmlRendererKeysInternal) {
             expect(map[key], `${key} should be UnsupportedHTML`).toBe(UnsupportedHTML)
         }
     })
 
     it('excludeHtmlOnly with invalid tags silently ignores them', () => {
-        const map = excludeHtmlOnly(['not-a-tag'] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        const map = excludeHtmlOnly(['not-a-tag'] as any)
         for (const key of htmlRendererKeysInternal) {
             expect(map[key], `${key} should be default`).toBe(Html[key])
         }

--- a/src/lib/utils/unsupportedHtmlRenderers.test.ts
+++ b/src/lib/utils/unsupportedHtmlRenderers.test.ts
@@ -1,4 +1,5 @@
 import Html, { UnsupportedHTML } from '$lib/renderers/html/index.js'
+import { htmlRendererKeysInternal } from '$lib/utils/rendererKeys.js'
 import { describe, expect, it } from 'vitest'
 import { allowHtmlOnly, buildUnsupportedHTML, excludeHtmlOnly } from './unsupportedHtmlRenderers.js'
 
@@ -43,5 +44,89 @@ describe('unsupported helpers', () => {
         expect(map.div).toBe(Custom)
         // a remains default
         expect(map.a).toBe(Html.a)
+    })
+})
+
+describe('unsupported HTML negative tests', () => {
+    it('allowHtmlOnly with empty array maps every key to UnsupportedHTML', () => {
+        const map = allowHtmlOnly([])
+        for (const key of htmlRendererKeysInternal) {
+            expect(map[key], `${key} should be UnsupportedHTML`).toBe(UnsupportedHTML)
+        }
+    })
+
+    it('allowHtmlOnly with all invalid tags maps every key to UnsupportedHTML', () => {
+        const map = allowHtmlOnly(['fake-tag-1', 'fake-tag-2'] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        for (const key of htmlRendererKeysInternal) {
+            expect(map[key], `${key} should be UnsupportedHTML`).toBe(UnsupportedHTML)
+        }
+    })
+
+    it('excludeHtmlOnly with invalid tags silently ignores them', () => {
+        const map = excludeHtmlOnly(['not-a-tag'] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        for (const key of htmlRendererKeysInternal) {
+            expect(map[key], `${key} should be default`).toBe(Html[key])
+        }
+    })
+})
+
+describe('unsupported HTML boundary tests', () => {
+    it('buildUnsupportedHTML returns a new object each call', () => {
+        const a = buildUnsupportedHTML()
+        const b = buildUnsupportedHTML()
+        expect(a).not.toBe(b)
+        expect(a).toEqual(b)
+    })
+
+    it('result key count matches htmlRendererKeysInternal length', () => {
+        const map = buildUnsupportedHTML()
+        expect(Object.keys(map)).toHaveLength(htmlRendererKeysInternal.length)
+    })
+
+    it('excludeHtmlOnly with empty array preserves all defaults', () => {
+        const map = excludeHtmlOnly([])
+        for (const key of htmlRendererKeysInternal) {
+            expect(map[key], `${key} should be default`).toBe(Html[key])
+        }
+    })
+
+    it('excludeHtmlOnly with empty overrides array is the same as without', () => {
+        const withoutOverrides = excludeHtmlOnly(['div'])
+        const withEmptyOverrides = excludeHtmlOnly(['div'], [])
+        expect(withoutOverrides).toEqual(withEmptyOverrides)
+    })
+})
+
+describe('unsupported HTML spot-check tag families', () => {
+    it('semantic tags are present', () => {
+        const semanticTags = ['article', 'section', 'nav', 'header', 'footer', 'main']
+        const map = buildUnsupportedHTML()
+        for (const tag of semanticTags) {
+            expect(map[tag], `${tag} should be present`).toBe(UnsupportedHTML)
+        }
+    })
+
+    it('form tags are present', () => {
+        const formTags = ['input', 'select', 'textarea', 'button', 'form', 'label']
+        const map = buildUnsupportedHTML()
+        for (const tag of formTags) {
+            expect(map[tag], `${tag} should be present`).toBe(UnsupportedHTML)
+        }
+    })
+
+    it('media tags are present', () => {
+        const mediaTags = ['audio', 'img', 'iframe', 'picture', 'source']
+        const map = buildUnsupportedHTML()
+        for (const tag of mediaTags) {
+            expect(map[tag], `${tag} should be present`).toBe(UnsupportedHTML)
+        }
+    })
+
+    it('heading tags are present', () => {
+        const headingTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+        const map = buildUnsupportedHTML()
+        for (const tag of headingTags) {
+            expect(map[tag], `${tag} should be present`).toBe(UnsupportedHTML)
+        }
     })
 })

--- a/src/lib/utils/unsupportedRenderers.test.ts
+++ b/src/lib/utils/unsupportedRenderers.test.ts
@@ -31,7 +31,7 @@ describe('unsupported renderers helpers', () => {
         const allowed = allowRenderersOnly([
             ['paragraph', Custom],
             ['not-a-key', Custom]
-        ] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        ] as any)
         expect(allowed.paragraph).toBe(Custom)
         // @ts-expect-error runtime index
         expect(allowed['not-a-key']).toBeUndefined()
@@ -50,7 +50,7 @@ describe('unsupported renderers helpers', () => {
             ['paragraph', Custom],
             // attempt to override excluded key should be ignored
             ['link', Custom]
-        ] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        ] as any)
         expect(map.paragraph).toBe(Custom)
         expect(map.link).toBe(Unsupported)
     })
@@ -65,14 +65,14 @@ describe('unsupported renderers negative tests', () => {
     })
 
     it('allowRenderersOnly with all invalid keys maps every key to Unsupported', () => {
-        const map = allowRenderersOnly(['fake-key-1', 'fake-key-2'] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        const map = allowRenderersOnly(['fake-key-1', 'fake-key-2'] as any)
         for (const key of rendererKeysInternal) {
             expect(map[key], `${key} should be Unsupported`).toBe(Unsupported)
         }
     })
 
     it('excludeRenderersOnly with invalid keys silently ignores them', () => {
-        const map = excludeRenderersOnly(['not-a-key'] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        const map = excludeRenderersOnly(['not-a-key'] as any)
         for (const key of rendererKeysInternal) {
             expect(map[key], `${key} should be default`).toBe(defaultRenderers[key])
         }

--- a/src/lib/utils/unsupportedRenderers.test.ts
+++ b/src/lib/utils/unsupportedRenderers.test.ts
@@ -1,5 +1,6 @@
 import { Unsupported } from '$lib/renderers/index.js'
 import { defaultRenderers } from '$lib/utils/markdown-parser.js'
+import { rendererKeysInternal } from '$lib/utils/rendererKeys.js'
 import { describe, expect, it } from 'vitest'
 import {
     allowRenderersOnly,
@@ -30,7 +31,7 @@ describe('unsupported renderers helpers', () => {
         const allowed = allowRenderersOnly([
             ['paragraph', Custom],
             ['not-a-key', Custom]
-        ] as any)
+        ] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
         expect(allowed.paragraph).toBe(Custom)
         // @ts-expect-error runtime index
         expect(allowed['not-a-key']).toBeUndefined()
@@ -49,8 +50,87 @@ describe('unsupported renderers helpers', () => {
             ['paragraph', Custom],
             // attempt to override excluded key should be ignored
             ['link', Custom]
-        ] as any)
+        ] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
         expect(map.paragraph).toBe(Custom)
         expect(map.link).toBe(Unsupported)
+    })
+})
+
+describe('unsupported renderers negative tests', () => {
+    it('allowRenderersOnly with empty array maps every key to Unsupported', () => {
+        const map = allowRenderersOnly([])
+        for (const key of rendererKeysInternal) {
+            expect(map[key], `${key} should be Unsupported`).toBe(Unsupported)
+        }
+    })
+
+    it('allowRenderersOnly with all invalid keys maps every key to Unsupported', () => {
+        const map = allowRenderersOnly(['fake-key-1', 'fake-key-2'] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        for (const key of rendererKeysInternal) {
+            expect(map[key], `${key} should be Unsupported`).toBe(Unsupported)
+        }
+    })
+
+    it('excludeRenderersOnly with invalid keys silently ignores them', () => {
+        const map = excludeRenderersOnly(['not-a-key'] as any) // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        for (const key of rendererKeysInternal) {
+            expect(map[key], `${key} should be default`).toBe(defaultRenderers[key])
+        }
+    })
+})
+
+describe('unsupported renderers boundary tests', () => {
+    it('buildUnsupportedRenderers returns a new object each call', () => {
+        const a = buildUnsupportedRenderers()
+        const b = buildUnsupportedRenderers()
+        expect(a).not.toBe(b)
+        expect(a).toEqual(b)
+    })
+
+    it('result key count matches rendererKeysInternal length', () => {
+        const map = buildUnsupportedRenderers()
+        expect(Object.keys(map)).toHaveLength(rendererKeysInternal.length)
+    })
+
+    it('excludeRenderersOnly with empty array preserves all defaults', () => {
+        const map = excludeRenderersOnly([])
+        for (const key of rendererKeysInternal) {
+            expect(map[key], `${key} should be default`).toBe(defaultRenderers[key])
+        }
+    })
+
+    it('excludeRenderersOnly with empty overrides array is the same as without', () => {
+        const withoutOverrides = excludeRenderersOnly(['paragraph'])
+        const withEmptyOverrides = excludeRenderersOnly(['paragraph'], [])
+        expect(withoutOverrides).toEqual(withEmptyOverrides)
+    })
+})
+
+describe('unsupported renderers spot-check completeness', () => {
+    it('block elements are covered', () => {
+        const blockKeys = ['heading', 'paragraph', 'blockquote', 'code', 'hr']
+        const map = buildUnsupportedRenderers()
+        for (const key of blockKeys) {
+            // @ts-expect-error: runtime key index
+            expect(map[key], `${key} should exist in result`).toBe(Unsupported)
+        }
+    })
+
+    it('inline elements are covered', () => {
+        const inlineKeys = ['text', 'link', 'em', 'strong', 'codespan', 'del', 'br']
+        const map = buildUnsupportedRenderers()
+        for (const key of inlineKeys) {
+            // @ts-expect-error: runtime key index
+            expect(map[key], `${key} should exist in result`).toBe(Unsupported)
+        }
+    })
+
+    it('table elements are covered', () => {
+        const tableKeys = ['table', 'tablehead', 'tablebody', 'tablerow', 'tablecell']
+        const map = buildUnsupportedRenderers()
+        for (const key of tableKeys) {
+            // @ts-expect-error: runtime key index
+            expect(map[key], `${key} should exist in result`).toBe(Unsupported)
+        }
     })
 })

--- a/src/routes/test/edge-cases/+page.svelte
+++ b/src/routes/test/edge-cases/+page.svelte
@@ -8,7 +8,7 @@
         //     .fill(0)
         //     .map((_, i) => `${'*'.repeat(i + 1)} Level ${i}`)
         //     .join('\n'),
-        /* eslint-disable */
+        // trunk-ignore-begin(eslint)
         unicode: `# 你好，世界！
 ## مرحبا بالعالم
 ### Привет, мир!
@@ -22,7 +22,7 @@
 <img src="invalid" onerror="alert('xss')">
 `
     }
-    /* eslint-enable */
+    // trunk-ignore-end(eslint)
 
     let source = ''
     let selectedExample = 'empty'


### PR DESCRIPTION
## Summary

A collection of code quality, performance, and testing improvements across the codebase. Highlights include hot-path performance optimizations for token caching and HTML parsing, expanded test coverage, consistent linting practices, and comprehensive JSDoc documentation.

## Changes

- ⚡ **Performance**: Memoize options hash in `getCacheKey` via WeakMap to skip `JSON.stringify` on cache hits; rewrite `containsMultipleTags` as single-pass early-exit loop; consolidate `isHtmlOpenTag` from two regex calls to one
- 🐛 **Bug fix**: Wrap `combinedOptions` and `combinedRenderers` in `$derived` to ensure reactivity
- 🧪 **Testing**: Add missing unit tests for markdown-parser, rendererKeys, and filter utilities
- 🔧 **Linting**: Replace all `eslint-disable` comments with `trunk-ignore` syntax across source and tests
- 📚 **Documentation**: Add Google-style JSDoc across component library; clarify trunk-ignore requirement in CLAUDE.md; document immutability assumption on options hash cache

## Commits

- [`0079e76`](https://github.com/humanspeak/svelte-markdown/commit/0079e767b592ac1eefbbd68cfc9e709475bbcf2e) docs(utils): document immutability assumption on options hash cache
- [`9f9988a`](https://github.com/humanspeak/svelte-markdown/commit/9f9988a7010fd69f127653fefbe6377a7490028f) perf(utils): optimize hot-path token caching and HTML parsing
- [`be25b3a`](https://github.com/humanspeak/svelte-markdown/commit/be25b3a0600267a884a1bc4d91cd255603cf7453) chore(tests): remove unnecessary lint suppression comments
- [`c106a9e`](https://github.com/humanspeak/svelte-markdown/commit/c106a9e324c6575ab19061d66c9cdcc95c1278cb) chore: replace eslint-disable comments with trunk-ignore across source
- [`02e4c30`](https://github.com/humanspeak/svelte-markdown/commit/02e4c30795b0e8fd34afec66f9c38edb08ad2533) docs: clarify trunk-ignore requirement over eslint-disable in CLAUDE.md
- [`a96176c`](https://github.com/humanspeak/svelte-markdown/commit/a96176c7ef1239a306d0e1321bb6b24c1fedad41) test(utils): add missing tests for markdown-parser, rendererKeys, and filter utilities
- [`9784399`](https://github.com/humanspeak/svelte-markdown/commit/97843995acbbbbe67fc5390a40a1653490fcd1e0) fix(core): wrap combinedOptions and combinedRenderers in $derived
- [`a3f4643`](https://github.com/humanspeak/svelte-markdown/commit/a3f46437f158e921ff3794df22c72d3eb06f248d) docs: add Google-style JSDoc across component library

🤖 Generated with [Claude Code](https://claude.com/claude-code)