### PR TITLE
fix(docs): use cf-wasm/resvg with workerd conditions for social cards

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
     server: {
         port: 8234
     },
+    ssr: {
+        resolve: {
+            conditions: ['workerd', 'worker']
+        }
+    },
     build: {
         rollupOptions: {
             output: {


### PR DESCRIPTION
## Summary

Fix social card PNG generation on Cloudflare Workers by switching to `@cf-wasm/resvg` with proper SSR resolve conditions. The previous `@resvg/resvg-js` package doesn't run on Workers, and the base `@cf-wasm/resvg` import used dynamic `WebAssembly.instantiate()` which Workers blocks.

## Changes

- 📦 Replace `@resvg/resvg-js` with `@cf-wasm/resvg` for Workers-compatible SVG-to-PNG
- 🐛 Add `workerd` and `worker` SSR resolve conditions in Vite config so the package resolves to its static WASM entry point during the Cloudflare build

## Commits

- [`a422b71`](https://github.com/humanspeak/svelte-markdown/commit/a422b711116a7b75021d4f37472a5afc419dfc5d) fix(docs): add workerd SSR resolve conditions for cf-wasm/resvg
- [`c0086e2`](https://github.com/humanspeak/svelte-markdown/commit/c0086e242299b1cc766d67b05018e9801636f024) build(docs): switch from @resvg/resvg-js to @cf-wasm/resvg

## Test plan

- [ ] `cd docs && pnpm build` — no errors
- [ ] Deploy to Cloudflare Workers — no "Wasm code generation disallowed" error
- [ ] Social card PNG endpoint returns valid images

🤖 Generated with [Claude Code](https://claude.com/claude-code)