### PR TITLE
build(docs): add tsx as devDependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -64,6 +64,7 @@
         "svelte-check": "^4.4.4",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1",
+        "tsx": "^4.19.4",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1",
         "vite": "^7.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -6435,7 +6438,6 @@ snapshots:
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-    optional: true
 
   github-slugger@2.0.0: {}
 
@@ -7294,8 +7296,7 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
-  resolve-pkg-maps@1.0.0:
-    optional: true
+  resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.11:
     dependencies:
@@ -7722,7 +7723,6 @@ snapshots:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `tsx` as a devDependency in docs to fix CI build failures

## Changes

### 🐛 Bug Fixes
- The `build` script uses `tsx` to run `generate-social-cards.ts` but `tsx` was only available globally, causing CI builds to fail with `sh: 1: tsx: not found`

## Commits

- [`6bec535`](https://github.com/humanspeak/svelte-markdown/commit/6bec535e6cac51a06335011504cdbe30d763848c) build(docs): add tsx as devDependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)