### PR TITLE
build(docs): add sitemap manifest generation to build pipeline

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "tsx ./scripts/fetch-github-stats.ts && tsx ./scripts/generate-social-cards.ts && vite build",
+        "build": "tsx ./scripts/fetch-github-stats.ts && node ./scripts/generate-sitemap-manifest.mjs && tsx ./scripts/generate-social-cards.ts && vite build",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
         "deploy": "npm run build && wrangler pages deploy",


### PR DESCRIPTION
## Summary

Add sitemap manifest generation as a build step in the docs site pipeline, improving SEO and discoverability.

## Changes

- 📦 Insert `generate-sitemap-manifest.mjs` step into the docs build script, running between GitHub stats fetch and social card generation

## Commits

- [`476827c`](https://github.com/humanspeak/svelte-markdown/commit/476827c7bcbff4972c309967af5c94efb27be692) build(docs): add sitemap manifest generation to build pipeline