### PR TITLE
ci(docs): increase Node heap size for Cloudflare Pages build

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -43,6 +43,7 @@ jobs:
             - name: Deploy Docs
               working-directory: docs
               env:
+                  NODE_OPTIONS: --max-old-space-size=4096
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

Fix OOM crash during Cloudflare Pages deploy by increasing the Node.js heap limit from ~2GB to 4GB.

## Changes

- 🐛 Add `NODE_OPTIONS: --max-old-space-size=4096` to the deploy step
- The docs build processes 11k+ modules with heavy deps (prettier, mermaid, shiki, katex) that exceed the default heap

## Commits

- [`f3f6bfa`](https://github.com/humanspeak/svelte-markdown/commit/f3f6bfa) ci(docs): increase Node heap size for Cloudflare Pages build

🤖 Generated with [Claude Code](https://claude.com/claude-code)