### PR TITLE
build(docs): bump docs-kit to 2026.3.5 and lucide to 0.577.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
         "social:watch": "chokidar 'src/lib/components/shared-link/OG.svelte' 'scripts/generate-social-cards.ts' -c 'tsx ./scripts/generate-social-cards.ts' --initial --silent"
     },
     "dependencies": {
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.3.3",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.3.5",
         "@humanspeak/svelte-markdown": "workspace:*",
         "github-slugger": "^2.0.0",
         "katex": "^0.16.33",
@@ -36,7 +36,7 @@
         "@humanspeak/svelte-motion": "^0.1.30",
         "@humanspeak/svelte-satori-fix": "^0.0.3",
         "@icons-pack/svelte-simple-icons": "^7.1.0",
-        "@lucide/svelte": "^0.576.0",
+        "@lucide/svelte": "^0.577.0",
         "@resvg/resvg-js": "^2.6.2",
         "@sveltejs/adapter-cloudflare": "^7.2.8",
         "@sveltejs/kit": "^2.53.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   docs:
     dependencies:
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.3.3
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/8cf83c793c9bda16f74acc47686b31e548259ca8(@humanspeak/svelte-motion@0.1.30(svelte@5.53.7))(@internationalized/date@3.11.0)(@lucide/svelte@0.576.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)
+        specifier: github:humanspeak/docs-kit#2026.3.5
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/cf20b36a37841d054aac812cc843a012778c48af(@humanspeak/svelte-motion@0.1.30(svelte@5.53.7))(@internationalized/date@3.11.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -188,8 +188,8 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)
       '@lucide/svelte':
-        specifier: ^0.576.0
-        version: 0.576.0(svelte@5.53.7)
+        specifier: ^0.577.0
+        version: 0.577.0(svelte@5.53.7)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -838,8 +838,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/8cf83c793c9bda16f74acc47686b31e548259ca8':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/8cf83c793c9bda16f74acc47686b31e548259ca8}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cf20b36a37841d054aac812cc843a012778c48af':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/cf20b36a37841d054aac812cc843a012778c48af}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-motion': '>=0.1.0'
@@ -1062,8 +1062,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@lucide/svelte@0.576.0':
-    resolution: {integrity: sha512-/xO9QPnPj5F5hvmPVdos+f9TeDQm0DntBdD7SpNPG9ZB7hOjzl8qUbfR6RsMik3yHvNlT4rUKE/ZMqzoBoiFDQ==}
+  '@lucide/svelte@0.577.0':
+    resolution: {integrity: sha512-0P6mkySd2MapIEgq08tADPmcN4DHndC/02PWwaLkOerXlx5Sv9aT4BxyXLIY+eccr0g/nEyCYiJesqS61YdBZQ==}
     peerDependencies:
       svelte: ^5
 
@@ -4635,10 +4635,10 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/8cf83c793c9bda16f74acc47686b31e548259ca8(@humanspeak/svelte-motion@0.1.30(svelte@5.53.7))(@internationalized/date@3.11.0)(@lucide/svelte@0.576.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cf20b36a37841d054aac812cc843a012778c48af(@humanspeak/svelte-motion@0.1.30(svelte@5.53.7))(@internationalized/date@3.11.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)':
     dependencies:
       '@humanspeak/svelte-motion': 0.1.30(svelte@5.53.7)
-      '@lucide/svelte': 0.576.0(svelte@5.53.7)
+      '@lucide/svelte': 0.577.0(svelte@5.53.7)
       '@sveltejs/kit': 2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       bits-ui: 2.16.2(@internationalized/date@3.11.0)(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)
       clsx: 2.1.1
@@ -4807,7 +4807,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lucide/svelte@0.576.0(svelte@5.53.7)':
+  '@lucide/svelte@0.577.0(svelte@5.53.7)':
     dependencies:
       svelte: 5.53.7
 


### PR DESCRIPTION
## Summary

Bump docs-kit and lucide icon library versions.

## Changes

- 📦 Bump `@humanspeak/docs-kit` from 2026.3.3 to 2026.3.5
- 📦 Bump `@lucide/svelte` from 0.576.0 to 0.577.0

## Commits

- [`62ea6aa`](https://github.com/humanspeak/svelte-markdown/commit/62ea6aa) build(docs): bump docs-kit to 2026.3.5 and lucide to 0.577.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)