### PR TITLE
fix(docs): resolve Ahrefs site audit SEO issues

### DIFF
--- a/docs/src/lib/components/general/Example.svelte
+++ b/docs/src/lib/components/general/Example.svelte
@@ -16,6 +16,10 @@
     }
 </script>
 
+{#if title}
+    <h1 class="sr-only">{title}</h1>
+{/if}
+
 <div class="isolate flex h-full w-full flex-1 flex-col">
     <!-- Toolbar -->
     <div class="border-border bg-card/50 flex h-12 w-full items-center border-b px-4">

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -55,11 +55,11 @@ export function buildBreadcrumbs(pathname: string): Breadcrumb[] {
             if (pathname.startsWith('/docs/')) {
                 const depth = pathname.replace('/docs/', '').split('/').length
                 if (depth === 1) {
-                    return [{ title: 'Docs', href: '/docs' }, { title: itemTitle }]
+                    return [{ title: 'Docs', href: '/docs/getting-started' }, { title: itemTitle }]
                 }
                 const sectionTitle = sectionBreadcrumbOverrides[section.title] ?? section.title
                 return [
-                    { title: 'Docs', href: '/docs' },
+                    { title: 'Docs', href: '/docs/getting-started' },
                     { title: sectionTitle },
                     { title: itemTitle }
                 ]


### PR DESCRIPTION
## Summary

Fixes SEO issues flagged by Ahrefs Site Audit for markdown.svelte.page. Breadcrumb links on ~20 docs pages pointed to `/docs` (a 301 redirect) instead of `/docs/getting-started`, and 2 example pages were missing semantic `<h1>` tags.

## Changes

🐛 **Breadcrumb redirect links** — Updated `buildBreadcrumbs()` in `docsNav.ts` to link to `/docs/getting-started` instead of `/docs`, eliminating "page has links to redirect" warnings across all docs pages

🐛 **Missing H1 on example pages** — Added a visually hidden `<h1>` (using `sr-only`) to `Example.svelte` so crawlers find a semantic heading without changing the visual design

## Commits

- [`ff35817`](https://github.com/humanspeak/svelte-markdown/commit/ff358179bd3f8e665cdafbea3039caad1eda92a7) fix(docs): resolve Ahrefs site audit SEO issues
