### PR TITLE
fix(seo): use page.data for unique SSR titles

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
         "social:watch": "chokidar 'src/lib/components/shared-link/OG.svelte' 'scripts/generate-social-cards.ts' -c 'tsx ./scripts/generate-social-cards.ts' --initial --silent"
     },
     "dependencies": {
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.3.12",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.3.13",
         "@humanspeak/svelte-markdown": "workspace:*",
         "github-slugger": "^2.0.0",
         "katex": "^0.16.35",

--- a/docs/src/lib/components/general/Example.svelte
+++ b/docs/src/lib/components/general/Example.svelte
@@ -16,6 +16,10 @@
     }
 </script>
 
+{#if title}
+    <h1 class="sr-only">{title}</h1>
+{/if}
+
 <div class="isolate flex h-full w-full flex-1 flex-col">
     <!-- Toolbar -->
     <div class="border-border bg-card/50 flex h-12 w-full items-center border-b px-4">

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -55,11 +55,11 @@ export function buildBreadcrumbs(pathname: string): Breadcrumb[] {
             if (pathname.startsWith('/docs/')) {
                 const depth = pathname.replace('/docs/', '').split('/').length
                 if (depth === 1) {
-                    return [{ title: 'Docs', href: '/docs' }, { title: itemTitle }]
+                    return [{ title: 'Docs', href: '/docs/getting-started' }, { title: itemTitle }]
                 }
                 const sectionTitle = sectionBreadcrumbOverrides[section.title] ?? section.title
                 return [
-                    { title: 'Docs', href: '/docs' },
+                    { title: 'Docs', href: '/docs/getting-started' },
                     { title: sectionTitle },
                     { title: itemTitle }
                 ]

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -15,10 +15,7 @@
     const { children } = $props()
 
     // SEO state — owned here, passed to SeoContextProvider for child access
-    const seo = $state<SeoContext>({
-        title: `${docsConfig.name} - Customizable Markdown Renderer for Svelte 5`,
-        description: docsConfig.description
-    })
+    const seo = $state<SeoContext>({})
 
     const npmUrl = `https://www.npmjs.com/package/${docsConfig.npmPackage}`
     const repoUrl = `https://github.com/${docsConfig.repo}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   docs:
     dependencies:
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.3.12
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/99a9108589b6e67185c70c32cdd7c61da4c7701c(@humanspeak/svelte-motion@0.1.31(svelte@5.53.7))(@internationalized/date@3.11.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)
+        specifier: github:humanspeak/docs-kit#2026.3.13
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/2014a516577b84e7a51fa200755651dceddfdb04(@humanspeak/svelte-motion@0.1.31(svelte@5.53.7))(@internationalized/date@3.11.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -826,8 +826,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/99a9108589b6e67185c70c32cdd7c61da4c7701c':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/99a9108589b6e67185c70c32cdd7c61da4c7701c}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/2014a516577b84e7a51fa200755651dceddfdb04':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/2014a516577b84e7a51fa200755651dceddfdb04}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-motion': '>=0.1.0'
@@ -4623,7 +4623,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/99a9108589b6e67185c70c32cdd7c61da4c7701c(@humanspeak/svelte-motion@0.1.31(svelte@5.53.7))(@internationalized/date@3.11.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/2014a516577b84e7a51fa200755651dceddfdb04(@humanspeak/svelte-motion@0.1.31(svelte@5.53.7))(@internationalized/date@3.11.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)':
     dependencies:
       '@humanspeak/svelte-motion': 0.1.31(svelte@5.53.7)
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.53.7)


### PR DESCRIPTION
## Summary
- Update docs-kit to 2026.3.13 which resolves duplicate title/description in SSR HTML
- Remove hardcoded default SEO values from root layout, letting page.data drive titles
- Fixes Ahrefs site audit warnings for duplicate metadata

## Test plan
- [ ] Build docs and inspect SSR HTML for unique titles per page
- [ ] Verify home page title includes project name
- [ ] Verify client-side navigation still updates document.title

🤖 Generated with [Claude Code](https://claude.com/claude-code)