### PR TITLE
ci: scope pnpm install to current package in CI workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -222,7 +222,7 @@ jobs:
 
             - name: Install
               run: |
-                  pnpm install --prefer-offline --frozen-lockfile --ignore-scripts
+                  pnpm install --filter . --prefer-offline --frozen-lockfile --ignore-scripts
 
             - name: Test
               run: |
@@ -268,7 +268,7 @@ jobs:
                   node-version: 24
 
             - name: Install dependencies
-              run: pnpm install --prefer-offline --frozen-lockfile --ignore-scripts
+              run: pnpm install --filter . --prefer-offline --frozen-lockfile --ignore-scripts
 
             - name: Install Playwright Browsers
               run: pnpm exec playwright install --with-deps
@@ -334,7 +334,7 @@ jobs:
                   node-version: 24
 
             - name: Install
-              run: pnpm install --prefer-offline --frozen-lockfile --ignore-scripts
+              run: pnpm install --filter . --prefer-offline --frozen-lockfile --ignore-scripts
 
             - name: Check Publishing Status
               id: publish-check

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,7 @@ jobs:
                       ${{ runner.os }}-vitest-
 
             - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+              run: pnpm install --filter . --frozen-lockfile
 
             - name: Run unit tests
               run: |
@@ -113,7 +113,7 @@ jobs:
                   node-version: 24
 
             - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+              run: pnpm install --filter . --frozen-lockfile
 
             - name: Cache Playwright browsers
               uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
## Summary

Scopes `pnpm install` commands in CI workflows to the current package using `--filter .`, preventing unnecessary installation of dependencies from other workspace packages.

## Changes

🔄 **CI/CD**
- Add `--filter .` to `pnpm install` in npm-publish workflow (3 jobs)
- Add `--filter .` to `pnpm install` in run-tests workflow (2 jobs)

## Commits

- [`d4e16ed`](https://github.com/humanspeak/svelte-markdown/commit/d4e16ed5ea436c714af3684f530e0de931a712d8) ci: scope pnpm install to current package in CI workflows