### PR TITLE
fix: resolve cyclic object error in streaming mode

### DIFF
--- a/src/lib/SvelteMarkdown.svelte
+++ b/src/lib/SvelteMarkdown.svelte
@@ -97,14 +97,16 @@
 
     // Streaming mode: full re-parse + smart in-place diff
     let incrementalParser: IncrementalParser | undefined
-    let lastOptionsKey = ''
+    let lastOptionsSrc: typeof options | undefined
+    let lastExtensionsSrc: typeof extensions | undefined
     let streamTokens = $state<Token[]>([])
 
     $effect(() => {
         if (!streaming || hasAsyncExtension) {
             if (incrementalParser) {
                 incrementalParser = undefined
-                lastOptionsKey = ''
+                lastOptionsSrc = undefined
+                lastExtensionsSrc = undefined
             }
             if (streaming && hasAsyncExtension) {
                 console.warn(
@@ -115,9 +117,8 @@
             return
         }
 
-        // Read combinedOptions unconditionally so Svelte tracks it as a dependency
+        // Read combinedOptions so Svelte tracks it as a dependency
         const currentOptions = combinedOptions
-        const optionsKey = JSON.stringify(currentOptions)
 
         if (Array.isArray(source)) {
             streamTokens = source as Token[]
@@ -130,10 +131,11 @@
             return
         }
 
-        // Recreate parser only when options actually change
-        if (!incrementalParser || lastOptionsKey !== optionsKey) {
+        // Recreate parser when user-facing options or extensions change
+        if (!incrementalParser || lastOptionsSrc !== options || lastExtensionsSrc !== extensions) {
             incrementalParser = new IncrementalParser(currentOptions)
-            lastOptionsKey = optionsKey
+            lastOptionsSrc = options
+            lastExtensionsSrc = extensions
         }
         const { tokens: newTokens, divergeAt } = incrementalParser.update(source as string)
 


### PR DESCRIPTION
## Summary

Fix `cyclic object value` TypeError that occurs when `streaming={true}` is used. The `JSON.stringify(combinedOptions)` call fails because Marked's merged defaults can contain circular references. Replace with direct reference tracking of the `options` and `extensions` props.

## Changes

🐛 **Bug Fix**
- Replace `JSON.stringify(combinedOptions)` with reference comparison of `options` and `extensions` props
- Fixes `Uncaught TypeError: cyclic object value` on production builds where Marked defaults contain circular refs
- Parser is now only recreated when the user passes different `options` or `extensions` objects, not on every streaming chunk

## Commits

- [`f767cf2`](https://github.com/humanspeak/svelte-markdown/commit/f767cf2df0aa95847308919c7784dd1e4686b4db) fix: replace JSON.stringify with reference tracking for options
