### PR TITLE
fix(docs): use text instead of markdown for code blocks in security page

### DIFF
--- a/docs/src/routes/docs/advanced/security/+page.svx
+++ b/docs/src/routes/docs/advanced/security/+page.svx
@@ -35,7 +35,7 @@ By default, all `href` values on markdown links and images are validated against
 
 Dangerous protocols like `javascript:`, `data:`, `vbscript:`, and `blob:` are blocked automatically.
 
-```markdown
+```text
 <!-- This link will have its href stripped -->
 [Click me](javascript:alert('XSS'))
 
@@ -50,7 +50,7 @@ For raw HTML within markdown, the default sanitizer:
 1. **Strips all event handler attributes** (`onclick`, `onerror`, `onload`, etc.)
 2. **Validates URL-bearing attributes** (`href`, `src`, `action`, `formaction`, `cite`, `data`, `poster`) against the same protocol allowlist
 
-```markdown
+```text
 <!-- onclick is stripped, javascript: href is blocked -->
 <a href="javascript:alert('XSS')" onclick="alert('XSS')">Click</a>
 


### PR DESCRIPTION
## Summary

Fixes the docs build failure caused by ` ```markdown ``` ` code blocks in the security page — Shiki doesn't have the `markdown` language loaded, so mdsvex fails during preprocessing.

## Changes

🐛 **Bug fix**
- Change ` ```markdown ``` ` to ` ```text ``` ` in security docs page to avoid Shiki `Language not found` error

## Commits

- [`4e4cd82`](https://github.com/humanspeak/svelte-markdown/commit/4e4cd82) fix(docs): use text instead of markdown for code blocks in security page

🤖 Generated with [Claude Code](https://claude.ai/code)
