### PR TITLE
fix(docs): remove not_found_handling breaking docs site

### DIFF
--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -10,8 +10,7 @@
     "main": ".svelte-kit/cloudflare/_worker.js",
     "assets": {
         "directory": ".svelte-kit/cloudflare",
-        "binding": "ASSETS",
-        "not_found_handling": "404-page"
+        "binding": "ASSETS"
     },
     "observability": {
         "enabled": true


### PR DESCRIPTION
## Summary

Fixes the docs site returning "Not Found" after migrating from Cloudflare Pages to Workers. The `not_found_handling: "404-page"` setting in `wrangler.jsonc` was causing Cloudflare to serve a static 404 for all non-static routes, bypassing the SvelteKit `_worker.js` entirely.

## Changes

🐛 **Fix docs site deployment**
- Remove `not_found_handling: "404-page"` from `wrangler.jsonc` — this setting prevented the SvelteKit worker from handling SSR and dynamic routes

## Commits

- [`febea1c`](https://github.com/humanspeak/svelte-markdown/commit/febea1c1e1a7691268378fb92338814ec87624ae) fix(docs): remove not_found_handling from wrangler config
