### PR TITLE
fix(extensions): broaden KaTeX delimiter and boundary handling

### DIFF
--- a/src/lib/extensions/katex/markedKatex.test.ts
+++ b/src/lib/extensions/katex/markedKatex.test.ts
@@ -121,6 +121,28 @@ describe('markedKatex', () => {
             expect(token!.text).toBe('x = 1 \\\\\ny = 2')
         })
 
+        // LLM output frequently uses single-line $$x$$ instead of the
+        // own-line form. Keep both shapes parseable as block math.
+        it('matches single-line $$x$$ as block', () => {
+            const def = getBlockDef()
+            const src = '$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$'
+            const token = def.tokenizer.call({} as never, src, [])
+            expect(token).toBeDefined()
+            expect(token!.type).toBe('blockKatex')
+            expect(token!.text).toBe('x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}')
+            expect((token as unknown as { displayMode: boolean }).displayMode).toBe(true)
+        })
+
+        it('matches single-line \\[x\\] as block', () => {
+            const def = getBlockDef()
+            const src = '\\[e^{i\\pi} + 1 = 0\\]'
+            const token = def.tokenizer.call({} as never, src, [])
+            expect(token).toBeDefined()
+            expect(token!.type).toBe('blockKatex')
+            expect(token!.text).toBe('e^{i\\pi} + 1 = 0')
+            expect((token as unknown as { displayMode: boolean }).displayMode).toBe(true)
+        })
+
         it('returns undefined for unclosed \\[ block', () => {
             const def = getBlockDef()
             expect(def.tokenizer.call({} as never, '\\[\nx', [])).toBeUndefined()
@@ -191,6 +213,32 @@ describe('markedKatex', () => {
         it('only matches from the start of the string', () => {
             const def = getInlineDef()
             expect(def.tokenizer.call({} as never, 'prefix \\(x\\)', [])).toBeUndefined()
+        })
+
+        // Boundary expansion: closing math followed by a closing
+        // bracket / paren / brace should match. Upstream marked-katex-extension
+        // omits these from the lookahead, which broke `($e$, $i$, $\pi$, $1$, $0$)`
+        // (the trailing `$0$)` failed). We add `)`, `]`, `}` to the boundary class.
+        it('matches $...$ followed by ) as boundary', () => {
+            const def = getInlineDef({ singleDollarInline: true })
+            const token = def.tokenizer.call({} as never, '$0$)', [])
+            expect(token).toBeDefined()
+            expect(token!.type).toBe('inlineKatex')
+            expect(token!.text).toBe('0')
+        })
+
+        it('matches $...$ followed by ] as boundary', () => {
+            const def = getInlineDef({ singleDollarInline: true })
+            const token = def.tokenizer.call({} as never, '$x$]', [])
+            expect(token).toBeDefined()
+            expect(token!.text).toBe('x')
+        })
+
+        it('matches $...$ followed by } as boundary', () => {
+            const def = getInlineDef({ singleDollarInline: true })
+            const token = def.tokenizer.call({} as never, '$x$}', [])
+            expect(token).toBeDefined()
+            expect(token!.text).toBe('x')
         })
     })
 

--- a/src/lib/extensions/katex/markedKatex.test.ts
+++ b/src/lib/extensions/katex/markedKatex.test.ts
@@ -240,6 +240,15 @@ describe('markedKatex', () => {
             expect(token).toBeDefined()
             expect(token!.text).toBe('x')
         })
+
+        // Negative complement to the boundary expansion above: digits and
+        // letters after the closing $ must still NOT match. Locks in the
+        // currency guard so a future boundary-class edit can't quietly
+        // regress `$5,000$` / `$0$42` style content into math.
+        it('does not match when a digit follows the closing $', () => {
+            const def = getInlineDef({ singleDollarInline: true })
+            expect(def.tokenizer.call({} as never, '$0$42', [])).toBeUndefined()
+        })
     })
 
     describe('factory', () => {

--- a/src/lib/extensions/katex/markedKatex.ts
+++ b/src/lib/extensions/katex/markedKatex.ts
@@ -33,17 +33,23 @@ const AMS_ENVIRONMENTS = ['equation', 'align', 'alignat', 'gather', 'CD'] as con
 // match `\begin{equation*}`.
 const AMS_NAMES = AMS_ENVIRONMENTS.flatMap((n) => [n, `${n}\\*`]).join('|')
 
-const blockBracketRule = /^\\\[[ \t]*\n([\s\S]+?)\n[ \t]*\\\](?:\n|$)/
-const blockDollarRule = /^\$\$[ \t]*\n([\s\S]+?)\n[ \t]*\$\$(?:\n|$)/
+// `\s*` (instead of `[ \t]*\n`) lets these rules match both the canonical
+// own-line form (`$$\nx\n$$`) and the single-line form (`$$x$$`) that LLMs
+// emit constantly. Without this, `$$x = \frac{...}{2a}$$` survives as
+// paragraph text because the inline tokenizer also rejects `$$` openers.
+const blockBracketRule = /^\\\[\s*([\s\S]+?)\s*\\\](?:\n|$)/
+const blockDollarRule = /^\$\$\s*([\s\S]+?)\s*\$\$(?:\n|$)/
 const blockAmsRule = new RegExp(
     `^\\\\begin\\{(${AMS_NAMES})\\}[\\s\\S]+?\\\\end\\{\\1\\}(?:\\n|$)?`
 )
 
 const inlineParenRule = /^\\\(([\s\S]+?)\\\)/
-// Mirrors the "standard" rule from upstream marked-katex-extension: requires a
-// whitespace, end-of-string, or punctuation boundary after the closing `$` so
-// strings like `$5,000` do not match.
-const inlineDollarRule = /^\$(?!\$)((?:\\.|[^\\\n$])+?)\$(?=[\s?!.,:？！。，：]|$)/
+// Mirrors the "standard" rule from upstream marked-katex-extension but
+// extends the boundary class with `)`, `]`, `}` so expressions like
+// `$0$)`, `$x$]`, `$x$}` (closing math right before a closing bracket)
+// still match. Currency strings like `$5,000 across $42` remain unmatched
+// because digits after the closing `$` aren't in any boundary class.
+const inlineDollarRule = /^\$(?!\$)((?:\\.|[^\\\n$])+?)\$(?=[\s?!.,:)\]}？！。，：]|$)/
 
 const earliestIndex = (src: string, needles: string[]): number | undefined => {
     let best = -1

--- a/src/lib/extensions/katex/markedKatex.ts
+++ b/src/lib/extensions/katex/markedKatex.ts
@@ -69,9 +69,14 @@ const earliestIndex = (src: string, needles: string[]): number | undefined => {
  * | Delimiter pair | Level | `displayMode` |
  * |---|---|---|
  * | `\(...\)` | inline | `false` |
- * | `\[...\]` (own-line) | block | `true` |
- * | `$$...$$` (own-line) | block | `true` |
+ * | `\[...\]` (own-line **or** single-line) | block | `true` |
+ * | `$$...$$` (own-line **or** single-line) | block | `true` |
  * | `\begin{equation}...\end{equation}` and other AMS envs | block | `true` |
+ *
+ * Both `\[x\]` and `\[\nx\n\]` parse as block math; same for `$$x$$` and the
+ * own-line `$$\nx\n$$` form. LLMs overwhelmingly emit the single-line form,
+ * so accepting both keeps the extension drop-in compatible with their output
+ * without losing the canonical own-line shape.
  *
  * Supported AMS environments: `equation`, `align`, `alignat`, `gather`, `CD`,
  * plus their starred variants (e.g. `equation*`).

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -64,6 +64,11 @@
         },
         { href: '/test/katex', name: 'KaTeX', description: 'Math rendering with KaTeX extension' },
         {
+            href: '/test/katex-issue',
+            name: 'KaTeX Issue',
+            description: 'Dataverse transcript boundary regression playground'
+        },
+        {
             href: '/test/katex-snippets',
             name: 'KaTeX Snippets',
             description: 'KaTeX with Svelte 5 snippets'

--- a/src/routes/test/katex-issue/+page.svelte
+++ b/src/routes/test/katex-issue/+page.svelte
@@ -1,0 +1,235 @@
+<script lang="ts">
+    import { KatexRenderer, markedKatex } from '$lib/extensions/katex/index.js'
+    import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
+    import type { RendererComponent, Renderers } from '$lib/utils/markdown-parser.js'
+
+    // Mirrors the genai/www config exactly — singleDollarInline: true so the
+    // LLM's existing $...$ / $$...$$ output keeps rendering during the
+    // migration off marked-katex-extension. This page is a regression
+    // playground for the exact dataverse-style transcript that exposed the
+    // boundary edge cases (currency-vs-math, $0$), inline $$...$$, etc.).
+    const extensions = [markedKatex({ singleDollarInline: true })]
+
+    interface KatexRenderers extends Renderers {
+        inlineKatex: RendererComponent
+        blockKatex: RendererComponent
+    }
+
+    const renderers: Partial<KatexRenderers> = {
+        inlineKatex: KatexRenderer,
+        blockKatex: KatexRenderer
+    }
+
+    // String.raw keeps backslashes literal — no double-escape gymnastics for
+    // \frac, \pm, \sqrt, etc. The exact text the user pasted, verbatim.
+    const dataverseSource = String.raw`That question is outside the scope of this dataverse — I'm focused on helping you analyze the transaction data (Amjad, Farhad, categories, etc.), not general math reference.
+
+For completeness, though:
+
+### Quadratic Formula
+For $ax^2 + bx + c = 0$ (with $a \neq 0$):
+
+$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
+
+The discriminant $b^2 - 4ac$ tells you the nature of the roots: positive = two real roots, zero = one repeated root, negative = two complex conjugate roots.
+
+### Euler's Identity
+
+$$e^{i\pi} + 1 = 0$$
+
+A special case of Euler's formula $e^{ix} = \cos(x) + i\sin(x)$ evaluated at $x = \pi$. Often cited as the most elegant equation in mathematics because it links five fundamental constants ($e$, $i$, $\pi$, $1$, $0$) and three core operations (addition, multiplication, exponentiation) in a single expression.
+
+Back to the analysis whenever you're ready.
+
+- Can you run the logistic regression of Amjad on hour, category, and amount?
+- Can you build the card-level features for a cardholder Amjad model?
+- Can you run the quantile regression on Amjad amount at the 95th percentile?`
+
+    // Each fragment is also surfaced individually so Playwright can target a
+    // specific delimiter form without the rest of the prose interfering.
+    const fragments: { id: string; label: string; markdown: string }[] = [
+        {
+            id: 'inline-quadratic-form',
+            label: 'Inline $ax^2 + bx + c = 0$ followed by " (with"',
+            markdown: 'For $ax^2 + bx + c = 0$ (with $a \\neq 0$):'
+        },
+        {
+            id: 'block-quadratic-formula',
+            label: 'Single-line $$ ... $$ block (no own-line delimiters)',
+            markdown: '$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$'
+        },
+        {
+            id: 'block-quadratic-formula-ownline',
+            label: 'Own-line $$ ... $$ block (delimiters on their own lines)',
+            markdown: '$$\nx = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}\n$$'
+        },
+        {
+            id: 'block-euler',
+            label: 'Single-line $$e^{i\\pi} + 1 = 0$$',
+            markdown: '$$e^{i\\pi} + 1 = 0$$'
+        },
+        {
+            id: 'inline-discriminant',
+            label: 'Inline $b^2 - 4ac$ in mid-sentence',
+            markdown: 'The discriminant $b^2 - 4ac$ tells you...'
+        },
+        {
+            id: 'inline-paren-list',
+            label: 'Parenthetical with trailing $0$) — closing $ before )',
+            markdown: 'links five constants ($e$, $i$, $\\pi$, $1$, $0$) and three operations'
+        },
+        {
+            id: 'inline-currency',
+            label: 'Currency strings (must NOT render as math)',
+            markdown: 'Budget: $5,000 across $42 line items.'
+        },
+        {
+            id: 'inline-latex-paren',
+            label: 'LaTeX-style \\(...\\) inline',
+            markdown: 'The Pythagorean identity is \\(\\sin^2 \\theta + \\cos^2 \\theta = 1\\).'
+        },
+        {
+            id: 'block-latex-bracket',
+            label: 'LaTeX-style \\[ ... \\] block (own-line delimiters)',
+            markdown: '\\[\n\\int_{-\\infty}^{\\infty} e^{-x^2} \\, dx = \\sqrt{\\pi}\n\\]'
+        },
+        {
+            id: 'block-ams-equation',
+            label: 'AMS \\begin{equation} ... \\end{equation}',
+            markdown:
+                '\\begin{equation}\n\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}\n\\end{equation}'
+        }
+    ]
+</script>
+
+<svelte:head>
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/katex@0.16.45/dist/katex.min.css"
+        crossorigin="anonymous"
+    />
+</svelte:head>
+
+<header data-testid="header">
+    <h1>KaTeX delimiter regression playground</h1>
+    <p>
+        Mirrors the <code>genai/www</code> config (<code>singleDollarInline: true</code>). Each
+        fragment below is a known edge case from the dataverse transcript.
+    </p>
+</header>
+
+<section data-testid="full-transcript-section">
+    <h2>Full transcript (verbatim from the failing message)</h2>
+    <div class="preview" data-testid="full-transcript-preview">
+        <SvelteMarkdown {extensions} source={dataverseSource} {renderers} />
+    </div>
+</section>
+
+<section data-testid="fragments-section">
+    <h2>Isolated fragments</h2>
+    <p>One fragment per row so Playwright can scope assertions to a specific delimiter form.</p>
+    <div class="fragments">
+        {#each fragments as fragment (fragment.id)}
+            <article class="fragment" data-testid="fragment-{fragment.id}">
+                <header>
+                    <code class="fragment-id">{fragment.id}</code>
+                    <span class="fragment-label">{fragment.label}</span>
+                </header>
+                <details class="fragment-source">
+                    <summary>Source</summary>
+                    <pre data-testid="fragment-{fragment.id}-source">{fragment.markdown}</pre>
+                </details>
+                <div class="fragment-rendered" data-testid="fragment-{fragment.id}-rendered">
+                    <SvelteMarkdown {extensions} source={fragment.markdown} {renderers} />
+                </div>
+            </article>
+        {/each}
+    </div>
+</section>
+
+<style>
+    :global(body) {
+        font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 1.5rem;
+        line-height: 1.5;
+    }
+
+    header[data-testid='header'] h1 {
+        margin: 0 0 0.5rem;
+    }
+
+    header[data-testid='header'] p {
+        color: #555;
+        margin: 0 0 1.5rem;
+    }
+
+    section {
+        margin-top: 2rem;
+        padding: 1rem 1.25rem;
+        border: 1px solid #ddd;
+        border-radius: 0.5rem;
+    }
+
+    section > h2 {
+        margin-top: 0;
+    }
+
+    .preview {
+        border: 1px solid #eee;
+        border-radius: 0.375rem;
+        padding: 1rem;
+        background: #fafafa;
+    }
+
+    .fragments {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .fragment {
+        border: 1px solid #eee;
+        border-radius: 0.375rem;
+        padding: 0.75rem 1rem;
+    }
+
+    .fragment > header {
+        display: flex;
+        gap: 0.75rem;
+        align-items: baseline;
+        margin-bottom: 0.5rem;
+    }
+
+    .fragment-id {
+        font-size: 0.75rem;
+        color: #666;
+        background: #f0f0f0;
+        padding: 0.125rem 0.375rem;
+        border-radius: 0.25rem;
+    }
+
+    .fragment-label {
+        font-size: 0.875rem;
+        color: #333;
+    }
+
+    .fragment-source pre {
+        font-size: 0.75rem;
+        background: #f5f5f5;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.25rem;
+        overflow-x: auto;
+        margin: 0.5rem 0;
+        white-space: pre-wrap;
+    }
+
+    .fragment-rendered {
+        padding: 0.5rem 0;
+        border-top: 1px dashed #eee;
+    }
+</style>


### PR DESCRIPTION
## Summary

Two regex tweaks in `markedKatex` that fix real-world LLM math output we were silently dropping. Surfaced from a `genai/www` dataverse transcript that had inline `$0$)` (closing `$` before `)`) and single-line `$$x = \frac{...}{2a}$$` — both rendered as paragraph text under the previous rules. The regex changes are minimal, the existing currency-stays-text behavior is preserved, and a new test route `/test/katex-issue` exists as a regression playground.

## Changes

### 🔧 Regex fixes — `src/lib/extensions/katex/markedKatex.ts`

| Rule | Before | After | Effect |
| --- | --- | --- | --- |
| `blockBracketRule` | `^\\\[[ \t]*\n([\s\S]+?)\n[ \t]*\\\](?:\n\|$)` | `^\\\[\s*([\s\S]+?)\s*\\\](?:\n\|$)` | Single-line `\[x\]` now matches as block math (own-line still works). |
| `blockDollarRule` | `^\$\$[ \t]*\n([\s\S]+?)\n[ \t]*\$\$(?:\n\|$)` | `^\$\$\s*([\s\S]+?)\s*\$\$(?:\n\|$)` | Single-line `$$x = \frac{...}{2a}$$` now matches (own-line still works). LLMs default to this form. |
| `inlineDollarRule` | `…\$(?=[\s?!.,:？！。，：]\|$)` | `…\$(?=[\s?!.,:)\]}？！。，：]\|$)` | Closing math followed by `)`, `]`, or `}` now matches. Fixes `$0$)` in `($e$, $i$, $\pi$, $1$, $0$)`. |

The boundary expansion does **not** allow currency strings to leak through — `$5,000 across $42` still doesn't match because digits after the closing `$` aren't in any boundary class. Verified by trace and by the existing `tests/katex.test.ts` "still does not match $5,000-style currency strings" assertion (which still passes after the change).

### 🧪 New unit tests — `src/lib/extensions/katex/markedKatex.test.ts`

- `matches single-line $$x$$ as block`
- `matches single-line \[x\] as block`
- `matches $...$ followed by ) as boundary`
- `matches $...$ followed by ] as boundary`
- `matches $...$ followed by } as boundary`

Total katex unit tests: 35 → 40. Suite-wide: 773 → 778.

### 🧰 New regression playground — `src/routes/test/katex-issue/+page.svelte`

Mirrors the `genai/www` config exactly (`singleDollarInline: true`). Renders the verbatim dataverse transcript top-to-bottom plus 10 isolated fragments, each with `data-testid` hooks (`fragment-<id>-rendered`, `fragment-<id>-source`) so Playwright can scope assertions to a single delimiter form. Linked from the homepage between `/test/katex` and `/test/katex-snippets`.

Used directly during development to confirm the fix — see commit message for the before/after `.katex` counts per fragment.

## Commits

- [`7757438`](https://github.com/humanspeak/svelte-markdown/commit/7757438) fix(extensions): broaden KaTeX delimiter and boundary handling

## Test plan

- [x] `pnpm test` — 778/778 pass
- [x] `pnpm exec playwright test tests/katex.test.ts tests/katex-snippets.test.ts` — 95/95 across all 5 browser projects
- [x] Live Playwright walk-through of `/test/katex-issue` — all 10 fragments render correctly, currency strings stay text
- [x] `pnpm check` — 0 type errors

## Out of scope

- Updating `genai/www` to remove its `singleDollarInline: true` workaround. After this fix lands and ships as 1.4.3, that consumer can stay on `singleDollarInline: true` indefinitely (no harm), or switch to `singleDollarInline: false` once the LLM prompt is updated to emit `\(...\)` exclusively.
- Refactoring the `npm-publish.yml` workflow's bump-and-push-to-main path — separate concern tracked elsewhere.
