### PR TITLE
perf(streaming): reuse parser on prop appends + add perf-bench harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "lint": "prettier --check . && eslint .",
         "lint:fix": "npm run format && eslint . --fix",
         "package": "svelte-kit sync && svelte-package && publint",
+        "perf:bench": "node scripts/perf-bench.mjs",
         "prepare": "husky",
         "prepublishOnly": "npm run package",
         "preview": "vite preview",

--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -1,0 +1,177 @@
+/**
+ * Headless-Chromium runner for the perf-bench fixture
+ * (`src/routes/test/perf-bench/+page.svelte`).
+ *
+ * Drives each preset twice — COLD (first navigation) and WARM (after
+ * reload) — and dumps a JSON blob of the page's stats line so each
+ * commit can be attributed to a specific before/after delta.
+ *
+ * Usage:
+ *     pnpm dev                               # in another shell
+ *     pnpm perf:bench                        # runs against http://localhost:8233
+ *     PERF_BENCH_URL=http://localhost:9000 pnpm perf:bench   # custom URL
+ *
+ * Caveat: headless Chromium is not a DevTools session — absolute
+ * numbers differ from a manual capture. The deltas between commits
+ * stay valid.
+ */
+
+import { chromium } from '@playwright/test'
+
+const URL = process.env.PERF_BENCH_URL ?? 'http://localhost:8233/test/perf-bench'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function readStats(page) {
+    return await page.$eval('[data-testid="perf-stats"]', (el) =>
+        el.textContent.replace(/\s+/g, ' ').trim()
+    )
+}
+
+function parseStats(s) {
+    const grab = (key) => {
+        const m = s.match(new RegExp(`${key}=([^\\s·]+)`))
+        return m ? m[1] : null
+    }
+    const num = (v) => (v == null ? null : Number.isNaN(Number(v)) ? v : Number(v))
+    return {
+        scenario: grab('scenario'),
+        srcKb: num(grab('srcKb')),
+        tokenCount: num(grab('tokenCount')),
+        parseColdMs: num(grab('parseColdMs')),
+        parseWarmMs: num(grab('parseWarmMs')),
+        lexMs: num(grab('lexMs')),
+        cleanupMs: num(grab('cleanupMs')),
+        hashMs: num(grab('hashMs')),
+        firstPaintMs: num(grab('firstPaintMs')),
+        domNodes: num(grab('domNodes')),
+        charsPerSec: num(grab('charsPerSec')),
+        cacheIters: num(grab('cacheIters')),
+        cacheTotalMs: num(grab('cacheTotalMs')),
+        cacheAvgMs: num(grab('cacheAvgMs')),
+        cacheP95Ms: num(grab('cacheP95Ms')),
+        cachePeakMs: num(grab('cachePeakMs')),
+        streamChunks: num(grab('streamChunks')),
+        streamTotalMs: num(grab('streamTotalMs')),
+        streamAvgMs: num(grab('streamAvgMs')),
+        streamP95Ms: num(grab('streamP95Ms')),
+        streamPeakMs: num(grab('streamPeakMs')),
+        chunksPerSec: num(grab('chunksPerSec')),
+        parseChunkAvgMs: num(grab('parseChunkAvgMs')),
+        parseChunkP95Ms: num(grab('parseChunkP95Ms')),
+        parseChunkPeakMs: num(grab('parseChunkPeakMs')),
+        longestTaskMs: grab('longestTaskMs'),
+        longTasks10s: grab('longTasks10s'),
+        rafP95Ms: num(grab('rafP95Ms')),
+        mutations10s: num(grab('mutations10s')),
+        loaf10s: grab('loaf10s'),
+        loafScriptMaxMs: grab('loafScriptMaxMs'),
+        heapAllocKbPerSec: grab('heapAllocKbPerSec')
+    }
+}
+
+/**
+ * Waits for the page's `scenario` field to flip to `${testId}-done`,
+ * meaning the in-page scenario function returned and the stats line is
+ * fully populated.
+ */
+async function waitForScenarioDone(page, testId, timeoutMs) {
+    await page.waitForFunction(
+        (id) => {
+            const el = document.querySelector('[data-testid="perf-stats"]')
+            return !!el && el.textContent.includes(`scenario=${id}-done`)
+        },
+        testId,
+        { timeout: timeoutMs }
+    )
+}
+
+async function runDocScenario(page, testId, { timeout = 60_000 } = {}) {
+    await page.locator('[data-testid="clear"]').click({ timeout })
+    // Give the page a beat to drop the previous scenario's mounted DOM
+    // before we click the next preset — otherwise the click can wait
+    // behind a long-running unmount task and time out.
+    await sleep(500)
+    await page.locator(`[data-testid="${testId}"]`).click({ timeout })
+    await waitForScenarioDone(page, testId, timeout)
+    // Allow the 250ms rolling-window refresh tick to fire at least once
+    // so observer-derived fields (longestTaskMs, mutations10s, …) are
+    // reflected in the scrape. Per-doc fields are already final.
+    await sleep(400)
+    return parseStats(await readStats(page))
+}
+
+async function runCacheWarm(page) {
+    return runDocScenario(page, 'cache-warm', { timeout: 30_000 })
+}
+
+async function runStreaming(page) {
+    // Streaming replays the corpus at ~30 chunks/sec; ~150 chunks → ~5s
+    // wall clock plus per-chunk render time.
+    return runDocScenario(page, 'stream-30tps', { timeout: 60_000 })
+}
+
+async function runAll(label, page) {
+    console.log(`\n=== ${label} run ===`)
+    const out = {}
+
+    const scenarios = [
+        ['parse1kb', 'parse-1kb', { timeout: 30_000 }],
+        ['parse50kb', 'parse-50kb', { timeout: 60_000 }],
+        ['parse500kb', 'parse-500kb', { timeout: 180_000 }],
+        ['parseHtmlHeavy', 'parse-html-heavy', { timeout: 60_000 }],
+        ['parseTableHeavy', 'parse-table-heavy', { timeout: 60_000 }]
+    ]
+
+    for (const [key, testId, opts] of scenarios) {
+        console.log(`  → ${testId}…`)
+        out[key] = await runDocScenario(page, testId, opts)
+        console.log('   ', JSON.stringify(out[key]))
+    }
+
+    console.log('  → cache-warm…')
+    out.cacheWarm = await runCacheWarm(page)
+    console.log('   ', JSON.stringify(out.cacheWarm))
+
+    console.log('  → stream-30tps…')
+    out.stream30tps = await runStreaming(page)
+    console.log('   ', JSON.stringify(out.stream30tps))
+
+    return out
+}
+
+;(async () => {
+    const browser = await chromium.launch({
+        headless: true,
+        // Needed for the perf-bench fixture's heap-delta metric.
+        // performance.memory.usedJSHeapSize is quantized to ~100KB without
+        // this flag, which rounds most per-rAF deltas to 0.
+        args: ['--enable-precise-memory-info']
+    })
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } })
+    const page = await context.newPage()
+
+    page.on('console', (msg) => {
+        if (msg.type() === 'error') console.log('  [browser error]', msg.text())
+    })
+    page.on('pageerror', (err) => console.log('  [page error]', err.message))
+
+    await page.goto(URL, { waitUntil: 'load' })
+    await page.waitForSelector('[data-testid="perf-stats"]')
+    await sleep(1000)
+    const cold = await runAll('COLD', page)
+
+    await page.reload({ waitUntil: 'load' })
+    await page.waitForSelector('[data-testid="perf-stats"]')
+    await sleep(1000)
+    const warm = await runAll('WARM', page)
+
+    await browser.close()
+
+    const allResults = { cold, warm, capturedAt: new Date().toISOString(), url: URL }
+    console.log('\n=== JSON ===')
+    console.log(JSON.stringify(allResults, null, 2))
+})().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/src/lib/SvelteMarkdown.svelte
+++ b/src/lib/SvelteMarkdown.svelte
@@ -229,7 +229,29 @@
             return
         }
 
-        resetStreamingState(nextSource as string)
+        const nextStr = nextSource as string
+        // Reuse the existing IncrementalParser when the new source extends
+        // the buffered source. Without this, prop-driven streaming (the
+        // common LLM-token-by-token case) drops the parser's prevTokens
+        // cache on every chunk, forcing divergeAt=0 and re-rendering the
+        // full token tree. Imperative writeChunk() already preserves the
+        // parser; this brings prop-source parity.
+        const isAppendOnly =
+            incrementalParser !== undefined &&
+            streamSourceBuffer !== '' &&
+            nextStr !== '' &&
+            nextStr.startsWith(streamSourceBuffer)
+
+        teardownStreamingBuffers()
+
+        if (nextStr === '') {
+            clearStreamingParser()
+            streamTokens.length = 0
+            return
+        }
+
+        streamSourceBuffer = nextStr
+        applyStreamingSource(nextStr, !isAppendOnly)
     }
 
     const canUseImperativeStreaming = (methodName: 'writeChunk' | 'resetStream'): boolean => {

--- a/src/lib/SvelteMarkdown.test.ts
+++ b/src/lib/SvelteMarkdown.test.ts
@@ -251,6 +251,44 @@ describe('imperative streaming API', () => {
         expect(container.textContent).toContain('Tail')
     })
 
+    test('reuses the IncrementalParser across append-only source prop updates', async () => {
+        // When the source prop grows by appending (the typical LLM
+        // token-by-token case), the parser's prevTokens cache must
+        // survive — otherwise divergeAt collapses to 0 and the entire
+        // token tree re-renders on every chunk. Pinned by spying on
+        // lexAndClean: the second parse should only lex the appended
+        // tail thanks to IncrementalParser's tail-window optimization.
+        const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+        const initialSource = '# Heading\n\nParagraph one\n\n'
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: { source: initialSource, streaming: true }
+        })
+        await flushStreamingBatch()
+
+        expect(lexSpy).toHaveBeenCalledTimes(1)
+        expect(lexSpy.mock.calls[0][0]).toBe(initialSource)
+
+        const appendedTail = 'Paragraph two\n\n'
+        const nextSource = initialSource + appendedTail
+        await rerender({ source: nextSource, streaming: true })
+        await flushStreamingBatch()
+
+        expect(lexSpy).toHaveBeenCalledTimes(2)
+        // Tail-window kicks in: the second lex call sees only the tail,
+        // not the full nextSource. If the parser had been reset, the
+        // full nextSource would have been re-lexed.
+        expect(lexSpy.mock.calls[1][0].length).toBeLessThan(nextSource.length)
+        expect(lexSpy.mock.calls[1][0]).toContain('Paragraph two')
+
+        // Correctness: both paragraphs render
+        const paragraphs = container.querySelectorAll('p')
+        expect(paragraphs.length).toBe(2)
+        expect(paragraphs[0].textContent).toBe('Paragraph one')
+        expect(paragraphs[1].textContent).toBe('Paragraph two')
+
+        lexSpy.mockRestore()
+    })
+
     test('writeChunk warns when streaming is false', async () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         const { component, container } = render(SvelteMarkdown, {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -90,6 +90,11 @@
             description: 'Mermaid with Svelte 5 snippets'
         },
         { href: '/test/performance', name: 'Performance', description: 'Large document rendering' },
+        {
+            href: '/test/perf-bench',
+            name: 'Perf Bench',
+            description: 'Parse/render gauges + rolling-10s observers (headless harness target)'
+        },
         { href: '/test/reactivity', name: 'Reactivity', description: 'Reactive source updates' },
         { href: '/test/snippets', name: 'Snippets', description: 'Svelte 5 snippet renderers' },
         {

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -1,0 +1,720 @@
+<script lang="ts">
+    import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
+    import { parseAndCacheTokens } from '$lib/utils/parse-and-cache.js'
+    import { benchmarkAppendStream } from '$lib/utils/stream-benchmark.js'
+    import { hashString, tokenCache } from '$lib/utils/token-cache.js'
+    import { shrinkHtmlTokens } from '$lib/utils/token-cleanup.js'
+    import { Lexer } from 'marked'
+    import { onMount, tick } from 'svelte'
+
+    /**
+     * Performance baseline fixture for svelte-markdown.
+     * Captures per-document parse/render timings and rolling-10s
+     * observer metrics so optimization commits can be attributed to
+     * a specific before/after delta. Modeled on the virtual-chat
+     * perf-bench page; gauges differ to suit a parser/renderer.
+     */
+
+    const ROLLING_WINDOW_MS = 10_000
+    const LONG_TASK_THRESHOLD_MS = 50
+
+    // ---- Corpus generators ----------------------------------------------------
+
+    const generateLarge = (sections: number, blocksPerSection: number): string => {
+        const out: string[] = []
+        for (let i = 0; i < sections; i++) {
+            out.push(`# Section ${i}\n\n## Subsection ${i}.1\n`)
+            for (let j = 0; j < blocksPerSection; j++) {
+                out.push(`### Content Block ${i}.${j}
+
+This is paragraph ${j} of section ${i}. It contains some **bold text** and *italic text*
+and a [link to nowhere](https://example.com/${i}/${j}).
+
+- List item 1
+- List item 2
+- List item 3
+
+> Here's a blockquote for good measure.
+
+\`\`\`javascript
+// Some code
+console.log('Section ${i}, Block ${j}');
+\`\`\`
+`)
+            }
+        }
+        return out.join('\n')
+    }
+
+    const generateSmall = (): string =>
+        `# Quick Example
+
+A short paragraph with **bold**, *italic*, and a [link](https://example.com).
+
+- one
+- two
+- three
+
+\`\`\`ts
+const x: number = 42
+\`\`\`
+`
+
+    const generateHtmlHeavy = (rows: number): string => {
+        const out: string[] = ['# HTML Heavy Corpus\n']
+        for (let i = 0; i < rows; i++) {
+            out.push(
+                `<div class="card-${i}"><header><h3>Card ${i}</h3></header>` +
+                    `<p>Paragraph <strong>${i}</strong> with <em>nested</em> ` +
+                    `<a href="https://example.com/${i}">link</a> and <code>inline ${i}</code>.</p>` +
+                    `<ul><li>row ${i}.a</li><li>row ${i}.b</li><li>row ${i}.c</li></ul>` +
+                    `<footer><small>id=${i}</small><br/></footer></div>\n`
+            )
+        }
+        return out.join('\n')
+    }
+
+    const generateTableHeavy = (tables: number): string => {
+        const out: string[] = ['# Table Heavy Corpus\n']
+        for (let i = 0; i < tables; i++) {
+            out.push(`## Table ${i}\n`)
+            out.push('| Col A | Col B | Col C | Col D |')
+            out.push('|-------|-------|-------|-------|')
+            for (let r = 0; r < 12; r++) {
+                out.push(
+                    `| **a${i}.${r}** | _b${i}.${r}_ | \`c${i}.${r}\` | [d${i}.${r}](https://x/${r}) |`
+                )
+            }
+            out.push('')
+        }
+        return out.join('\n')
+    }
+
+    // 1500-char streaming corpus reused from /test/streaming
+    const STREAM_CORPUS = `# Reactive Systems
+
+Reactive programming is a **declarative paradigm** for _data streams_ and propagation of change.
+
+## Core Principles
+
+1. **Observables** — represent a stream of data over time
+2. **Operators** — transform, filter, and combine streams
+3. **Subscribers** — consume the final output
+
+> "The best way to predict the future is to invent it." — Alan Kay
+
+### Example
+
+\`\`\`javascript
+import { writable } from 'svelte/store'
+const count = writable(0)
+count.subscribe(value => console.log(\`Count: \${value}\`))
+count.update(n => n + 1)
+\`\`\`
+
+## Comparison Table
+
+| Feature | Svelte | React | Vue |
+|---------|--------|-------|-----|
+| Reactivity | Compile-time | Runtime | Runtime |
+| Bundle Size | Small | Medium | Medium |
+| Performance | Excellent | Good | Good |
+
+## Patterns
+
+- Reactive primitives
+  - Signals
+  - Computed
+- State management
+  - Local state
+  - Stores
+
+## Conclusion
+
+For more, see the [Svelte docs](https://svelte.dev/docs).
+
+---
+
+*Thanks for reading.*
+`
+
+    // ---- Per-scenario reactive state -----------------------------------------
+
+    let source = $state('')
+    let previewEl: HTMLDivElement | undefined = $state()
+    let scenario = $state<string>('idle')
+
+    let stat = $state({
+        srcKb: 0,
+        tokenCount: 0,
+        parseColdMs: 0,
+        parseWarmMs: 0,
+        lexMs: 0,
+        cleanupMs: 0,
+        hashMs: 0,
+        firstPaintMs: 0,
+        domNodes: 0,
+        charsPerSec: 0,
+        // cache scenario
+        cacheIters: 0,
+        cacheTotalMs: 0,
+        cacheAvgMs: 0,
+        cacheP95Ms: 0,
+        cachePeakMs: 0,
+        // streaming scenario
+        streamChunks: 0,
+        streamTotalMs: 0,
+        streamAvgMs: 0,
+        streamP95Ms: 0,
+        streamPeakMs: 0,
+        chunksPerSec: 0,
+        // streaming-only pure-parse percentiles (independent of wall-clock pacing)
+        parseChunkAvgMs: 0,
+        parseChunkP95Ms: 0,
+        parseChunkPeakMs: 0
+    })
+
+    // ---- Rolling-10s observer state ------------------------------------------
+
+    let displayLongestTaskMs = $state(0)
+    let displayLongTaskCount = $state(0)
+    let displayRafP95Ms = $state(0)
+    let displayMutationCount = $state(0)
+    let displayLoafCount = $state(0)
+    let displayLoafScriptMaxMs = $state(0)
+    let displayHeapAllocKbPerSec = $state(0)
+    let longTaskSupported = $state(true)
+    let loafSupported = $state(true)
+    let heapSupported = $state(true)
+
+    let longTaskEntries: { time: number; duration: number }[] = []
+    let rafIntervals: { time: number; delta: number }[] = []
+    let mutationEvents: { time: number; count: number }[] = []
+    let loafEntries: { time: number; durationMs: number; scriptMs: number }[] = []
+    let heapDeltas: { time: number; deltaBytes: number }[] = []
+
+    let isStreaming = $state(false)
+    let streamHandle: ReturnType<typeof setTimeout> | null = null
+
+    // ---- Helpers --------------------------------------------------------------
+
+    const percentile = (values: number[], p: number): number => {
+        if (values.length === 0) return 0
+        const sorted = [...values].sort((a, b) => a - b)
+        const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * p) - 1))
+        return sorted[idx]
+    }
+
+    const round = (n: number, places = 2): number => {
+        const m = 10 ** places
+        return Math.round(n * m) / m
+    }
+
+    const resetStat = () => {
+        stat = {
+            srcKb: 0,
+            tokenCount: 0,
+            parseColdMs: 0,
+            parseWarmMs: 0,
+            lexMs: 0,
+            cleanupMs: 0,
+            hashMs: 0,
+            firstPaintMs: 0,
+            domNodes: 0,
+            charsPerSec: 0,
+            cacheIters: 0,
+            cacheTotalMs: 0,
+            cacheAvgMs: 0,
+            cacheP95Ms: 0,
+            cachePeakMs: 0,
+            streamChunks: 0,
+            streamTotalMs: 0,
+            streamAvgMs: 0,
+            streamP95Ms: 0,
+            streamPeakMs: 0,
+            chunksPerSec: 0,
+            parseChunkAvgMs: 0,
+            parseChunkP95Ms: 0,
+            parseChunkPeakMs: 0
+        }
+    }
+
+    /**
+     * Resolves on the next MutationObserver fire on the preview element,
+     * returning the timestamp of that fire. Used to measure end-to-end
+     * source-set → DOM-commit latency for `firstPaintMs`.
+     */
+    const waitForPaint = (): Promise<number> => {
+        return new Promise((resolve) => {
+            if (!previewEl) {
+                resolve(performance.now())
+                return
+            }
+            const mo = new MutationObserver(() => {
+                mo.disconnect()
+                resolve(performance.now())
+            })
+            mo.observe(previewEl, { childList: true, subtree: true, characterData: true })
+        })
+    }
+
+    /**
+     * Runs the full per-document timing suite for a given corpus.
+     * Updates `stat` with parse/lex/cleanup/hash + first-paint metrics
+     * and assigns `source` so the live preview re-renders.
+     */
+    const runDocScenario = async (label: string, corpus: string) => {
+        scenario = label
+        resetStat()
+
+        // Direct timings (synchronous, no render in loop)
+        tokenCache.clearAllTokens()
+        const opts = { gfm: true, breaks: false, headerIds: true, headerPrefix: '' }
+
+        const tCold0 = performance.now()
+        const cold = parseAndCacheTokens(corpus, opts, false)
+        const parseColdMs = performance.now() - tCold0
+
+        const tWarm0 = performance.now()
+        parseAndCacheTokens(corpus, opts, false)
+        const parseWarmMs = performance.now() - tWarm0
+
+        // Isolated lex + cleanup (fresh cache, fresh tokens)
+        tokenCache.clearAllTokens()
+        const tLex0 = performance.now()
+        const rawTokens = new Lexer(opts).lex(corpus)
+        const lexMs = performance.now() - tLex0
+        const tClean0 = performance.now()
+        shrinkHtmlTokens(rawTokens as never)
+        const cleanupMs = performance.now() - tClean0
+
+        const tHash0 = performance.now()
+        hashString(corpus)
+        const hashMs = performance.now() - tHash0
+
+        // Render path (clear cache so the component re-parses cold)
+        tokenCache.clearAllTokens()
+        source = ''
+        await tick()
+        const paintPromise = waitForPaint()
+        const tPaint0 = performance.now()
+        source = corpus
+        const paintAt = await paintPromise
+        const firstPaintMs = paintAt - tPaint0
+
+        await tick()
+        const domNodes = previewEl ? previewEl.querySelectorAll('*').length : 0
+
+        const srcKb = round(corpus.length / 1024, 1)
+        const charsPerSec = parseColdMs > 0 ? Math.round((corpus.length / parseColdMs) * 1000) : 0
+
+        stat = {
+            ...stat,
+            srcKb,
+            tokenCount: cold.length,
+            parseColdMs: round(parseColdMs),
+            parseWarmMs: round(parseWarmMs, 3),
+            lexMs: round(lexMs),
+            cleanupMs: round(cleanupMs),
+            hashMs: round(hashMs, 3),
+            firstPaintMs: round(firstPaintMs),
+            domNodes,
+            charsPerSec
+        }
+
+        scenario = `${label}-done`
+    }
+
+    /**
+     * Cache-hit benchmark: parses the same source N times in a tight loop
+     * after one cold parse. Subsequent calls should be sub-millisecond
+     * cache hits; this scenario surfaces overhead in `getCacheKey` /
+     * `hashString` / WeakMap lookup.
+     */
+    const runCacheWarm = (iterations = 100) => {
+        scenario = 'cache-warm'
+        resetStat()
+        const corpus = generateLarge(50, 5) // ~25KB, modest
+        const opts = { gfm: true, breaks: false, headerIds: true, headerPrefix: '' }
+
+        // Prime the cache with one cold parse, not counted
+        tokenCache.clearAllTokens()
+        parseAndCacheTokens(corpus, opts, false)
+
+        const durations: number[] = []
+        for (let i = 0; i < iterations; i++) {
+            const t0 = performance.now()
+            parseAndCacheTokens(corpus, opts, false)
+            durations.push(performance.now() - t0)
+        }
+
+        const total = durations.reduce((s, d) => s + d, 0)
+        stat = {
+            ...stat,
+            srcKb: round(corpus.length / 1024, 1),
+            cacheIters: iterations,
+            cacheTotalMs: round(total),
+            cacheAvgMs: round(total / iterations, 3),
+            cacheP95Ms: round(percentile(durations, 0.95), 3),
+            cachePeakMs: round(Math.max(...durations), 3)
+        }
+        source = corpus
+        scenario = 'cache-warm-done'
+    }
+
+    /**
+     * Real-time streaming scenario. Word-chunks the corpus, appends one
+     * chunk per tick at ~30 chunks/sec, and times each parse+render
+     * cycle. The live SvelteMarkdown component is mounted in streaming
+     * mode so the IncrementalParser is exercised. Rolling observers
+     * pick up longtasks/rAF/mutations during the run.
+     */
+    const runStreaming = async (chunksPerSecondTarget = 30) => {
+        if (isStreaming) return
+        scenario = 'stream-30tps'
+        resetStat()
+        source = ''
+        tokenCache.clearAllTokens()
+        await tick()
+
+        const chunks: string[] = []
+        const re = /\S+\s*/g
+        let match
+        while ((match = re.exec(STREAM_CORPUS)) !== null) chunks.push(match[0])
+
+        // Up-front pure-parse benchmark for percentiles independent of
+        // wall-clock pacing. Doesn't touch the live component.
+        const opts = { gfm: true, breaks: false, headerIds: true, headerPrefix: '' }
+        const bench = benchmarkAppendStream(chunks, opts)
+
+        // Real-time replay against the mounted component
+        const baseDelay = 1000 / chunksPerSecondTarget
+        const renderDurations: number[] = []
+        let i = 0
+        isStreaming = true
+        const startWall = performance.now()
+        await new Promise<void>((resolve) => {
+            const step = async () => {
+                if (i >= chunks.length) {
+                    resolve()
+                    return
+                }
+                const t0 = performance.now()
+                source += chunks[i]
+                i++
+                await tick()
+                renderDurations.push(performance.now() - t0)
+                streamHandle = setTimeout(step, baseDelay)
+            }
+            void step()
+        })
+        const wallMs = performance.now() - startWall
+        isStreaming = false
+        if (streamHandle !== null) {
+            clearTimeout(streamHandle)
+            streamHandle = null
+        }
+
+        const renderTotal = renderDurations.reduce((s, d) => s + d, 0)
+        stat = {
+            ...stat,
+            srcKb: round(STREAM_CORPUS.length / 1024, 1),
+            streamChunks: chunks.length,
+            streamTotalMs: round(renderTotal),
+            streamAvgMs: round(renderTotal / chunks.length, 3),
+            streamP95Ms: round(percentile(renderDurations, 0.95), 3),
+            streamPeakMs: round(Math.max(...renderDurations), 3),
+            chunksPerSec: round((chunks.length / wallMs) * 1000, 1),
+            parseChunkAvgMs: round(bench.totalParseMs / bench.chunkCount, 3),
+            parseChunkP95Ms: round(bench.p95ParseMs, 3),
+            parseChunkPeakMs: round(bench.peakParseMs, 3)
+        }
+        scenario = 'stream-30tps-done'
+    }
+
+    const clear = () => {
+        if (streamHandle !== null) {
+            clearTimeout(streamHandle)
+            streamHandle = null
+        }
+        isStreaming = false
+        source = ''
+        tokenCache.clearAllTokens()
+        resetStat()
+        longTaskEntries = []
+        rafIntervals = []
+        mutationEvents = []
+        loafEntries = []
+        heapDeltas = []
+        displayLongestTaskMs = 0
+        displayLongTaskCount = 0
+        displayRafP95Ms = 0
+        displayMutationCount = 0
+        displayLoafCount = 0
+        displayLoafScriptMaxMs = 0
+        displayHeapAllocKbPerSec = 0
+        scenario = 'idle'
+    }
+
+    // ---- Observer wiring (verbatim from virtual-chat, adapted target) --------
+
+    onMount(() => {
+        const cleanups: Array<() => void> = []
+
+        try {
+            const po = new PerformanceObserver((list) => {
+                const now = performance.now()
+                for (const entry of list.getEntries()) {
+                    longTaskEntries.push({ time: now, duration: entry.duration })
+                }
+            })
+            po.observe({ entryTypes: ['longtask'] })
+            cleanups.push(() => po.disconnect())
+        } catch {
+            longTaskSupported = false
+        }
+
+        try {
+            type ScriptTiming = { duration: number }
+            type LongAnimationFrameTiming = PerformanceEntry & { scripts?: ScriptTiming[] }
+            const po = new PerformanceObserver((list) => {
+                const now = performance.now()
+                for (const raw of list.getEntries()) {
+                    const entry = raw as LongAnimationFrameTiming
+                    let scriptMs = 0
+                    if (entry.scripts) {
+                        for (const s of entry.scripts) scriptMs += s.duration
+                    }
+                    loafEntries.push({ time: now, durationMs: entry.duration, scriptMs })
+                }
+            })
+            po.observe({ type: 'long-animation-frame', buffered: true })
+            cleanups.push(() => po.disconnect())
+        } catch {
+            loafSupported = false
+        }
+
+        const wrapper = document.querySelector('[data-testid="perf-preview"]')
+        if (wrapper) {
+            const mo = new MutationObserver((records) => {
+                mutationEvents.push({ time: performance.now(), count: records.length })
+            })
+            mo.observe(wrapper, { childList: true, subtree: true, characterData: true })
+            cleanups.push(() => mo.disconnect())
+        }
+
+        type MemoryInfo = { usedJSHeapSize: number }
+        type PerformanceWithMemory = Performance & { memory?: MemoryInfo }
+        const perfMem = (performance as PerformanceWithMemory).memory
+        if (!perfMem) heapSupported = false
+
+        let rafId = 0
+        let lastRaf = performance.now()
+        let firstSampleSeen = false
+        let lastHeapBytes = perfMem?.usedJSHeapSize ?? 0
+        const tickRaf = (now: number) => {
+            const delta = now - lastRaf
+            lastRaf = now
+            if (firstSampleSeen) {
+                rafIntervals.push({ time: now, delta })
+                if (perfMem) {
+                    const current = perfMem.usedJSHeapSize
+                    const heapDelta = current - lastHeapBytes
+                    if (heapDelta > 0) heapDeltas.push({ time: now, deltaBytes: heapDelta })
+                    lastHeapBytes = current
+                }
+            } else {
+                firstSampleSeen = true
+            }
+            rafId = requestAnimationFrame(tickRaf)
+        }
+        rafId = requestAnimationFrame(tickRaf)
+        cleanups.push(() => cancelAnimationFrame(rafId))
+
+        const refreshHandle = setInterval(() => {
+            const now = performance.now()
+            const cutoff = now - ROLLING_WINDOW_MS
+
+            longTaskEntries = longTaskEntries.filter((e) => e.time >= cutoff)
+            rafIntervals = rafIntervals.filter((e) => e.time >= cutoff)
+            mutationEvents = mutationEvents.filter((e) => e.time >= cutoff)
+            loafEntries = loafEntries.filter((e) => e.time >= cutoff)
+            heapDeltas = heapDeltas.filter((e) => e.time >= cutoff)
+
+            let longest = 0
+            let longCount = 0
+            for (const e of longTaskEntries) {
+                if (e.duration > longest) longest = e.duration
+                if (e.duration > LONG_TASK_THRESHOLD_MS) longCount++
+            }
+            displayLongestTaskMs = Math.round(longest)
+            displayLongTaskCount = longCount
+
+            if (rafIntervals.length > 0) {
+                const sorted = rafIntervals.map((e) => e.delta).sort((a, b) => a - b)
+                const idx = Math.floor(0.95 * sorted.length)
+                displayRafP95Ms = Math.round(sorted[Math.min(idx, sorted.length - 1)] * 10) / 10
+            } else {
+                displayRafP95Ms = 0
+            }
+
+            let mutCount = 0
+            for (const e of mutationEvents) mutCount += e.count
+            displayMutationCount = mutCount
+
+            let loafScriptMax = 0
+            for (const e of loafEntries) {
+                if (e.scriptMs > loafScriptMax) loafScriptMax = e.scriptMs
+            }
+            displayLoafCount = loafEntries.length
+            displayLoafScriptMaxMs = Math.round(loafScriptMax)
+
+            if (heapSupported) {
+                let totalBytes = 0
+                for (const e of heapDeltas) totalBytes += e.deltaBytes
+                const seconds = ROLLING_WINDOW_MS / 1000
+                displayHeapAllocKbPerSec = Math.round(totalBytes / 1024 / seconds)
+            } else {
+                displayHeapAllocKbPerSec = 0
+            }
+        }, 250)
+        cleanups.push(() => clearInterval(refreshHandle))
+
+        return () => {
+            for (const fn of cleanups) fn()
+        }
+    })
+</script>
+
+<svelte:head>
+    <title>Test: Perf bench</title>
+</svelte:head>
+
+<div class="page">
+    <h1>Test: Perf bench</h1>
+    <p class="lede">
+        Captures per-document parse/render timings and rolling-10s observer metrics. Each preset
+        clears the token cache, runs the scenario, and updates the stats line. Use as a baseline
+        before/after parser optimization commits.
+    </p>
+
+    <div class="presets">
+        <button
+            data-testid="parse-1kb"
+            onclick={() => runDocScenario('parse-1kb', generateSmall())}
+        >
+            Parse 1KB
+        </button>
+        <button
+            data-testid="parse-50kb"
+            onclick={() => runDocScenario('parse-50kb', generateLarge(16, 10))}
+        >
+            Parse ~50KB
+        </button>
+        <button
+            data-testid="parse-500kb"
+            onclick={() => runDocScenario('parse-500kb', generateLarge(165, 10))}
+        >
+            Parse ~500KB
+        </button>
+        <button
+            data-testid="parse-html-heavy"
+            onclick={() => runDocScenario('parse-html-heavy', generateHtmlHeavy(500))}
+        >
+            Parse HTML-heavy
+        </button>
+        <button
+            data-testid="parse-table-heavy"
+            onclick={() => runDocScenario('parse-table-heavy', generateTableHeavy(40))}
+        >
+            Parse table-heavy
+        </button>
+        <button data-testid="cache-warm" onclick={() => runCacheWarm(100)}>Cache warm ×100</button>
+        <button data-testid="stream-30tps" onclick={() => runStreaming(30)} disabled={isStreaming}>
+            {isStreaming ? 'Streaming…' : 'Stream 30/s'}
+        </button>
+        <button data-testid="clear" onclick={clear}>Clear</button>
+    </div>
+
+    <div class="stats" data-testid="perf-stats">
+        scenario={scenario} srcKb={stat.srcKb} tokenCount={stat.tokenCount} parseColdMs={stat.parseColdMs}
+        parseWarmMs={stat.parseWarmMs} lexMs={stat.lexMs} cleanupMs={stat.cleanupMs} hashMs={stat.hashMs}
+        firstPaintMs={stat.firstPaintMs} domNodes={stat.domNodes} charsPerSec={stat.charsPerSec} · cacheIters={stat.cacheIters}
+        cacheTotalMs={stat.cacheTotalMs} cacheAvgMs={stat.cacheAvgMs}
+        cacheP95Ms={stat.cacheP95Ms} cachePeakMs={stat.cachePeakMs} · streamChunks={stat.streamChunks}
+        streamTotalMs={stat.streamTotalMs} streamAvgMs={stat.streamAvgMs} streamP95Ms={stat.streamP95Ms}
+        streamPeakMs={stat.streamPeakMs} chunksPerSec={stat.chunksPerSec} parseChunkAvgMs={stat.parseChunkAvgMs}
+        parseChunkP95Ms={stat.parseChunkP95Ms} parseChunkPeakMs={stat.parseChunkPeakMs} · longestTaskMs={longTaskSupported
+            ? displayLongestTaskMs
+            : 'n/a'}
+        longTasks10s={longTaskSupported ? displayLongTaskCount : 'n/a'} rafP95Ms={displayRafP95Ms}
+        mutations10s={displayMutationCount} loaf10s={loafSupported ? displayLoafCount : 'n/a'}
+        loafScriptMaxMs={loafSupported ? displayLoafScriptMaxMs : 'n/a'} heapAllocKbPerSec={heapSupported
+            ? displayHeapAllocKbPerSec
+            : 'n/a'}
+    </div>
+
+    <div class="preview" data-testid="perf-preview" bind:this={previewEl}>
+        <SvelteMarkdown {source} streaming={isStreaming} />
+    </div>
+</div>
+
+<style>
+    .page {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1rem;
+        height: 100vh;
+        box-sizing: border-box;
+    }
+    h1 {
+        margin: 0;
+        font-size: 1.1rem;
+    }
+    .lede {
+        margin: 0;
+        font-size: 0.85rem;
+        color: #555;
+    }
+    .presets {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+    .presets button {
+        padding: 0.4rem 0.75rem;
+        font-size: 0.85rem;
+        border: 1px solid #cbd5e0;
+        border-radius: 0.25rem;
+        background: #edf2f7;
+        cursor: pointer;
+    }
+    .presets button:hover:not(:disabled) {
+        background: #e2e8f0;
+    }
+    .presets button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+    .stats {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.7rem;
+        color: #2d3748;
+        background: #f7fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 0.25rem;
+        padding: 0.5rem 0.75rem;
+        line-height: 1.5;
+        word-break: break-word;
+    }
+    .preview {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        border: 1px solid #e2e8f0;
+        border-radius: 0.25rem;
+        padding: 0.75rem;
+        background: white;
+    }
+</style>


### PR DESCRIPTION
## Summary

- New perf-bench harness (`/test/perf-bench` route + `pnpm perf:bench` Playwright runner) that captures per-document parse/render gauges plus rolling-10s observer metrics, modeled on the sibling svelte-virtual-chat pattern. Establishes baselines so future optimization commits can be attributed to a specific before/after delta.
- Streaming fix: `syncStreamingSourceFromProp` now detects append-only prop changes and reuses the existing `IncrementalParser` instead of forcing a fresh parser on every chunk. Imperative `writeChunk()` already preserved the parser; this brings prop-source streaming to parity. Pinned by a unit test.

## Why

The harness made an existing bug visible: prop-driven streaming (`source += chunk`, the typical LLM token-by-token case) was paying ~60x the parse cost in render per chunk, because every chunk reset the `IncrementalParser`, dropped its `prevTokens` cache, and collapsed `divergeAt` to 0 — re-rendering the entire token tree. Imperative `writeChunk()` did not have this issue.

## Numbers

WARM headless run on 152 chunks @ 30/s (perf-bench `stream-30tps`):

| | before | after |
| --- | --- | --- |
| `streamP95Ms` | 11.9 | **2.7** |
| `streamAvgMs` | 5.4 | **1.2** |
| `streamPeakMs` | 12.8 | 3.5 |

~4x lower per-chunk render p95 on prop-source streaming.

## Other gauges from the harness baseline (WARM)

| Scenario | parseColdMs | parseWarmMs | lexMs | cleanupMs | firstPaintMs | tokens | domNodes |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1KB | 12 | 0.1 | 0.3 | 0.1 | 9 | 7 | 11 |
| 50KB | 11 | 0.4 | 5 | 0.6 | 539 | 1663 | 2112 |
| 500KB | 73 | 4 | 50 | 10 | 5098 | 17159 | 21780 |
| HTML-heavy | 26 | 1 | **0.8** | **15.6** | 1975 | 1001 | 7501 |
| table-heavy | 8 | 0.3 | 3.7 | 0.8 | 533 | 161 | 4681 |
| cache x100 | — | — | — | — | — | — | avg 0.61 ms, p95 0.7 ms |

These surface two follow-up targets:
- HTML cleanup (`shrinkHtmlTokens`) is 18x the lex on HTML-heavy input — tracked in #284.
- Render cost dominates parse by 30-70x across every scenario — separate, larger track (likely virtualization).

## What's in scope here

- `src/routes/test/perf-bench/+page.svelte` — preset-driven scenarios with `[data-testid="perf-stats"]` line; per-doc gauges + rolling-10s observers (longtask, LoAF, rAF, mutations, heap)
- `scripts/perf-bench.mjs` — Playwright headless runner; cold + warm cycles; emits structured JSON
- `package.json` — `perf:bench` script
- Root test glossary — link to the new route
- `src/lib/SvelteMarkdown.svelte` — `syncStreamingSourceFromProp` reuses the parser on append-only prop updates
- `src/lib/SvelteMarkdown.test.ts` — new test pins the behavior by spying on `lexAndClean` and asserting tail-window lex on the second parse

No library API changes. No new exports. All timing hooks call already-public utilities.

## Test plan

- [x] All 780 vitest tests pass (`pnpm test:only`)
- [x] `pnpm check` clean (0 errors)
- [x] `pnpm lint` unchanged from main (same 4 pre-existing prettier warnings on unrelated files)
- [x] New unit test verified to FAIL without the streaming fix and PASS with it
- [x] `pnpm perf:bench` cold + warm full cycle runs end-to-end with plausible numbers
- [ ] Reviewer: optional — run `pnpm dev` + open `/test/perf-bench`, click each preset, confirm stats line populates

## Workflow

```bash
pnpm dev               # terminal 1
pnpm perf:bench        # terminal 2 (defaults to http://localhost:8233/test/perf-bench)
PERF_BENCH_URL=http://localhost:9000 pnpm perf:bench   # custom URL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)