### PR TITLE
perf(render): inline leaf-token dispatch + bench measurement gaps

### DIFF
--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -44,8 +44,20 @@ function parseStats(s) {
         cleanupMs: num(grab('cleanupMs')),
         hashMs: num(grab('hashMs')),
         firstPaintMs: num(grab('firstPaintMs')),
+        // Render-attribution column: firstPaintMs minus parseColdMs.
+        // Surfaces parse-side wins that pure firstPaint would hide
+        // when render dominates.
+        renderOnlyMs: num(grab('renderOnlyMs')),
         domNodes: num(grab('domNodes')),
         charsPerSec: num(grab('charsPerSec')),
+        // Dev-mode Parser-instance counter — the non-wall-clock signal
+        // that cracked open the original render investigation.
+        parserInstances: num(grab('parserInstances')),
+        // Per-scenario observer snapshots (filtered to the scenario's
+        // [start, end] window — not the rolling-10s aggregate below).
+        scenarioLongestTaskMs: num(grab('scenarioLongestTaskMs')),
+        scenarioMutations: num(grab('scenarioMutations')),
+        scenarioLoafScriptMaxMs: num(grab('scenarioLoafScriptMaxMs')),
         cacheIters: num(grab('cacheIters')),
         cacheTotalMs: num(grab('cacheTotalMs')),
         cacheAvgMs: num(grab('cacheAvgMs')),
@@ -60,6 +72,10 @@ function parseStats(s) {
         parseChunkAvgMs: num(grab('parseChunkAvgMs')),
         parseChunkP95Ms: num(grab('parseChunkP95Ms')),
         parseChunkPeakMs: num(grab('parseChunkPeakMs')),
+        // Bursty-stream-only: inter-chunk gap distribution.
+        streamGapAvgMs: num(grab('streamGapAvgMs')),
+        streamGapP95Ms: num(grab('streamGapP95Ms')),
+        streamGapPeakMs: num(grab('streamGapPeakMs')),
         longestTaskMs: grab('longestTaskMs'),
         longTasks10s: grab('longTasks10s'),
         rafP95Ms: num(grab('rafP95Ms')),
@@ -111,6 +127,13 @@ async function runStreaming(page) {
     return runDocScenario(page, 'stream-30tps', { timeout: 60_000 })
 }
 
+async function runStreamingBursty(page) {
+    // Bursty variant: jittered chunk sizes (1–10 typical, occasional
+    // 30–50 burst) with delays in [5,30]/[30,80]/[80,200]ms buckets.
+    // Wall-clock varies more than steady 30tps, so widen the timeout.
+    return runDocScenario(page, 'stream-bursty', { timeout: 120_000 })
+}
+
 async function runAll(label, page) {
     console.log(`\n=== ${label} run ===`)
     const out = {}
@@ -120,7 +143,14 @@ async function runAll(label, page) {
         ['parse50kb', 'parse-50kb', { timeout: 60_000 }],
         ['parse500kb', 'parse-500kb', { timeout: 180_000 }],
         ['parseHtmlHeavy', 'parse-html-heavy', { timeout: 60_000 }],
-        ['parseTableHeavy', 'parse-table-heavy', { timeout: 60_000 }]
+        ['parseTableHeavy', 'parse-table-heavy', { timeout: 60_000 }],
+        // Mixed-shape corpus that defeats optimizations only winning on
+        // the highly-repetitive `generateLarge` shapes.
+        ['parseRealistic', 'parse-realistic', { timeout: 90_000 }],
+        // Same 50KB body as `parse50kb` but mounted with custom
+        // markdown + html snippet overrides — drives the slow dispatch
+        // path so override-path regressions can't slip through.
+        ['parse50kbOverridden', 'parse-50kb-overridden', { timeout: 90_000 }]
     ]
 
     for (const [key, testId, opts] of scenarios) {
@@ -136,6 +166,10 @@ async function runAll(label, page) {
     console.log('  → stream-30tps…')
     out.stream30tps = await runStreaming(page)
     console.log('   ', JSON.stringify(out.stream30tps))
+
+    console.log('  → stream-bursty…')
+    out.streamBursty = await runStreamingBursty(page)
+    console.log('   ', JSON.stringify(out.streamBursty))
 
     return out
 }

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -94,6 +94,27 @@
         [key: string]: unknown
     } = $props()
 
+    /**
+     * Dev-only Parser-instance counter. Exposed via `window.__svm_parserCount`
+     * and `window.__svm_parserByType` so the perf-bench harness can attribute
+     * render cost to component allocations without a Chrome profile. The
+     * `import.meta.env.DEV` guard is resolved at build time by Vite, so
+     * production bundles drop this block entirely (zero overhead). Reset by
+     * the perf-bench page at scenario start.
+     *
+     * `type` is read once at script init — Parser instances are remounted
+     * (not re-keyed) when their type changes, so the initial value is the
+     * effective lifetime value for counting purposes.
+     */
+    if (import.meta.env.DEV && typeof window !== 'undefined') {
+        // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        const w = window as any
+        const initialType: string = type ?? '<root>'
+        w.__svm_parserCount = (w.__svm_parserCount ?? 0) + 1
+        const byType = (w.__svm_parserByType = w.__svm_parserByType ?? {})
+        byType[initialType] = (byType[initialType] ?? 0) + 1
+    }
+
     // Sanitize rest props before they reach any renderer or snippet.
     // This is the single enforcement point — custom renderers cannot bypass it.
     const sanitizedRest = $derived.by(() => {

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -1,3 +1,28 @@
+<script module lang="ts">
+    /**
+     * Self-closing HTML tags that must not receive children — `<br>content</br>`
+     * is invalid and `<svelte:element>` would emit it anyway. Module-scoped so
+     * the Set is allocated once per module load, not once per Parser instance.
+     */
+    const SELF_CLOSING_HTML = new Set([
+        'br',
+        'hr',
+        'img',
+        'input',
+        'link',
+        'meta',
+        'area',
+        'base',
+        'col',
+        'embed',
+        'keygen',
+        'param',
+        'source',
+        'track',
+        'wbr'
+    ])
+</script>
+
 <script lang="ts">
     /**
      * @component Parser
@@ -132,26 +157,6 @@
         // has been added by the user.
         !(renderers as Record<string, unknown>).space && !snippetOverrides.space
     )
-
-    // Self-closing HTML tags must not receive children — `<br>content</br>`
-    // is invalid and `<svelte:element>` would emit it anyway.
-    const SELF_CLOSING_HTML = new Set([
-        'br',
-        'hr',
-        'img',
-        'input',
-        'link',
-        'meta',
-        'area',
-        'base',
-        'col',
-        'embed',
-        'keygen',
-        'param',
-        'source',
-        'track',
-        'wbr'
-    ])
 
     // Sanitize rest props before they reach any renderer or snippet.
     // This is the single enforcement point — custom renderers cannot bypass it.

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -48,12 +48,13 @@
 
     import Parser from '$lib/Parser.svelte'
     import Html from '$lib/renderers/html/index.js'
-    import type {
-        Renderers,
-        Token,
-        TokensList,
-        Tokens,
-        RendererComponent
+    import {
+        defaultRenderers,
+        type Renderers,
+        type Token,
+        type TokensList,
+        type Tokens,
+        type RendererComponent
     } from '$lib/utils/markdown-parser.js'
     import {
         defaultSanitizeAttributes,
@@ -115,6 +116,43 @@
         byType[initialType] = (byType[initialType] ?? 0) + 1
     }
 
+    // Inline-render eligibility flags (issue #286): leaf text, space, and
+    // default-renderer html tokens are by far the most common token
+    // shapes. Their default render path is a no-op wrapper chain (Parser
+    // → Text/RawText/HtmlComponent → `{text}` or `<tag>...</tag>`). For
+    // space tokens it's even worse: Parser is instantiated, hits no
+    // branch, and renders nothing. Detect once whether the user has kept
+    // the default renderers / has no snippet override so we can render
+    // these inline at the call site without spawning a Parser.
+    const inlineTextOk = $derived(
+        renderers.text === defaultRenderers.text && !snippetOverrides.text
+    )
+    const inlineSpaceOk = $derived(
+        // No default renderer for `space`; only safe to skip when nothing
+        // has been added by the user.
+        !(renderers as Record<string, unknown>).space && !snippetOverrides.space
+    )
+
+    // Self-closing HTML tags must not receive children — `<br>content</br>`
+    // is invalid and `<svelte:element>` would emit it anyway.
+    const SELF_CLOSING_HTML = new Set([
+        'br',
+        'hr',
+        'img',
+        'input',
+        'link',
+        'meta',
+        'area',
+        'base',
+        'col',
+        'embed',
+        'keygen',
+        'param',
+        'source',
+        'track',
+        'wbr'
+    ])
+
     // Sanitize rest props before they reach any renderer or snippet.
     // This is the single enforcement point — custom renderers cannot bypass it.
     const sanitizedRest = $derived.by(() => {
@@ -138,19 +176,56 @@
     })
 </script>
 
+{#snippet dispatch(token: Token, restProps: Record<string, unknown>)}
+    {#if token.type === 'space' && inlineSpaceOk}
+        <!-- inlined: space tokens render nothing -->
+    {:else if token.type === 'text' && inlineTextOk && !(token as Tokens.Text).tokens}
+        {(token as Tokens.Text).text ?? token.raw}
+    {:else if token.type === 'html' && renderers.html && (token as any).tag && renderers.html[(token as any).tag] === Html[(token as any).tag] && !htmlSnippetOverrides[(token as any).tag]}
+        // trunk-ignore(eslint/@typescript-eslint/no-explicit-any) //
+        trunk-ignore(eslint/@typescript-eslint/no-explicit-any) //
+        trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        {@const htmlTok = token as Token & {
+            tag: string
+            attributes?: Record<string, string>
+            tokens?: Token[]
+        }}
+        {@const sanitizedAttrs = htmlTok.attributes
+            ? sanitizeAttributes(
+                  htmlTok.attributes,
+                  { type: 'html', tag: htmlTok.tag },
+                  sanitizeUrl
+              )
+            : undefined}
+        {#if SELF_CLOSING_HTML.has(htmlTok.tag)}
+            <svelte:element this={htmlTok.tag} {...sanitizedAttrs} />
+        {:else}
+            <svelte:element this={htmlTok.tag} {...sanitizedAttrs}>
+                {#if htmlTok.tokens && htmlTok.tokens.length}
+                    {#each htmlTok.tokens as childToken, i (i)}
+                        {@render dispatch(childToken, restProps)}
+                    {/each}
+                {/if}
+            </svelte:element>
+        {/if}
+    {:else}
+        <Parser
+            {...restProps}
+            {...token}
+            {renderers}
+            {snippetOverrides}
+            {htmlSnippetOverrides}
+            {sanitizeUrl}
+            {sanitizeAttributes}
+        />
+    {/if}
+{/snippet}
+
 {#if !type}
     {#if tokens}
+        {@const { text: _text, raw: _raw, tokens: _tokens, ...parserRest } = rest}
         {#each tokens as token, index (index)}
-            {@const { text: _text, raw: _raw, tokens: _tokens, ...parserRest } = rest}
-            <Parser
-                {...parserRest}
-                {...token}
-                {renderers}
-                {snippetOverrides}
-                {htmlSnippetOverrides}
-                {sanitizeUrl}
-                {sanitizeAttributes}
-            />
+            {@render dispatch(token, parserRest)}
         {/each}
     {/if}
 {:else if type in renderers || type in snippetOverrides}
@@ -169,14 +244,9 @@
                             {#each header ?? [] as headerItem, i (i)}
                                 {@const { align: _align, ...cellRest } = sanitizedRest}
                                 {#snippet headerCellContent()}
-                                    <Parser
-                                        tokens={headerItem.tokens}
-                                        {renderers}
-                                        {snippetOverrides}
-                                        {htmlSnippetOverrides}
-                                        {sanitizeUrl}
-                                        {sanitizeAttributes}
-                                    />
+                                    {#each headerItem.tokens ?? [] as headerCellToken, k (k)}
+                                        {@render dispatch(headerCellToken, {})}
+                                    {/each}
                                 {/snippet}
                                 {#if cellSnippet}
                                     {@render cellSnippet({
@@ -223,15 +293,7 @@
                                     {@const { align: _align, ...cellRest } = sanitizedRest}
                                     {#snippet bodyCellContent()}
                                         {#each cells.tokens ?? [] as cellToken, index (index)}
-                                            <Parser
-                                                {...cellRest}
-                                                {...cellToken}
-                                                {renderers}
-                                                {snippetOverrides}
-                                                {htmlSnippetOverrides}
-                                                {sanitizeUrl}
-                                                {sanitizeAttributes}
-                                            />
+                                            {@render dispatch(cellToken, cellRest)}
                                         {/each}
                                     {/snippet}
                                     {#if cellSnippet}
@@ -296,15 +358,9 @@
                     {@const orderedItemSnippet =
                         snippetOverrides['orderedlistitem'] || snippetOverrides['listitem']}
                     {#snippet orderedItemContent()}
-                        <Parser
-                            {...parserRest}
-                            tokens={item.tokens}
-                            {renderers}
-                            {snippetOverrides}
-                            {htmlSnippetOverrides}
-                            {sanitizeUrl}
-                            {sanitizeAttributes}
-                        />
+                        {#each item.tokens ?? [] as itemToken, k (k)}
+                            {@render dispatch(itemToken, parserRest)}
+                        {/each}
                     {/snippet}
                     {#if orderedItemSnippet}
                         {@render orderedItemSnippet({ ...item, children: orderedItemContent })}
@@ -332,15 +388,9 @@
                     {@const unorderedItemSnippet =
                         snippetOverrides['unorderedlistitem'] || snippetOverrides['listitem']}
                     {#snippet unorderedItemContent()}
-                        <Parser
-                            {...parserRest}
-                            tokens={item.tokens}
-                            {renderers}
-                            {snippetOverrides}
-                            {htmlSnippetOverrides}
-                            {sanitizeUrl}
-                            {sanitizeAttributes}
-                        />
+                        {#each item.tokens ?? [] as itemToken, k (k)}
+                            {@render dispatch(itemToken, parserRest)}
+                        {/each}
                     {/snippet}
                     {#if unorderedItemSnippet}
                         {@render unorderedItemSnippet({ ...item, children: unorderedItemContent })}
@@ -363,20 +413,15 @@
         {@const { tag, ...localRest } = sanitizedRest}
         {@const htmlTag = sanitizedRest.tag as keyof typeof Html}
         {@const htmlSnippet = htmlSnippetOverrides[htmlTag as string]}
+        {@const localRestForChildren = Object.fromEntries(
+            Object.entries(localRest).filter(([key]) => key !== 'attributes')
+        )}
         {#if htmlSnippet}
             {#snippet htmlSnippetChildren()}
                 {#if tokens && (tokens as Token[]).length}
-                    <Parser
-                        tokens={tokens as Token[]}
-                        {renderers}
-                        {snippetOverrides}
-                        {htmlSnippetOverrides}
-                        {sanitizeUrl}
-                        {sanitizeAttributes}
-                        {...Object.fromEntries(
-                            Object.entries(localRest).filter(([key]) => key !== 'attributes')
-                        )}
-                    />
+                    {#each tokens as childToken, index (index)}
+                        {@render dispatch(childToken, localRestForChildren)}
+                    {/each}
                 {:else}
                     <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
                 {/if}
@@ -390,34 +435,22 @@
             {#if HtmlComponent}
                 <HtmlComponent {...sanitizedRest}>
                     {#if tokens && (tokens as Token[]).length}
-                        <Parser
-                            tokens={tokens as Token[]}
-                            {renderers}
-                            {snippetOverrides}
-                            {htmlSnippetOverrides}
-                            {sanitizeUrl}
-                            {sanitizeAttributes}
-                            {...Object.fromEntries(
-                                Object.entries(localRest).filter(([key]) => key !== 'attributes')
-                            )}
-                        />
+                        {#each tokens as childToken, index (index)}
+                            {@render dispatch(childToken, localRestForChildren)}
+                        {/each}
                     {:else}
                         <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
                     {/if}
                 </HtmlComponent>
             {/if}
         {:else}
-            <Parser
-                tokens={(tokens as Token[]) ?? ([] as Token[])}
-                {renderers}
-                {snippetOverrides}
-                {htmlSnippetOverrides}
-                {sanitizeUrl}
-                {sanitizeAttributes}
-                {...Object.fromEntries(
-                    Object.entries(localRest).filter(([key]) => key !== 'tokens')
-                )}
-            />
+            {@const fallbackRest = Object.fromEntries(
+                Object.entries(localRest).filter(([key]) => key !== 'tokens')
+            )}
+            {@const fallbackTokens = (tokens as Token[]) ?? ([] as Token[])}
+            {#each fallbackTokens as fallbackToken, index (index)}
+                {@render dispatch(fallbackToken, fallbackRest)}
+            {/each}
         {/if}
     {:else}
         {@const GeneralComponent = renderers[type as keyof typeof renderers] as RendererComponent}
@@ -426,15 +459,9 @@
         {#snippet renderChildren()}
             {#if tokens}
                 {@const { text: _text, raw: _raw, ...parserRest } = sanitizedRest}
-                <Parser
-                    {...parserRest}
-                    {tokens}
-                    {renderers}
-                    {snippetOverrides}
-                    {htmlSnippetOverrides}
-                    {sanitizeUrl}
-                    {sanitizeAttributes}
-                />
+                {#each tokens as childToken, index (index)}
+                    {@render dispatch(childToken, parserRest)}
+                {/each}
             {:else}
                 <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
             {/if}

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -96,8 +96,8 @@
     } = $props()
 
     /**
-     * Dev-only Parser-instance counter. Exposed via `window.__svm_parserCount`
-     * and `window.__svm_parserByType` so the perf-bench harness can attribute
+     * Dev-only Parser-instance counter. Exposed via `window.__svmParserCount`
+     * and `window.__svmParserByType` so the perf-bench harness can attribute
      * render cost to component allocations without a Chrome profile. The
      * `import.meta.env.DEV` guard is resolved at build time by Vite, so
      * production bundles drop this block entirely (zero overhead). Reset by
@@ -111,8 +111,8 @@
         // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
         const w = window as any
         const initialType: string = type ?? '<root>'
-        w.__svm_parserCount = (w.__svm_parserCount ?? 0) + 1
-        const byType = (w.__svm_parserByType = w.__svm_parserByType ?? {})
+        w.__svmParserCount = (w.__svmParserCount ?? 0) + 1
+        const byType = (w.__svmParserByType = w.__svmParserByType ?? {})
         byType[initialType] = (byType[initialType] ?? 0) + 1
     }
 

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -177,19 +177,22 @@
 </script>
 
 {#snippet dispatch(token: Token, restProps: Record<string, unknown>)}
+    {@const htmlTok = token as Token & {
+        tag?: string
+        attributes?: Record<string, string>
+        tokens?: Token[]
+    }}
+    {@const inlineHtmlOk =
+        token.type === 'html' &&
+        !!htmlTok.tag &&
+        !!renderers.html &&
+        renderers.html[htmlTok.tag] === Html[htmlTok.tag] &&
+        !htmlSnippetOverrides[htmlTok.tag]}
     {#if token.type === 'space' && inlineSpaceOk}
         <!-- inlined: space tokens render nothing -->
     {:else if token.type === 'text' && inlineTextOk && !(token as Tokens.Text).tokens}
         {(token as Tokens.Text).text ?? token.raw}
-    {:else if token.type === 'html' && renderers.html && (token as any).tag && renderers.html[(token as any).tag] === Html[(token as any).tag] && !htmlSnippetOverrides[(token as any).tag]}
-        // trunk-ignore(eslint/@typescript-eslint/no-explicit-any) //
-        trunk-ignore(eslint/@typescript-eslint/no-explicit-any) //
-        trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
-        {@const htmlTok = token as Token & {
-            tag: string
-            attributes?: Record<string, string>
-            tokens?: Token[]
-        }}
+    {:else if inlineHtmlOk && htmlTok.tag}
         {@const sanitizedAttrs = htmlTok.attributes
             ? sanitizeAttributes(
                   htmlTok.attributes,

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -709,7 +709,11 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
                 idx++
                 await tick()
                 renderDurations.push(performance.now() - t0)
-                const gap = chunkDelays[idx] ?? 0
+                // Read the delay associated with the chunk we just emitted
+                // (now at idx-1 after the increment), not the next chunk's
+                // delay — the latter would skip chunkDelays[0] entirely and
+                // leave the final iteration's gap as 0.
+                const gap = chunkDelays[idx - 1] ?? 0
                 gapDurations.push(gap)
                 streamHandle = setTimeout(step, gap)
             }

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -249,8 +249,8 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         domNodes: 0,
         charsPerSec: 0,
         // Parser-instance allocation count (dev-only window counter,
-        // captured per scenario from `__svm_parserCount` /
-        // `__svm_parserByType` in Parser.svelte). Tracks render-cost
+        // captured per scenario from `__svmParserCount` /
+        // `__svmParserByType` in Parser.svelte). Tracks render-cost
         // drivers that wall-clock alone misses.
         parserInstances: 0,
         // Per-scenario observer snapshots: filtered to the scenario's
@@ -376,8 +376,8 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         if (typeof window === 'undefined') return
         // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
         const w = window as any
-        w.__svm_parserCount = 0
-        w.__svm_parserByType = {}
+        w.__svmParserCount = 0
+        w.__svmParserByType = {}
     }
 
     const readParserCounter = (): { total: number; byType: Record<string, number> } => {
@@ -385,8 +385,8 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
         const w = window as any
         return {
-            total: w.__svm_parserCount ?? 0,
-            byType: w.__svm_parserByType ?? {}
+            total: w.__svmParserCount ?? 0,
+            byType: w.__svmParserByType ?? {}
         }
     }
 

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
+    import type { HtmlSnippetProps, ParagraphSnippetProps, TextSnippetProps } from '$lib/types.js'
     import { parseAndCacheTokens } from '$lib/utils/parse-and-cache.js'
     import { benchmarkAppendStream } from '$lib/utils/stream-benchmark.js'
     import { hashString, tokenCache } from '$lib/utils/token-cache.js'
@@ -71,6 +72,94 @@ const x: number = 42
                     `<footer><small>id=${i}</small><br/></footer></div>\n`
             )
         }
+        return out.join('\n')
+    }
+
+    /**
+     * Realistic-mix corpus generator. Unlike `generateLarge` which emits
+     * the same heading + paragraph + list + code shape per section
+     * (over-rewards optimizations that win on text/space tokens),
+     * `generateRealistic` cycles through a varied set of element shapes
+     * roughly matching what a polished README or technical-blog post
+     * looks like — varying paragraph length, occasional inline code,
+     * mixed lists, code blocks of multiple languages, the occasional
+     * table, and the occasional inline `<span>` / `<kbd>` HTML.
+     *
+     * Sized to land near the 50KB target with `sections=120`.
+     */
+    const generateRealistic = (sections: number): string => {
+        const out: string[] = ['# Realistic Mix Corpus\n']
+        out.push(
+            'This corpus is intentionally varied to defeat optimizations that only win on highly-repetitive shapes. It mixes paragraph lengths, list types, code blocks, the occasional table, and inline raw HTML.\n'
+        )
+
+        const inlineSamples = [
+            'For more, see the [official guide](https://example.com/guide).',
+            'Run `pnpm install` first, then `pnpm dev`.',
+            'Press <kbd>Ctrl</kbd>+<kbd>K</kbd> to open the search.',
+            'The result is _significantly_ faster — roughly **3-5×** depending on input.',
+            'A note: <span class="warn">order matters</span> when chaining filters.'
+        ]
+        const paragraphSamples = [
+            'A short follow-up paragraph that reinforces the point above. It mostly contains plain prose.',
+            'Sometimes the prose stretches across multiple sentences. There is a `code reference` here, an *italicized* phrase, and a [hyperlink](https://example.com) — three different inline shapes packed into one paragraph for variety.',
+            'Longer paragraphs are also common in technical writing. They might explain a concept, walk through an example, or compare alternatives. The renderer must dispatch one component per inline child token, so paragraph density is a useful stress factor.',
+            'A trailing one-liner.'
+        ]
+
+        for (let i = 0; i < sections; i++) {
+            // Heading — alternate between ## and ### so depth varies
+            const depth = i % 4 === 0 ? '##' : '###'
+            out.push(
+                `${depth} Section ${i}: ${inlineSamples[i % inlineSamples.length].slice(0, 30)}`
+            )
+
+            // 1–3 paragraphs
+            const pCount = 1 + (i % 3)
+            for (let p = 0; p < pCount; p++) {
+                out.push(paragraphSamples[(i + p) % paragraphSamples.length])
+            }
+            out.push(inlineSamples[i % inlineSamples.length])
+
+            // Every 3rd: a list (alternating ordered/unordered)
+            if (i % 3 === 0) {
+                const ordered = i % 6 === 0
+                for (let li = 0; li < 4; li++) {
+                    const prefix = ordered ? `${li + 1}.` : '-'
+                    out.push(`${prefix} List item ${li} with **bold** and \`code\` flair`)
+                }
+                out.push('')
+            }
+
+            // Every 4th: a code block (vary languages)
+            if (i % 4 === 0) {
+                const langs = ['ts', 'js', 'python', 'bash']
+                const lang = langs[((i / 4) % langs.length) | 0]
+                out.push(`\`\`\`${lang}`)
+                out.push(`// example ${i}`)
+                out.push(`const result = compute(${i});`)
+                out.push(`console.log(result);`)
+                out.push('```')
+                out.push('')
+            }
+
+            // Every 7th: a small table
+            if (i % 7 === 0) {
+                out.push('| Field | Value | Notes |')
+                out.push('|-------|-------|-------|')
+                out.push(`| name | example-${i} | section ${i} |`)
+                out.push(`| size | ${i * 32}B | computed |`)
+                out.push(`| flag | \`true\` | enabled |`)
+                out.push('')
+            }
+
+            // Every 11th: a blockquote
+            if (i % 11 === 0) {
+                out.push(`> Quote from section ${i}: a brief aside that wraps the explanation.`)
+                out.push('')
+            }
+        }
+
         return out.join('\n')
     }
 
@@ -153,8 +242,24 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         cleanupMs: 0,
         hashMs: 0,
         firstPaintMs: 0,
+        // First-class render-attribution column. `firstPaintMs - parseColdMs`
+        // — the same formula the issue report computed manually. Surfaces
+        // parse-side wins that pure firstPaintMs hides when render dominates.
+        renderOnlyMs: 0,
         domNodes: 0,
         charsPerSec: 0,
+        // Parser-instance allocation count (dev-only window counter,
+        // captured per scenario from `__svm_parserCount` /
+        // `__svm_parserByType` in Parser.svelte). Tracks render-cost
+        // drivers that wall-clock alone misses.
+        parserInstances: 0,
+        // Per-scenario observer snapshots: filtered to the scenario's
+        // time window, not the rolling-10s window. Catch the
+        // longest-task / mutation / LoAF count attributable to *this*
+        // scenario without relying on cross-scenario correlation.
+        scenarioLongestTaskMs: 0,
+        scenarioMutations: 0,
+        scenarioLoafScriptMaxMs: 0,
         // cache scenario
         cacheIters: 0,
         cacheTotalMs: 0,
@@ -171,7 +276,12 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         // streaming-only pure-parse percentiles (independent of wall-clock pacing)
         parseChunkAvgMs: 0,
         parseChunkP95Ms: 0,
-        parseChunkPeakMs: 0
+        parseChunkPeakMs: 0,
+        // streaming jitter shape (only populated by the bursty stream
+        // scenario): wall-clock distribution of inter-chunk gaps.
+        streamGapAvgMs: 0,
+        streamGapP95Ms: 0,
+        streamGapPeakMs: 0
     })
 
     // ---- Rolling-10s observer state ------------------------------------------
@@ -195,6 +305,15 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
 
     let isStreaming = $state(false)
     let streamHandle: ReturnType<typeof setTimeout> | null = null
+
+    // When true, the live preview mounts with custom markdown + html
+    // snippet overrides plus a custom html.div renderer. Drives the
+    // `parse-50kb-overridden` scenario so the slow dispatch path
+    // (the one that fires whenever a user actually customizes anything)
+    // is measured alongside the default fast paths. Without this, an
+    // optimization to the fast path could silently regress the
+    // override path and never show up in the bench.
+    let useOverrides = $state(false)
 
     // ---- Helpers --------------------------------------------------------------
 
@@ -220,8 +339,13 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             cleanupMs: 0,
             hashMs: 0,
             firstPaintMs: 0,
+            renderOnlyMs: 0,
             domNodes: 0,
             charsPerSec: 0,
+            parserInstances: 0,
+            scenarioLongestTaskMs: 0,
+            scenarioMutations: 0,
+            scenarioLoafScriptMaxMs: 0,
             cacheIters: 0,
             cacheTotalMs: 0,
             cacheAvgMs: 0,
@@ -235,7 +359,64 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             chunksPerSec: 0,
             parseChunkAvgMs: 0,
             parseChunkP95Ms: 0,
-            parseChunkPeakMs: 0
+            parseChunkPeakMs: 0,
+            streamGapAvgMs: 0,
+            streamGapP95Ms: 0,
+            streamGapPeakMs: 0
+        }
+    }
+
+    /**
+     * Resets the dev-mode Parser-instance counter so a fresh scenario gets
+     * a clean total. The window globals are populated by the dev-only
+     * block at the top of `Parser.svelte` and stay 0/empty in production
+     * builds (Vite drops the block).
+     */
+    const resetParserCounter = () => {
+        if (typeof window === 'undefined') return
+        // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        const w = window as any
+        w.__svm_parserCount = 0
+        w.__svm_parserByType = {}
+    }
+
+    const readParserCounter = (): { total: number; byType: Record<string, number> } => {
+        if (typeof window === 'undefined') return { total: 0, byType: {} }
+        // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+        const w = window as any
+        return {
+            total: w.__svm_parserCount ?? 0,
+            byType: w.__svm_parserByType ?? {}
+        }
+    }
+
+    /**
+     * Filters the observer entry buffers to the [start, end] window the
+     * scenario actually ran in, then computes scenario-scoped aggregates.
+     * Replaces the earlier "rolling-10s" attribution which leaked across
+     * scenarios and forced manual correlation.
+     */
+    const snapshotScenarioObservers = (start: number, end: number) => {
+        let longestTaskMs = 0
+        for (const e of longTaskEntries) {
+            if (e.time >= start && e.time <= end && e.duration > longestTaskMs) {
+                longestTaskMs = e.duration
+            }
+        }
+        let mutations = 0
+        for (const e of mutationEvents) {
+            if (e.time >= start && e.time <= end) mutations += e.count
+        }
+        let loafScriptMaxMs = 0
+        for (const e of loafEntries) {
+            if (e.time >= start && e.time <= end && e.scriptMs > loafScriptMaxMs) {
+                loafScriptMaxMs = e.scriptMs
+            }
+        }
+        return {
+            longestTaskMs: Math.round(longestTaskMs),
+            mutations,
+            loafScriptMaxMs: Math.round(loafScriptMaxMs)
         }
     }
 
@@ -262,10 +443,15 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
      * Runs the full per-document timing suite for a given corpus.
      * Updates `stat` with parse/lex/cleanup/hash + first-paint metrics
      * and assigns `source` so the live preview re-renders.
+     *
+     * @param overridden When true, the live preview is mounted with a
+     * set of custom renderers + snippet overrides — exercises the slow
+     * dispatch path that's otherwise silently regressable.
      */
-    const runDocScenario = async (label: string, corpus: string) => {
+    const runDocScenario = async (label: string, corpus: string, overridden = false) => {
         scenario = label
         resetStat()
+        useOverrides = overridden
 
         // Direct timings (synchronous, no render in loop)
         tokenCache.clearAllTokens()
@@ -296,6 +482,11 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         tokenCache.clearAllTokens()
         source = ''
         await tick()
+        // Let any pending unmount mutations from `source = ''` settle so
+        // they aren't attributed to *this* scenario's window.
+        await tick()
+        resetParserCounter()
+        const scenarioStart = performance.now()
         const paintPromise = waitForPaint()
         const tPaint0 = performance.now()
         source = corpus
@@ -303,7 +494,10 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         const firstPaintMs = paintAt - tPaint0
 
         await tick()
+        const scenarioEnd = performance.now()
         const domNodes = previewEl ? previewEl.querySelectorAll('*').length : 0
+        const parserCounter = readParserCounter()
+        const observerSnap = snapshotScenarioObservers(scenarioStart, scenarioEnd)
 
         const srcKb = round(corpus.length / 1024, 1)
         const charsPerSec = parseColdMs > 0 ? Math.round((corpus.length / parseColdMs) * 1000) : 0
@@ -318,8 +512,13 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             cleanupMs: round(cleanupMs),
             hashMs: round(hashMs, 3),
             firstPaintMs: round(firstPaintMs),
+            renderOnlyMs: round(Math.max(0, firstPaintMs - parseColdMs)),
             domNodes,
-            charsPerSec
+            charsPerSec,
+            parserInstances: parserCounter.total,
+            scenarioLongestTaskMs: observerSnap.longestTaskMs,
+            scenarioMutations: observerSnap.mutations,
+            scenarioLoafScriptMaxMs: observerSnap.loafScriptMaxMs
         }
 
         scenario = `${label}-done`
@@ -432,15 +631,129 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         scenario = 'stream-30tps-done'
     }
 
+    /**
+     * Bursty streaming variant. Real LLM token streams are not steady
+     * — they arrive in 1–10 token bursts separated by 0–200ms pauses,
+     * occasionally with a 50+ token slug landing in one chunk after a
+     * long stall. This replays the same corpus as `runStreaming` but
+     * with jittered chunk sizes and inter-chunk delays so the rAF
+     * batching window in `SvelteMarkdown.svelte` is actually
+     * exercised. Pacing is seeded so runs are reproducible.
+     */
+    const runStreamingBursty = async (seed = 1) => {
+        if (isStreaming) return
+        scenario = 'stream-bursty'
+        resetStat()
+        source = ''
+        tokenCache.clearAllTokens()
+        await tick()
+
+        // Cheap seeded PRNG (mulberry32) — good enough for jitter
+        // distributions and lets the bench reproduce across runs.
+        let s = seed >>> 0
+        const rand = () => {
+            s = (s + 0x6d2b79f5) | 0
+            let t = s
+            t = Math.imul(t ^ (t >>> 15), t | 1)
+            t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+        }
+
+        // Word-tokenize the corpus, then assemble bursts of 1–10 tokens
+        // (occasionally up to 50) into chunks. Each chunk gets a
+        // delay drawn from {short: [5,30], medium: [30,80], long: [80,200]}
+        // weighted toward short (so the average is realistic).
+        const words: string[] = []
+        const re = /\S+\s*/g
+        let match
+        while ((match = re.exec(STREAM_CORPUS)) !== null) words.push(match[0])
+
+        const chunks: string[] = []
+        const chunkDelays: number[] = []
+        let i = 0
+        while (i < words.length) {
+            const r = rand()
+            const burst = r < 0.05 ? 30 + Math.floor(rand() * 20) : 1 + Math.floor(rand() * 9)
+            const slice = words.slice(i, i + burst).join('')
+            chunks.push(slice)
+            i += burst
+            const dr = rand()
+            // Bias delays toward "short" so the stream finishes in
+            // reasonable wall-clock time. Long pauses are rare but
+            // present.
+            const delay =
+                dr < 0.7
+                    ? 5 + rand() * 25 // 5–30ms (typical)
+                    : dr < 0.95
+                      ? 30 + rand() * 50 // 30–80ms (medium)
+                      : 80 + rand() * 120 // 80–200ms (rare long pause)
+            chunkDelays.push(delay)
+        }
+
+        const opts = { gfm: true, breaks: false, headerIds: true, headerPrefix: '' }
+        const bench = benchmarkAppendStream(chunks, opts)
+
+        const renderDurations: number[] = []
+        const gapDurations: number[] = []
+        let idx = 0
+        isStreaming = true
+        const startWall = performance.now()
+        await new Promise<void>((resolve) => {
+            const step = async () => {
+                if (idx >= chunks.length) {
+                    resolve()
+                    return
+                }
+                const t0 = performance.now()
+                source += chunks[idx]
+                idx++
+                await tick()
+                renderDurations.push(performance.now() - t0)
+                const gap = chunkDelays[idx] ?? 0
+                gapDurations.push(gap)
+                streamHandle = setTimeout(step, gap)
+            }
+            void step()
+        })
+        const wallMs = performance.now() - startWall
+        isStreaming = false
+        if (streamHandle !== null) {
+            clearTimeout(streamHandle)
+            streamHandle = null
+        }
+
+        const renderTotal = renderDurations.reduce((s, d) => s + d, 0)
+        const gapTotal = gapDurations.reduce((s, d) => s + d, 0)
+        stat = {
+            ...stat,
+            srcKb: round(STREAM_CORPUS.length / 1024, 1),
+            streamChunks: chunks.length,
+            streamTotalMs: round(renderTotal),
+            streamAvgMs: round(renderTotal / chunks.length, 3),
+            streamP95Ms: round(percentile(renderDurations, 0.95), 3),
+            streamPeakMs: round(Math.max(...renderDurations), 3),
+            chunksPerSec: round((chunks.length / wallMs) * 1000, 1),
+            parseChunkAvgMs: round(bench.totalParseMs / bench.chunkCount, 3),
+            parseChunkP95Ms: round(bench.p95ParseMs, 3),
+            parseChunkPeakMs: round(bench.peakParseMs, 3),
+            streamGapAvgMs: round(gapTotal / gapDurations.length, 3),
+            streamGapP95Ms: round(percentile(gapDurations, 0.95), 3),
+            streamGapPeakMs: round(Math.max(...gapDurations), 3)
+        }
+        scenario = 'stream-bursty-done'
+    }
+
     const clear = () => {
         if (streamHandle !== null) {
             clearTimeout(streamHandle)
             streamHandle = null
         }
         isStreaming = false
+        useOverrides = false
         source = ''
         tokenCache.clearAllTokens()
         resetStat()
+        resetParserCounter()
         longTaskEntries = []
         rafIntervals = []
         mutationEvents = []
@@ -629,9 +942,28 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         >
             Parse table-heavy
         </button>
+        <button
+            data-testid="parse-realistic"
+            onclick={() => runDocScenario('parse-realistic', generateRealistic(120))}
+        >
+            Parse realistic
+        </button>
+        <button
+            data-testid="parse-50kb-overridden"
+            onclick={() => runDocScenario('parse-50kb-overridden', generateLarge(16, 10), true)}
+        >
+            Parse 50KB (overrides)
+        </button>
         <button data-testid="cache-warm" onclick={() => runCacheWarm(100)}>Cache warm ×100</button>
         <button data-testid="stream-30tps" onclick={() => runStreaming(30)} disabled={isStreaming}>
             {isStreaming ? 'Streaming…' : 'Stream 30/s'}
+        </button>
+        <button
+            data-testid="stream-bursty"
+            onclick={() => runStreamingBursty()}
+            disabled={isStreaming}
+        >
+            {isStreaming ? 'Streaming…' : 'Stream bursty'}
         </button>
         <button data-testid="clear" onclick={clear}>Clear</button>
     </div>
@@ -639,12 +971,15 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
     <div class="stats" data-testid="perf-stats">
         scenario={scenario} srcKb={stat.srcKb} tokenCount={stat.tokenCount} parseColdMs={stat.parseColdMs}
         parseWarmMs={stat.parseWarmMs} lexMs={stat.lexMs} cleanupMs={stat.cleanupMs} hashMs={stat.hashMs}
-        firstPaintMs={stat.firstPaintMs} domNodes={stat.domNodes} charsPerSec={stat.charsPerSec} · cacheIters={stat.cacheIters}
-        cacheTotalMs={stat.cacheTotalMs} cacheAvgMs={stat.cacheAvgMs}
-        cacheP95Ms={stat.cacheP95Ms} cachePeakMs={stat.cachePeakMs} · streamChunks={stat.streamChunks}
-        streamTotalMs={stat.streamTotalMs} streamAvgMs={stat.streamAvgMs} streamP95Ms={stat.streamP95Ms}
-        streamPeakMs={stat.streamPeakMs} chunksPerSec={stat.chunksPerSec} parseChunkAvgMs={stat.parseChunkAvgMs}
-        parseChunkP95Ms={stat.parseChunkP95Ms} parseChunkPeakMs={stat.parseChunkPeakMs} · longestTaskMs={longTaskSupported
+        firstPaintMs={stat.firstPaintMs} renderOnlyMs={stat.renderOnlyMs} domNodes={stat.domNodes}
+        charsPerSec={stat.charsPerSec} parserInstances={stat.parserInstances} scenarioLongestTaskMs={stat.scenarioLongestTaskMs}
+        scenarioMutations={stat.scenarioMutations} scenarioLoafScriptMaxMs={stat.scenarioLoafScriptMaxMs}
+        · cacheIters={stat.cacheIters} cacheTotalMs={stat.cacheTotalMs} cacheAvgMs={stat.cacheAvgMs} cacheP95Ms={stat.cacheP95Ms}
+        cachePeakMs={stat.cachePeakMs} · streamChunks={stat.streamChunks} streamTotalMs={stat.streamTotalMs}
+        streamAvgMs={stat.streamAvgMs} streamP95Ms={stat.streamP95Ms} streamPeakMs={stat.streamPeakMs}
+        chunksPerSec={stat.chunksPerSec} parseChunkAvgMs={stat.parseChunkAvgMs} parseChunkP95Ms={stat.parseChunkP95Ms}
+        parseChunkPeakMs={stat.parseChunkPeakMs} streamGapAvgMs={stat.streamGapAvgMs} streamGapP95Ms={stat.streamGapP95Ms}
+        streamGapPeakMs={stat.streamGapPeakMs} · longestTaskMs={longTaskSupported
             ? displayLongestTaskMs
             : 'n/a'}
         longTasks10s={longTaskSupported ? displayLongTaskCount : 'n/a'} rafP95Ms={displayRafP95Ms}
@@ -654,8 +989,39 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             : 'n/a'}
     </div>
 
+    {#snippet overrideParagraphSnippet(props: ParagraphSnippetProps)}
+        <p data-overridden="paragraph" class="overridden-p">
+            {@render props.children?.()}
+        </p>
+    {/snippet}
+    {#snippet overrideTextSnippet(props: TextSnippetProps)}
+        <span data-overridden="text">{props.text ?? ''}</span>
+    {/snippet}
+    {#snippet overrideHtmlDivSnippet(props: HtmlSnippetProps)}
+        <div data-overridden="html_div" {...props.attributes ?? {}}>
+            {@render props.children?.()}
+        </div>
+    {/snippet}
+
     <div class="preview" data-testid="perf-preview" bind:this={previewEl}>
-        <SvelteMarkdown {source} streaming={isStreaming} />
+        {#if useOverrides}
+            <!--
+                Slow-path scenario: pass markdown + html snippet overrides
+                so the dispatch in Parser.svelte goes through the
+                snippet-call branches rather than the inlined fast paths.
+                Catches regressions in the override path that pure
+                fast-path benchmarks would miss.
+            -->
+            <SvelteMarkdown
+                {source}
+                streaming={isStreaming}
+                paragraph={overrideParagraphSnippet}
+                text={overrideTextSnippet}
+                html_div={overrideHtmlDivSnippet}
+            />
+        {:else}
+            <SvelteMarkdown {source} streaming={isStreaming} />
+        {/if}
     </div>
 </div>
 


### PR DESCRIPTION
## Summary

Two tracks bundled together because the optimization motivated the harness gaps and the harness now pins the optimization. The render-side work in #286 lands as a structural change to `Parser.svelte` (Parser instance count drops 63–99.99%, firstPaintMs drops 38–81% across bench scenarios), and the perf-bench harness gains the six measurement gaps that made the original investigation harder than it needed to be — Parser instance counter, `renderOnlyMs`, per-scenario observer snapshots, plus three new scenarios covering realistic-mix corpora, the override path, and bursty streaming.

User-facing API is fully preserved: every customization path (`renderers.html.x`, `htmlSnippetOverrides`, `renderers.text`, snippet overrides) still wins over the inline fast-path via identity-equality checks. The new `parse-50kb-overridden` scenario exists specifically to gate this — slow-path regressions can no longer slip past the bench.

## Changes

### ✨ Render-side optimization (`Parser.svelte`)

- **Inline the recursive `<Parser tokens={...}>` proxy.** Every `renderChildren` / list-item / table-cell / html-children context used to spawn a proxy `<Parser>` whose only job was `{#each tokens}`, then a real `<Parser>` per token. Now the loop iterates inline in the parent context. Eliminates the `<root>` parser instance category — 7K of 21K instances on parse-html-heavy, 22K of 70K on parse-500kb.
- **Add a `dispatch` snippet** that fast-paths three common shapes when the user has not customized:
  - `space` tokens render nothing inline (default path was a no-op anyway, but Parser was still being instantiated)
  - leaf `text` tokens emit `{token.text ?? token.raw}` inline (default path was Parser → Text → RawText → `{text}`, three components for what's effectively just text)
  - `html` tokens render via `<svelte:element this={tag} {...sanitizedAttrs}>` with a `SELF_CLOSING_HTML` guard for void elements (`br`, `hr`, `img`, etc.)
- Each fast-path **gates on identity equality against the default renderer map** (`renderers.html[tag] === Html[tag]`) plus absence of the corresponding snippet override, so any customization falls through to `<Parser>` dispatch unchanged.
- The destructure-and-spread `{@const ...parserRest } = rest}` was hoisted out of `{#each}` loops as part of the rewrite.

### 🧪 Perf-bench measurement gaps

- **Parser instance counter** — dev-only `__svm_parserCount` / `__svm_parserByType` window hook in `Parser.svelte`, gated on `import.meta.env.DEV` so production bundles drop the block entirely. The bench page resets it per scenario and exposes `parserInstances` in the stats line. This was the non-wall-clock signal that cracked open the original #286 investigation; future regressions in component allocation count will surface directly without manual instrumentation.
- **`renderOnlyMs` first-class column** — `firstPaintMs - parseColdMs`. The same formula the issue computed manually, now a real field. Surfaces parse-side wins that pure firstPaint hides when render dominates.
- **Per-scenario observer snapshots** — `scenarioLongestTaskMs`, `scenarioMutations`, `scenarioLoafScriptMaxMs` filtered to the scenario's `[start, end]` window rather than the rolling-10s aggregate, so cross-scenario correlation isn't needed to attribute longtasks or mutation churn.
- **`parse-realistic` scenario** — a mixed-shape corpus generator that varies paragraph length, alternates ordered/unordered lists, mixes code-block languages, includes occasional tables/blockquotes/inline HTML. Defeats optimizations that only win on the highly-repetitive `generateLarge` shape.
- **`parse-50kb-overridden` scenario** — same body as `parse-50kb` but the live preview mounts with custom `paragraph` + `text` + `html_div` snippet overrides. Drives the slow dispatch path so override-path regressions can't slip past the bench.
- **`stream-bursty` scenario** — jittered chunk sizes (1–10 typical, rare 30–50 bursts) and inter-chunk delays drawn from short/medium/long buckets, pacing seeded with mulberry32 for reproducibility. Adds `streamGapAvgMs` / `P95Ms` / `PeakMs` columns. Real LLM streams are not steady 30 tps; this exercises the rAF batching window in `SvelteMarkdown.svelte` under realistic conditions.

### 🐛 Render fix (caught by the new bench gate)

- The first cut of the html fast-path put `(token as any).tag` casts inline in a multi-line `{:else if}` condition with `// trunk-ignore` line comments between operands. Trunk fmt's reflow + Svelte's template parser caused the trunk-ignore comments to leak into the rendered DOM as text — caught immediately by `SvelteMarkdown.test.ts > short html renders properly`. Restructured to extract a single typed `htmlTok` cast via `{@const}` at the top of the snippet so the conditional is a clean boolean.

## Numbers

`parse-html-heavy` (145.5 KB, 1001 tokens, median of 5 cold + 5 warm headless Chromium runs):

| Metric | Before | After | Δ |
| --- | --- | --- | --- |
| Parser instances | 21,503 | **1** | **−99.99%** |
| firstPaintMs | 1,714 ms | 331 ms | **−81%** |
| render:parse ratio | 75× | 13× | |

`parse-500kb` (510.5 KB, 17,159 tokens, 21,780 DOM nodes):

| Metric | Before | After | Δ |
| --- | --- | --- | --- |
| Parser instances | 70,619 | 20,130 | −71% |
| firstPaintMs | 4,712 ms | 2,343 ms | **−50%** |
| render:parse ratio | 70× | 35× | |

`parse-50kb`: 6,847 → 1,952 instances (−71%), firstPaintMs 515 → 251 ms (−51%).
`parse-table-heavy`: 5,363 → 2,001 instances (−63%), firstPaintMs 508 → 313 ms (−38%).

The override-path scenario shows the slow path engaging correctly: `parse-50kb-overridden` registers 3,424 Parser instances (~75% more than the 1,952 fast-path baseline), confirming the dispatch falls through to `<Parser>` when customization is detected.

## Testing

- `pnpm test:only` — **781 / 781** vitest tests pass
- `pnpm check` — 0 errors, 4 warnings (3 pre-existing, 1 intentional in our dev-mode counter; explained inline)
- `pnpm test:e2e` — 308 desktop Playwright tests pass (chromium / firefox / webkit); mobile-safari spot-checks pass too
- `pnpm perf:bench` end-to-end smoke — all 9 scenarios fire, all new fields populate sensibly, slow-path scenario engages

## Commits

- [`35139ca`](https://github.com/humanspeak/svelte-markdown/commit/35139ca) test(perf-bench): close measurement gaps identified during #286
- [`9c894ee`](https://github.com/humanspeak/svelte-markdown/commit/9c894ee) perf(render): inline-dispatch leaf tokens, eliminate Parser proxy layer
- [`02bfa68`](https://github.com/humanspeak/svelte-markdown/commit/02bfa68) fix(render): hoist html dispatch cast out of {:else if} expression

Closes #286
