### PR TITLE
ci: drop standalone sitemap:manifest deploy step

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -49,10 +49,6 @@ jobs:
             - name: Build Package
               run: pnpm run build
 
-            - name: Generate sitemap manifest
-              working-directory: docs
-              run: pnpm run sitemap:manifest
-
             - name: Deploy Docs
               working-directory: docs
               env:


### PR DESCRIPTION
## Summary

The Cloudflare deploy workflow runs `pnpm run sitemap:manifest` in `docs/` between the build and the wrangler upload, but that script no longer exists — the brutalist-sweep migration (PR #299) replaced the standalone generator with the `sitemapManifestPlugin` Vite plugin from docs-kit, which fires inside the existing `vite build`. The standalone step now fails with:

```
ERR_PNPM_NO_SCRIPT
Command "sitemap:manifest" not found.
```

Failing run: https://github.com/humanspeak/svelte-markdown/actions/runs/26131451601/job/76857244464

## Changes

🛠️ **`.github/workflows/cloudflare-deploy.yml`** — remove the now-redundant `Generate sitemap manifest` step. The `Deploy Docs` step's `pnpm run deploy` already invokes `vite build`, which runs `sitemapManifestPlugin`'s `buildStart` hook and emits `src/lib/sitemap-manifest.json` before wrangler uploads. No coverage loss.

## Why a separate PR

The breaking change (removing `sitemap:manifest` from `docs/package.json`) lives in #299, but the workflow lives on `main` and would silently fail there too once #299 merges. Landing this fix first means #299 can merge cleanly and `main`'s deploy stays green.

## Test plan

- [ ] CI deploy job no longer references `sitemap:manifest`
- [ ] After merge, kick a deploy on `main` — sitemap manifest still gets emitted (verify by hitting `/sitemap.xml` after deploy)
- [ ] PR #299 rebased on top of this can run `Deploy Docs` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)