### PR TITLE
docs: docs-kit 2026.5.31 — shared types, manifest-path fix, /docs/examples re-skin

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.27",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.31",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.16.47",
         "marked-code-format": "^1.1.6",

--- a/docs/src/routes/docs/examples/+page.svelte
+++ b/docs/src/routes/docs/examples/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Icon from '$lib/components/general/Icon.svelte'
-    import { ArrowRight } from '@lucide/svelte'
     import type { IconName } from '$lib/icons'
 
     const seo = getSeoContext()
@@ -15,10 +13,15 @@
         seo.ogSlug = 'docs-examples'
     }
 
-    const examples: {
-        category: string
-        items: { title: string; description: string; href: string; icon: IconName }[]
-    }[] = [
+    type ExampleItem = {
+        title: string
+        description: string
+        href: string
+        icon: IconName
+        kind?: 'doc' | 'live'
+    }
+
+    const examples: { category: string; items: ExampleItem[] }[] = [
         {
             category: 'Getting Started',
             items: [
@@ -79,14 +82,16 @@
                     description:
                         'Render Mermaid diagrams with a custom marked extension and async component renderers.',
                     href: '/examples/mermaid',
-                    icon: 'workflow'
+                    icon: 'workflow',
+                    kind: 'live'
                 },
                 {
                     title: 'LLM Streaming',
                     description:
                         'Simulate real-time AI response streaming with adjustable speed, jitter, and chunk modes.',
                     href: '/examples/llm-streaming',
-                    icon: 'zap'
+                    icon: 'zap',
+                    kind: 'live'
                 }
             ]
         }
@@ -119,143 +124,294 @@
             notes: 'Access AST tokens'
         }
     ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<!-- Hero Section -->
-<div class="not-prose mb-10">
-    <h1 class="text-foreground mb-3 text-4xl font-bold">Usage Examples</h1>
-    <p class="text-muted-foreground max-w-2xl text-lg">
-        Explore practical examples of how to use @humanspeak/svelte-markdown in real-world
-        scenarios.
-    </p>
-</div>
+<div class="dx not-prose">
+    <header class="dx-head">
+        <div class="dx-kicker">// docs / examples</div>
+        <h1>usage <span>examples</span>.</h1>
+        <p>
+            Curated patterns for integrating <b>@humanspeak/svelte-markdown</b> — short walkthrough
+            docs paired with live demos. Items marked <span class="dx-tag dx-tag-live">live</span>
+            jump to interactive editors under <code>/examples</code>.
+        </p>
+    </header>
 
-<!-- Examples Grid by Category -->
-{#each examples as category, categoryIndex}
-    <div class="not-prose mb-10">
-        <h2 class="text-foreground mb-4 text-xl font-semibold">{category.category}</h2>
-        <div class="grid gap-4 sm:grid-cols-2">
-            {#each category.items as example, itemIndex}
-                <a
-                    href={example.href}
-                    class="example-card group border-border bg-card hover:border-brand-500/50 hover:shadow-brand-500/10 relative overflow-hidden rounded-xl border p-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
-                    style="animation-delay: {(categoryIndex * 3 + itemIndex) * 50}ms"
-                >
-                    <!-- Gradient overlay on hover -->
-                    <div
-                        class="from-brand-500/5 absolute inset-0 bg-gradient-to-br to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-                    ></div>
-
-                    <!-- Content -->
-                    <div class="relative z-10">
-                        <!-- Icon -->
-                        <div
-                            class="from-brand-500 to-brand-600 mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br text-white transition-transform duration-300 group-hover:scale-110"
-                        >
-                            <Icon name={example.icon} class="size-4" />
-                        </div>
-
-                        <h3
-                            class="text-foreground group-hover:text-brand-600 mb-1.5 text-lg font-semibold transition-colors"
-                        >
-                            {example.title}
-                        </h3>
-
-                        <p class="text-muted-foreground mb-3 line-clamp-2 text-sm">
-                            {example.description}
-                        </p>
-
-                        <!-- View link -->
-                        <div
-                            class="text-brand-600 group-hover:text-brand-700 flex items-center text-sm font-medium"
-                        >
-                            View Example
-                            <ArrowRight
-                                class="ml-2 size-4 transition-transform duration-200 group-hover:translate-x-1"
-                            />
-                        </div>
-                    </div>
-
-                    <!-- Decorative corner -->
-                    <div
-                        class="from-brand-500/10 absolute top-0 right-0 h-16 w-16 rounded-bl-full bg-gradient-to-bl to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-                    ></div>
-                </a>
-            {/each}
-        </div>
-    </div>
-{/each}
-
-<!-- Quick Reference Section -->
-<div class="not-prose mb-10">
-    <h2 class="text-foreground mb-4 text-xl font-semibold">Quick Reference</h2>
-    <div class="border-border overflow-x-auto rounded-xl border">
-        <table class="w-full text-sm">
-            <thead class="bg-muted/50">
-                <tr>
-                    <th class="text-foreground px-4 py-3 text-left font-medium">Use Case</th>
-                    <th class="text-foreground px-4 py-3 text-left font-medium">Usage</th>
-                    <th class="text-foreground px-4 py-3 text-left font-medium">Notes</th>
-                </tr>
-            </thead>
-            <tbody class="divide-border divide-y">
-                {#each quickReference as row}
-                    <tr class="hover:bg-muted/30 transition-colors">
-                        <td class="text-foreground px-4 py-3">{row.useCase}</td>
-                        <td class="px-4 py-3">
-                            <code class="bg-muted text-brand-600 rounded px-1.5 py-0.5 text-xs"
-                                >{row.component}</code
-                            >
-                        </td>
-                        <td class="text-muted-foreground px-4 py-3">{row.notes}</td>
-                    </tr>
-                {/each}
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<!-- Best Practices Section -->
-<div class="not-prose">
-    <h2 class="text-foreground mb-4 text-xl font-semibold">Best Practices</h2>
-    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {#each [{ icon: 'shield' as IconName, title: 'Filter untrusted HTML', description: 'Use allowHtmlOnly/excludeHtmlOnly for user content' }, { icon: 'zap' as IconName, title: 'Leverage token caching', description: 'Repeated renders are 50-200x faster automatically' }, { icon: 'paintbrush' as IconName, title: 'Use custom renderers', description: 'Override specific elements for custom styling' }, { icon: 'code' as IconName, title: 'Use isInline for labels', description: 'Avoid block-level wrapping for inline content' }, { icon: 'workflow' as IconName, title: 'Inspect tokens when debugging', description: 'Use the parsed callback to see the AST' }] as practice}
-            <div class="border-border bg-card flex items-start gap-3 rounded-lg border p-4">
-                <div
-                    class="bg-brand-500/10 text-brand-600 flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
-                >
-                    <Icon name={practice.icon} class="size-3.5" />
-                </div>
-                <div>
-                    <h3 class="text-foreground font-medium">{practice.title}</h3>
-                    <p class="text-muted-foreground text-sm">{practice.description}</p>
-                </div>
+    {#each examples as category, ci (category.category)}
+        <section class="dx-cat">
+            <div class="dx-cat-head">
+                <span class="dx-cat-id">{pad2(ci + 1)}</span>
+                <h2>{category.category}</h2>
+                <span class="dx-cat-count">
+                    {category.items.length} item{category.items.length === 1 ? '' : 's'}
+                </span>
             </div>
-        {/each}
-    </div>
+            <div class="dx-grid">
+                {#each category.items as item (item.href)}
+                    <a class="dx-cell" href={item.href}>
+                        <div class="dx-cell-head">
+                            <span class="dx-cell-tag">
+                                {item.kind === 'live' ? 'LIVE DEMO' : 'WALKTHROUGH'}
+                            </span>
+                            <span class="dx-cell-arrow">↗</span>
+                        </div>
+                        <h3>{item.title}</h3>
+                        <p>{item.description}</p>
+                    </a>
+                {/each}
+            </div>
+        </section>
+    {/each}
+
+    <section class="dx-ref">
+        <div class="dx-cat-head">
+            <span class="dx-cat-id">{pad2(examples.length + 1)}</span>
+            <h2>Quick Reference</h2>
+            <span class="dx-cat-count">{quickReference.length} patterns</span>
+        </div>
+        <div class="dx-table-wrap">
+            <table class="dx-table">
+                <thead>
+                    <tr>
+                        <th>Use case</th>
+                        <th>Usage</th>
+                        <th>Notes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each quickReference as row (row.useCase)}
+                        <tr>
+                            <td>{row.useCase}</td>
+                            <td><code>{row.component}</code></td>
+                            <td class="dx-table-notes">{row.notes}</td>
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    </section>
 </div>
 
 <style>
-    .line-clamp-2 {
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
+    /* ── Page chrome — sits inside DocsLayoutV2's content rail. */
+    .dx {
+        font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+        color: var(--brut-ink, currentColor);
+    }
+    .dx-head {
+        margin-bottom: 32px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid var(--brut-rule);
+    }
+    .dx-kicker {
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 10.5px;
+        color: var(--brut-ink-3);
+        letter-spacing: 0.14em;
+        margin-bottom: 12px;
+    }
+    .dx-head h1 {
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 32px;
+        font-weight: 500;
+        letter-spacing: -0.02em;
+        margin: 0 0 14px;
+        color: var(--brut-ink);
+        text-transform: lowercase;
+    }
+    .dx-head h1 span {
+        color: var(--brut-accent);
+    }
+    .dx-head p {
+        font-size: 14px;
+        line-height: 1.6;
+        color: var(--brut-ink-2);
+        margin: 0;
+        max-width: 60ch;
+    }
+    .dx-head p b {
+        color: var(--brut-ink);
+        font-weight: 600;
+    }
+    .dx-head p code {
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 0.92em;
+        background: var(--brut-bg-2);
+        border: 1px solid var(--brut-rule);
+        padding: 0 4px;
+        border-radius: 2px;
+        color: var(--brut-ink);
+    }
+    .dx-tag {
+        display: inline-block;
+        padding: 1px 6px;
+        border: 1px solid var(--brut-rule);
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--brut-ink-3);
+        vertical-align: 1px;
+    }
+    .dx-tag-live {
+        color: var(--brut-accent);
+        border-color: var(--brut-accent);
     }
 
-    .example-card {
-        animation: fadeInUp 0.5s ease-out both;
+    /* ── Category header (id · title · count) ────────────────────── */
+    .dx-cat {
+        margin-bottom: 32px;
+    }
+    .dx-cat-head {
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        margin-bottom: 14px;
+    }
+    .dx-cat-id {
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 11px;
+        color: var(--brut-ink-3);
+        letter-spacing: 0.14em;
+    }
+    .dx-cat-head h2 {
+        font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+        font-size: 17px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        margin: 0;
+        color: var(--brut-ink);
+    }
+    .dx-cat-count {
+        margin-left: auto;
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 10.5px;
+        color: var(--brut-ink-3);
+        letter-spacing: 0.08em;
     }
 
-    @keyframes fadeInUp {
-        from {
-            opacity: 0;
-            transform: translateY(12px);
+    /* ── Tile cards — hairline borders, mono labels, no gradients. */
+    .dx-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0;
+        border-top: 1px solid var(--brut-rule);
+        border-left: 1px solid var(--brut-rule);
+    }
+    .dx-cell {
+        display: flex;
+        flex-direction: column;
+        padding: 16px 18px;
+        border-right: 1px solid var(--brut-rule);
+        border-bottom: 1px solid var(--brut-rule);
+        background: var(--brut-bg);
+        color: var(--brut-ink);
+        text-decoration: none;
+        transition: background-color 0.15s;
+    }
+    .dx-cell:hover {
+        background: color-mix(in oklab, var(--brut-accent) 6%, transparent);
+    }
+    .dx-cell-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 10px;
+    }
+    .dx-cell-tag {
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--brut-ink-3);
+    }
+    .dx-cell:hover .dx-cell-tag {
+        color: var(--brut-accent);
+    }
+    .dx-cell-arrow {
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 14px;
+        color: var(--brut-ink-3);
+        transition:
+            color 0.15s,
+            transform 0.15s;
+    }
+    .dx-cell:hover .dx-cell-arrow {
+        color: var(--brut-accent);
+        transform: translate(2px, -2px);
+    }
+    .dx-cell h3 {
+        font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+        font-size: 15px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        margin: 0 0 6px;
+        color: var(--brut-ink);
+    }
+    .dx-cell p {
+        font-size: 13px;
+        line-height: 1.5;
+        color: var(--brut-ink-2);
+        margin: 0;
+    }
+
+    /* ── Quick-reference table ────────────────────────────────────── */
+    .dx-ref {
+        margin-top: 40px;
+    }
+    .dx-table-wrap {
+        overflow-x: auto;
+        border: 1px solid var(--brut-rule);
+    }
+    .dx-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+    }
+    .dx-table th {
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 10.5px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        text-align: left;
+        padding: 10px 14px;
+        background: var(--brut-bg-2);
+        border-bottom: 1px solid var(--brut-rule);
+        color: var(--brut-ink-3);
+        font-weight: 500;
+    }
+    .dx-table td {
+        padding: 10px 14px;
+        border-bottom: 1px solid var(--brut-rule);
+        color: var(--brut-ink);
+        vertical-align: top;
+    }
+    .dx-table tbody tr:last-child td {
+        border-bottom: 0;
+    }
+    .dx-table code {
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 12px;
+        background: var(--brut-bg-2);
+        border: 1px solid var(--brut-rule);
+        padding: 1px 5px;
+        border-radius: 2px;
+        color: var(--brut-ink);
+        white-space: nowrap;
+    }
+    .dx-table-notes {
+        color: var(--brut-ink-2);
+    }
+
+    /* ── Responsive ───────────────────────────────────────────────── */
+    @media (max-width: 720px) {
+        .dx-grid {
+            grid-template-columns: 1fr;
         }
-        to {
-            opacity: 1;
-            transform: translateY(0);
+        .dx-head h1 {
+            font-size: 26px;
         }
     }
 </style>

--- a/docs/src/routes/examples/agent-output/+page.svelte
+++ b/docs/src/routes/examples/agent-output/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import AgentConsole from '$lib/examples/agent-output/demos/AgentConsole.svelte'
     import demoManifest from '$lib/demo-manifest.json'
     import { Shield, ShieldCheck, ShieldOff, Zap } from '@lucide/svelte'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -25,27 +30,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'AGENT',
@@ -59,8 +46,6 @@
             sourceUrl: `${SOURCE_URL}agent-output/demos/AgentConsole.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet agentSection()}
@@ -120,7 +105,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/caching-performance/+page.svelte
+++ b/docs/src/routes/examples/caching-performance/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import CachingBenchmark from '$lib/examples/caching-performance/demos/CachingBenchmark.svelte'
     import demoManifest from '$lib/demo-manifest.json'
     import { Gauge, Recycle, Zap } from '@lucide/svelte'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -20,27 +25,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'BENCHMARK',
@@ -54,8 +41,6 @@
             sourceUrl: `${SOURCE_URL}caching-performance/demos/CachingBenchmark.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet benchmarkSection()}
@@ -102,7 +87,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/code-formatting/+page.svelte
+++ b/docs/src/routes/examples/code-formatting/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import PrettierExtension from '$lib/examples/code-formatting/demos/PrettierExtension.svelte'
     import SnippetRendered from '$lib/examples/code-formatting/demos/SnippetRendered.svelte'
     import { Code, Package, Puzzle, Tag, Wrench } from '@lucide/svelte'
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -21,27 +26,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'EXTENSION',
@@ -67,8 +54,6 @@
             sourceUrl: `${SOURCE_URL}code-formatting/demos/SnippetRendered.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet extensionSection()}
@@ -154,7 +139,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/custom-renderers/+page.svelte
+++ b/docs/src/routes/examples/custom-renderers/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import DefaultRenderers from '$lib/examples/custom-renderers/demos/DefaultRenderers.svelte'
     import FilteredRenderers from '$lib/examples/custom-renderers/demos/FilteredRenderers.svelte'
     import { Filter, Layers, Sparkles, Wrench } from '@lucide/svelte'
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -21,27 +26,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'DEFAULT',
@@ -67,8 +54,6 @@
             sourceUrl: `${SOURCE_URL}custom-renderers/demos/FilteredRenderers.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet defaultSection()}
@@ -146,7 +131,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/footnotes/+page.svelte
+++ b/docs/src/routes/examples/footnotes/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import ComponentRendered from '$lib/examples/footnotes/demos/ComponentRendered.svelte'
     import SnippetRendered from '$lib/examples/footnotes/demos/SnippetRendered.svelte'
     import { ArrowLeftRight, BookOpen, Code, Paintbrush, Puzzle } from '@lucide/svelte'
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -26,27 +31,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'COMPONENT',
@@ -72,8 +59,6 @@
             sourceUrl: `${SOURCE_URL}footnotes/demos/SnippetRendered.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet componentSection()}
@@ -159,7 +144,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/github-alerts/+page.svelte
+++ b/docs/src/routes/examples/github-alerts/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import ComponentRendered from '$lib/examples/github-alerts/demos/ComponentRendered.svelte'
     import SnippetRendered from '$lib/examples/github-alerts/demos/SnippetRendered.svelte'
     import { AlertCircle, Code, Layers, Paintbrush, Puzzle } from '@lucide/svelte'
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -26,27 +31,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'COMPONENT',
@@ -72,8 +59,6 @@
             sourceUrl: `${SOURCE_URL}github-alerts/demos/SnippetRendered.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet componentSection()}
@@ -158,7 +143,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/html-filtering/+page.svelte
+++ b/docs/src/routes/examples/html-filtering/+page.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import AllowAllHtml from '$lib/examples/html-filtering/demos/AllowAllHtml.svelte'
     import AllowOnlySafe from '$lib/examples/html-filtering/demos/AllowOnlySafe.svelte'
@@ -12,7 +18,6 @@
     // demo and the displayed code stay in lockstep with zero per-page
     // bookkeeping.
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -34,27 +39,10 @@
     // component is mounted as the body, and the manifest entry is fed
     // through CodeReferenceV2 as the toggleable code panel. Adding a new
     // policy is one new demo file + one row here.
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'UNRESTRICTED',
@@ -92,8 +80,6 @@
             sourceUrl: `${SOURCE_URL}html-filtering/demos/BlockAllHtml.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet allowAllSection()}
@@ -206,7 +192,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/linked-headings/+page.svelte
+++ b/docs/src/routes/examples/linked-headings/+page.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import DefaultHeadings from '$lib/examples/linked-headings/demos/DefaultHeadings.svelte'
     import RendererHeadings from '$lib/examples/linked-headings/demos/RendererHeadings.svelte'
     import SnippetHeadings from '$lib/examples/linked-headings/demos/SnippetHeadings.svelte'
     import { Anchor, Code, Hash, Link, Sparkles, Wrench } from '@lucide/svelte'
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -22,27 +27,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'DEFAULT',
@@ -80,8 +67,6 @@
             sourceUrl: `${SOURCE_URL}linked-headings/demos/SnippetHeadings.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet defaultSection()}
@@ -201,7 +186,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/llm-streaming/+page.svelte
+++ b/docs/src/routes/examples/llm-streaming/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import StreamingConsole from '$lib/examples/llm-streaming/demos/StreamingConsole.svelte'
     import demoManifest from '$lib/demo-manifest.json'
     import { Activity, DollarSign, Lightbulb, Zap } from '@lucide/svelte'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -25,27 +30,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'STREAMING',
@@ -59,8 +46,6 @@
             sourceUrl: `${SOURCE_URL}llm-streaming/demos/StreamingConsole.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet streamingSection()}
@@ -125,7 +110,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/marked-extensions/+page.svelte
+++ b/docs/src/routes/examples/marked-extensions/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import ComponentRendered from '$lib/examples/marked-extensions/demos/ComponentRendered.svelte'
     import SnippetRendered from '$lib/examples/marked-extensions/demos/SnippetRendered.svelte'
     import { Code, Layers, Paintbrush, Puzzle, Sigma } from '@lucide/svelte'
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -21,27 +26,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'COMPONENT',
@@ -67,8 +54,6 @@
             sourceUrl: `${SOURCE_URL}marked-extensions/demos/SnippetRendered.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet componentSection()}
@@ -155,7 +140,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/mermaid/+page.svelte
+++ b/docs/src/routes/examples/mermaid/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import ComponentRendered from '$lib/examples/mermaid/demos/ComponentRendered.svelte'
     import SnippetRendered from '$lib/examples/mermaid/demos/SnippetRendered.svelte'
     import { Code, Frame, GitBranch, Layers, Moon, Puzzle } from '@lucide/svelte'
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -26,27 +31,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'COMPONENT',
@@ -72,8 +59,6 @@
             sourceUrl: `${SOURCE_URL}mermaid/demos/SnippetRendered.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet componentSection()}
@@ -165,7 +150,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/playground/+page.svelte
+++ b/docs/src/routes/examples/playground/+page.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import MarkdownPlayground from '$lib/examples/playground/demos/MarkdownPlayground.svelte'
     import { Edit3, Eye, Zap } from '@lucide/svelte'
@@ -7,7 +13,6 @@
     // source of truth: editing the .svelte file regenerates this entry and
     // the displayed code stays in lockstep with the rendered demo.
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -23,27 +28,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'DEMO',
@@ -57,8 +44,6 @@
             sourceUrl: `${SOURCE_URL}playground/demos/MarkdownPlayground.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet playgroundSection()}
@@ -110,7 +95,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/docs/src/routes/examples/snippet-overrides/+page.svelte
+++ b/docs/src/routes/examples/snippet-overrides/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type DemoManifestEntry,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import DefaultRendering from '$lib/examples/snippet-overrides/demos/DefaultRendering.svelte'
     import WithSnippets from '$lib/examples/snippet-overrides/demos/WithSnippets.svelte'
     import { Code, Layers, Paintbrush, Sparkles } from '@lucide/svelte'
     import demoManifest from '$lib/demo-manifest.json'
-    import type { Snippet } from 'svelte'
 
     const seo = getSeoContext()
     if (seo) {
@@ -21,27 +26,9 @@
     const SOURCE_URL =
         'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
 
-    type Section = {
-        figId: string
-        tag: string
-        title: { prefix?: string; accent: string; end?: string }
-        description: string
-        snippet: Snippet
-        codeSnippet?: Snippet
-        notes?: Snippet
-        mode?: 'live' | 'static'
-        barCells?: { k: string; v: string }[]
-        sourceUrl?: string
-    }
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
 
-    type ManifestEntry = {
-        code: string
-        lang: string
-        html?: { light: string; dark: string }
-    }
-    const manifest = demoManifest as Record<string, ManifestEntry>
-
-    const sections: Section[] = [
+    const sections: ExampleSection[] = [
         {
             figId: 'FIG-001',
             tag: 'DEFAULT',
@@ -67,8 +54,6 @@
             sourceUrl: `${SOURCE_URL}snippet-overrides/demos/WithSnippets.svelte`
         }
     ]
-
-    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
 {#snippet defaultSection()}
@@ -153,7 +138,7 @@
         title={section.title}
         description={section.description}
         mode={section.mode ?? 'live'}
-        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        sheetLabel={formatSheetLabel(i, sections.length)}
         barCells={section.barCells}
         sourceUrl={section.sourceUrl}
         codeSnippet={section.codeSnippet}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.5.27
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/006da929e586e7e702dd258cc99cad31bc3bac53(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)
+        specifier: github:humanspeak/docs-kit#2026.5.31
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/75d04f5228a399b8cd64a03bc0e2830f87a43c70(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -831,8 +831,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/006da929e586e7e702dd258cc99cad31bc3bac53':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/006da929e586e7e702dd258cc99cad31bc3bac53}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/75d04f5228a399b8cd64a03bc0e2830f87a43c70':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/75d04f5228a399b8cd64a03bc0e2830f87a43c70}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4561,7 +4561,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/006da929e586e7e702dd258cc99cad31bc3bac53(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/75d04f5228a399b8cd64a03bc0e2830f87a43c70(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)':
     dependencies:
       '@humanspeak/svelte-motion': 0.4.5(svelte@5.55.8)
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.55.8)


### PR DESCRIPTION
## Summary

Post-merge refresh against the latest docs-kit (`2026.5.27` → `2026.5.31`) plus the one user-facing page the brutalist sweep left behind.

### docs-kit upgrade highlights (5.27 → 5.31)

| Tag | Headline | Adopted as |
|---|---|---|
| `2026.5.28` | `stripComments` + `stripWrappers` plugin options | Available; not yet needed by our demos |
| `2026.5.29` | Drop empty `<style></style>` after orphan-rule strip | Verified manifest has zero hits |
| `2026.5.30` | Resolve manifest paths from Vite project root, not `process.cwd()` | Verified manifests land in `docs/src/lib/`, no workspace-root stragglers |
| `2026.5.31` | `.dk-ex-body { flex: 1 1 auto }` + shared `ExampleSection`/`DemoManifestEntry` types + `formatSheetLabel` helper + `dk-demo-shell` convention | **Types adopted across all 13 example pages**; flex change applies transparently |

### Changes

📐 **`refactor(docs): adopt shared ExampleSection types from docs-kit 2026.5.31`** (15 files, +136 / −330)

Every one of the 13 `/examples/*` `+page.svelte` files now imports `ExampleSection` + `DemoManifestEntry` + `formatSheetLabel` from docs-kit instead of redeclaring `type Section`, `type ManifestEntry`, and `const pad2` locally.

| Before | After |
|---|---|
| `type Section = { figId; tag; title; ... }` (×13) | `import type { ExampleSection }` |
| `type ManifestEntry = { code; lang; html? }` (×13) | `import type { DemoManifestEntry }` |
| `const pad2 = ...` + inline template literal sheetLabel (×13) | `formatSheetLabel(i, sections.length)` |
| `import type { Snippet } from 'svelte'` (×13) | dropped — shared type carries its own |

Single source of truth for the section shape. If `ExampleV2`'s props ever drift, all consumers update through a single docs-kit bump.

🎨 **`refactor(docs): re-skin /docs/examples with brutalist chrome`** (1 file, +286 / −130)

The `/docs/examples` hub was the last user-facing page still on the colorful-gradient-tile aesthetic. Rewrites with:

- Mono kicker (`// docs / examples`) + lowercase mono `h1` with accent
- Numbered categories (01–04) with item-count chips
- Hairline-bordered tile cards — no gradients, no fadeInUp animation
- `WALKTHROUGH` vs `LIVE DEMO` tags distinguish static `.svx` pages from live editors at `/examples/<slug>`
- Quick Reference table with brut typography
- Drops the Best Practices section (content was duplicated from category tiles)

Stays inside `DocsLayoutV2` so the docs sidebar + breadcrumbs + TOC continue working — this is a content-area rewrite, not a layout swap.

## Test plan

- [ ] `pnpm install` resolves docs-kit `2026.5.31`
- [ ] Visit every `/examples/<slug>` page — sheet labels render (`SHEET 01 / 02`, etc.) and notes column still shows code chips
- [ ] Visit `/docs/examples` — numbered categories, WALKTHROUGH/LIVE DEMO tags, Quick Reference table render cleanly in both light and dark mode
- [ ] svelte-check passes (12 pre-existing title-type errors from the brutalist sweep should be gone — `ExampleSection`'s wider type absorbs them)
- [ ] Mobile breakpoint (≤720 px) — `/docs/examples` tile grid collapses to 1 column

🤖 Generated with [Claude Code](https://claude.com/claude-code)