### PR TITLE
docs: docMirrorsPlugin + brut blog chrome + slimmer header nav

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,6 @@
 .wrangler/
 static/og-default.png
 static/twitter-default.png
+static/docs/
 src/lib/sitemap-manifest.json
 src/lib/demo-manifest.json

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.33",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.34",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.16.47",
         "marked-code-format": "^1.1.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.31",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.33",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.16.47",
         "marked-code-format": "^1.1.6",

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -35,9 +35,7 @@ import {
  */
 export const headerNav: { label: string; href: string }[] = [
     { label: 'docs', href: '/docs' },
-    { label: 'api', href: '/docs/api/svelte-markdown' },
     { label: 'examples', href: '/examples' },
-    { label: 'playground', href: '/examples/playground' },
     { label: 'compare', href: '/compare' },
     { label: 'blog', href: '/blog' }
 ]

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -64,10 +64,21 @@ const itemBreadcrumbOverrides: Record<string, string> = {
  * "/docs/renderers/html-renderers"). Falls back to `[{ title: 'Docs' }]`
  * when no match is found.
  */
+/** Pretty titles for individual blog posts, keyed by slug. */
+const blogPostTitles: Record<string, string> = {
+    'rendering-agent-html-safely': 'Rendering Agent HTML Safely'
+}
+
 export const buildBreadcrumbs = (pathname: string): Breadcrumb[] => {
     if (pathname === '/docs') return [{ title: 'Docs' }]
     if (pathname === '/examples') return [{ title: 'Examples' }]
     if (pathname === '/compare') return [{ title: 'Compare' }]
+    if (pathname === '/blog' || pathname === '/blog/') return [{ title: 'Blog' }]
+    if (pathname.startsWith('/blog/')) {
+        const slug = pathname.replace('/blog/', '').replace(/\/$/, '')
+        const title = blogPostTitles[slug] ?? slug
+        return [{ title: 'Blog', href: '/blog' }, { title }]
+    }
 
     for (const section of docsSections) {
         for (const item of section.items) {

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -631,17 +631,22 @@ Happy coding! <span style="color: hotpink">♥</span>`
                         </p>
                         <div class="ai-cell-foot">~24 kB · open ↗</div>
                     </a>
-                    <a class="ai-cell" href="/examples/agent-output" rel="noopener">
-                        <div class="ai-cell-k">03 · live demos</div>
+                    <a
+                        class="ai-cell"
+                        href="/docs/getting-started.md"
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        <div class="ai-cell-k">03 · per-page mirrors</div>
                         <h3>
-                            <code>/examples/*</code>
+                            <code>/docs/&lt;slug&gt;.md</code>
                         </h3>
                         <p>
-                            13 interactive examples — agent streaming with live sanitization, LLM
-                            chunks with offset patches, caching benchmark. The patterns the agent
-                            should generate.
+                            Every doc page mirrored as raw markdown — Svelte scripts stripped,
+                            fenced code preserved. The citation surface ChatGPT, Perplexity, and
+                            Claude prefer.
                         </p>
-                        <div class="ai-cell-foot">13 demos · open ↗</div>
+                        <div class="ai-cell-foot">21 docs · open ↗</div>
                     </a>
                 </div>
                 <div class="ai-prompt">

--- a/docs/src/routes/blog/+layout.svelte
+++ b/docs/src/routes/blog/+layout.svelte
@@ -1,11 +1,25 @@
 <script lang="ts">
     import favicon from '$lib/assets/logo.svg'
     import { docsConfig } from '$lib/docs-config'
-    import { BlogLayout } from '@humanspeak/docs-kit/blog'
+    import { buildBreadcrumbs, headerNav } from '$lib/docsNav'
+    import { enhanceCodeBlocks } from '@humanspeak/docs-kit'
+    import { BlogLayoutV2 } from '@humanspeak/docs-kit/blog'
+    import rootPkg from '../../../../package.json'
+    import '@fontsource-variable/inter/index.css'
+    import '@fontsource-variable/jetbrains-mono/index.css'
 
     const { children } = $props()
+    const PKG_VERSION = rootPkg.version
 </script>
 
-<BlogLayout config={docsConfig} {favicon}>
-    {@render children?.()}
-</BlogLayout>
+<BlogLayoutV2
+    config={docsConfig}
+    {favicon}
+    version={PKG_VERSION}
+    nav={headerNav}
+    breadcrumbResolver={buildBreadcrumbs}
+>
+    <div class="flex flex-1 flex-col" use:enhanceCodeBlocks>
+        {@render children?.()}
+    </div>
+</BlogLayoutV2>

--- a/docs/src/routes/blog/+page.svelte
+++ b/docs/src/routes/blog/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import { BlogIndex, loadBlogPostsMdsvex } from '@humanspeak/docs-kit/blog'
+    import { BlogIndexV2, loadBlogPostsMdsvex } from '@humanspeak/docs-kit/blog'
 
     const modules = import.meta.glob('/src/routes/blog/*/+page.svx', { eager: true })
     const posts = loadBlogPostsMdsvex(modules)
@@ -17,4 +17,4 @@
     }
 </script>
 
-<BlogIndex {posts} />
+<BlogIndexV2 {posts} />

--- a/docs/src/routes/blog/rendering-agent-html-safely/+page.svx
+++ b/docs/src/routes/blog/rendering-agent-html-safely/+page.svx
@@ -13,7 +13,7 @@ readingTime: 9
 ---
 
 <script lang="ts">
-    import { BlogPost, type BlogPostMeta } from '@humanspeak/docs-kit/blog'
+    import { BlogPostV2, type BlogPostMeta } from '@humanspeak/docs-kit/blog'
     import { docsConfig } from '$lib/docs-config'
 
     const post: BlogPostMeta = {
@@ -28,7 +28,7 @@ readingTime: 9
     }
 </script>
 
-<BlogPost {post} config={docsConfig}>
+<BlogPostV2 {post} config={docsConfig}>
 
 A few weeks ago, [Thariq](https://x.com/trq212) wrote a post called [Using Claude Code: The Unreasonable Effectiveness of HTML](https://x.com/trq212/status/2052809885763747935). His thesis is short and, if you’ve been paying attention to how people are actually using coding agents, hard to argue with:
 
@@ -255,4 +255,4 @@ We’d rather you know about every sharp edge up front than discover one in prod
 
 — Jason Kummerl
 
-</BlogPost>
+</BlogPostV2>

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -150,7 +150,7 @@ Route semantic markup like `<thinking>`, `<tool-call>`, or any custom element to
 - [Rendering Agent HTML Safely (blog post)](https://markdown.svelte.page/blog/rendering-agent-html-safely)
 - [Full LLM Reference](https://markdown.svelte.page/llms-full.txt)
 
-Every documentation page also has a raw-Markdown mirror at the same URL with a `.md` suffix — e.g. `https://markdown.svelte.page/docs/getting-started.md`, `https://markdown.svelte.page/docs/advanced-security.md`. The mirror strips Svelte scripts + component tags, preserves fenced code, and carries a source-attribution header so LLMs (ChatGPT, Perplexity, Claude) can cite the canonical HTML doc.
+Every documentation page is also mirrored as raw Markdown under `/docs/<slug>.md` — e.g. `https://markdown.svelte.page/docs/getting-started.md`, `https://markdown.svelte.page/docs/advanced-security.md`. The mirror strips Svelte scripts + component tags, preserves fenced code, and carries a source-attribution header so LLMs (ChatGPT, Perplexity, Claude) can cite the canonical HTML doc.
 
 ## Links
 

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -150,6 +150,8 @@ Route semantic markup like `<thinking>`, `<tool-call>`, or any custom element to
 - [Rendering Agent HTML Safely (blog post)](https://markdown.svelte.page/blog/rendering-agent-html-safely)
 - [Full LLM Reference](https://markdown.svelte.page/llms-full.txt)
 
+Every documentation page also has a raw-Markdown mirror at the same URL with a `.md` suffix — e.g. `https://markdown.svelte.page/docs/getting-started.md`, `https://markdown.svelte.page/docs/advanced-security.md`. The mirror strips Svelte scripts + component tags, preserves fenced code, and carries a source-attribution header so LLMs (ChatGPT, Perplexity, Claude) can cite the canonical HTML doc.
+
 ## Links
 
 - Homepage: <https://markdown.svelte.page>

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,19 +1,31 @@
-import { demoManifestPlugin, sitemapManifestPlugin } from '@humanspeak/docs-kit/vite'
+import {
+    demoManifestPlugin,
+    docMirrorsPlugin,
+    sitemapManifestPlugin
+} from '@humanspeak/docs-kit/vite'
 import { sveltekit } from '@sveltejs/kit/vite'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-    // Both manifest plugins emit JSON into `src/lib/`:
+    // Three docs-kit plugins run on `buildStart` and rewatch via Vite's
+    // own file watcher — no chokidar process, no package.json scripts to
+    // maintain.
     //   * `demoManifestPlugin`     scans `src/lib/examples/<...>/demos/*.svelte`
-    //     and writes pre-highlighted source into `demo-manifest.json`.
+    //     and writes pre-highlighted source into `src/lib/demo-manifest.json`.
     //   * `sitemapManifestPlugin`  scans `src/routes/**/+page.{svelte,svx,md}`
-    //     and writes `sitemap-manifest.json` (the input to `sitemap.xml`).
-    // Both run on `buildStart` and rewatch via Vite's own file watcher —
-    // no chokidar process, no package.json scripts to maintain.
+    //     and writes `src/lib/sitemap-manifest.json` (the input to
+    //     `sitemap.xml`).
+    //   * `docMirrorsPlugin`       scans `src/routes/docs/**/+page.svx`,
+    //     strips Svelte scripts + component tags while preserving fenced
+    //     code blocks, and emits clean Markdown to `static/docs/<slug>.md`.
+    //     Served verbatim at `https://markdown.svelte.page/docs/<slug>.md`
+    //     so LLM crawlers (ChatGPT, Perplexity, Claude) can cite the
+    //     source the way they prefer.
     plugins: [
         sitemapManifestPlugin({ blogDir: false }),
         demoManifestPlugin(),
+        docMirrorsPlugin({ siteUrl: 'https://markdown.svelte.page' }),
         tailwindcss(),
         sveltekit()
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.5.33
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/2fe12c35941eaa600ef093e7879a10ffd5a10685(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)
+        specifier: github:humanspeak/docs-kit#2026.5.34
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/c59e85c774a3b34bb9c5375e2f3b13a77eeced14(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -831,8 +831,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/2fe12c35941eaa600ef093e7879a10ffd5a10685':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/2fe12c35941eaa600ef093e7879a10ffd5a10685}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/c59e85c774a3b34bb9c5375e2f3b13a77eeced14':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/c59e85c774a3b34bb9c5375e2f3b13a77eeced14}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4561,7 +4561,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/2fe12c35941eaa600ef093e7879a10ffd5a10685(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/c59e85c774a3b34bb9c5375e2f3b13a77eeced14(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)':
     dependencies:
       '@humanspeak/svelte-motion': 0.4.5(svelte@5.55.8)
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.55.8)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.5.31
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/75d04f5228a399b8cd64a03bc0e2830f87a43c70(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)
+        specifier: github:humanspeak/docs-kit#2026.5.33
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/2fe12c35941eaa600ef093e7879a10ffd5a10685(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -831,8 +831,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/75d04f5228a399b8cd64a03bc0e2830f87a43c70':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/75d04f5228a399b8cd64a03bc0e2830f87a43c70}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/2fe12c35941eaa600ef093e7879a10ffd5a10685':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/2fe12c35941eaa600ef093e7879a10ffd5a10685}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4561,7 +4561,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/75d04f5228a399b8cd64a03bc0e2830f87a43c70(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/2fe12c35941eaa600ef093e7879a10ffd5a10685(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)':
     dependencies:
       '@humanspeak/svelte-motion': 0.4.5(svelte@5.55.8)
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.55.8)


### PR DESCRIPTION
## Summary

Three follow-ups landing on top of merged #301: pull in docs-kit's new `docMirrorsPlugin` so every doc page has a `.md` mirror at `https://markdown.svelte.page/docs/<slug>.md`, trim the header nav from six items to four (drop redundant `api` and `playground` deep links), and adopt the freshly released BlogV2 brut surfaces so `/blog` and `/blog/<slug>` stop being the only routes on the legacy Tailwind-prose chrome.

## Changes

✨ Features
- Wire `docMirrorsPlugin` from docs-kit `2026.5.33` — 21 doc pages now emit clean `.md` mirrors at build time with Svelte scripts stripped and fenced code preserved (LLM citation surface for ChatGPT/Perplexity/Claude). Home-page FIG-006 AI-READY cell 03 + `llms.txt` updated to point at the real mirrors.
- Adopt brut chrome on the blog via docs-kit `2026.5.34` (`BlogLayoutV2` / `BlogIndexV2` / `BlogPostV2`) — coord strip, FIG-001 hero, Inter prose body, header nav + breadcrumb consistent with the rest of the site. `buildBreadcrumbs` taught to resolve `/blog` and `/blog/<slug>` to `Blog` / `Blog › <pretty title>` instead of falling back to `Docs`.

🔧 Improvements
- Trim header nav: 6 items → 4 (`docs · examples · compare · blog`). `api` was just `/docs/api/svelte-markdown` (reachable via the docs sidebar) and `playground` was just one card in the examples index. Reclaims ~⅓ of the header row width.

📦 Dependencies
- `@humanspeak/docs-kit` pin `2026.5.31` → `2026.5.34` (picks up docMirrorsPlugin, description-through-SvelteMarkdown for ExampleV2 inline code chips, and the new BlogV2 components).

## Commits

- [`d095ac9`](https://github.com/humanspeak/svelte-markdown/commit/d095ac9) feat(docs): wire docMirrorsPlugin from docs-kit 2026.5.33
- [`e022ced`](https://github.com/humanspeak/svelte-markdown/commit/e022ced) chore(docs): trim header nav to four primary surfaces
- [`85a5d59`](https://github.com/humanspeak/svelte-markdown/commit/85a5d59) feat(blog): adopt BlogLayoutV2 / BlogIndexV2 / BlogPostV2 chrome
