### PR TITLE
fix(docs): drop duplicate <meta name="description"> on homepage

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.36",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.39",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.16.47",
         "marked-code-format": "^1.1.6",

--- a/docs/src/lib/docs-config.ts
+++ b/docs/src/lib/docs-config.ts
@@ -7,7 +7,7 @@ export const docsConfig: DocsKitConfig = {
     repo: 'humanspeak/svelte-markdown',
     url: 'https://markdown.svelte.page',
     description:
-        'A powerful, customizable markdown and HTML renderer for Svelte 5 — built for rendering streaming AI agent output from Claude Code, ChatGPT, and agentic workflows. TypeScript-first, 24 renderers, 69+ HTML tags, token caching, XSS-safe defaults, and allow/deny utilities.',
+        'A powerful, customizable markdown and HTML renderer for Svelte 5 — built for rendering streaming AI agent output from Claude Code, ChatGPT, and agentic workflows. TypeScript-first, 24 renderers, 84 HTML tags, token caching, XSS-safe defaults, and allow/deny utilities.',
     keywords: [
         'svelte',
         'markdown',

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { HeaderV2, FooterV2, getBreadcrumbContext } from '@humanspeak/docs-kit'
+    import { HeaderV2, FooterV2, getBreadcrumbContext, getSeoContext } from '@humanspeak/docs-kit'
     import { docsConfig } from '$lib/docs-config'
     import favicon from '$lib/assets/logo.svg'
     import SvelteMarkdown, { rendererKeys, htmlRendererKeys } from '@humanspeak/svelte-markdown'
@@ -21,6 +21,16 @@
 
     const breadcrumbContext = getBreadcrumbContext()
     if (breadcrumbContext) breadcrumbContext.breadcrumbs = []
+
+    // Homepage-specific SEO copy. Mutated synchronously so SSR emits the
+    // right <title>/<meta name="description"> in one pass — docs-kit's
+    // SeoHead renders after children and reads these reactively. Counts
+    // come from the live renderer keys so they can never drift.
+    const seo = getSeoContext()
+    if (seo) {
+        seo.title = 'svelte-markdown · streaming markdown + HTML renderer for Svelte 5'
+        seo.description = `A streaming-aware markdown + HTML renderer for Svelte 5. ${rendererKeys.length} renderers, ${htmlRendererKeys.length} HTML tags, allow/deny utilities, XSS-safe defaults, and a streaming mode tuned for LLM output. MIT, zero runtime deps.`
+    }
 
     // ── Package stats are fetched from the npm registry at request
     // time by `+page.server.ts` (cached for ~1 hour at the edge and in
@@ -308,14 +318,6 @@ Happy coding! <span style="color: hotpink">♥</span>`
         }
     }
 </script>
-
-<svelte:head>
-    <title>svelte-markdown · streaming markdown + HTML renderer for Svelte 5</title>
-    <meta
-        name="description"
-        content="A streaming-aware markdown + HTML renderer for Svelte 5. 24 renderers, 84 HTML tags, allow/deny utilities, XSS-safe defaults, and a streaming mode tuned for LLM output. MIT, zero runtime deps."
-    />
-</svelte:head>
 
 <div class="brut-wrap flex min-h-svh flex-col">
     <HeaderV2 config={docsConfig} {favicon} version={PKG_VERSION} nav={headerNav} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.5.36
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/b602a2706867fd1a881c2e6eee27b7f34d501e05(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)
+        specifier: github:humanspeak/docs-kit#2026.5.39
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/4152af23562dfa3bce9e038fcc2d78e58931c173(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -831,8 +831,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/b602a2706867fd1a881c2e6eee27b7f34d501e05':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/b602a2706867fd1a881c2e6eee27b7f34d501e05}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/4152af23562dfa3bce9e038fcc2d78e58931c173':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/4152af23562dfa3bce9e038fcc2d78e58931c173}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4561,7 +4561,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/b602a2706867fd1a881c2e6eee27b7f34d501e05(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/4152af23562dfa3bce9e038fcc2d78e58931c173(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.4.5(svelte@5.55.8))(@internationalized/date@3.12.1)(@lucide/svelte@1.16.0(svelte@5.55.8))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8))(shiki@4.1.0)(svelte@5.55.8)':
     dependencies:
       '@humanspeak/svelte-motion': 0.4.5(svelte@5.55.8)
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.55.8)


### PR DESCRIPTION
## Summary

Clears the Ahrefs-flagged duplicate `<meta name="description">` on the homepage. The site was emitting two contradictory description tags — docs-kit's `SeoHead` plus a hand-rolled one in `<svelte:head>` — and Google was picking one arbitrarily. Library code is untouched, hence `skip-publish`.

## Changes

🐛 **Homepage was emitting two `<meta name="description">` tags**
- docs-kit's `SeoHead` (inside `RootLayout`) emits one for every page, resolving as `seo.description ?? $page.data.description ?? config.description`. On the homepage that fell back to `config.description` → "69+ HTML tags".
- `docs/src/routes/+page.svelte` *also* hand-rolled its own `<title>` + `<meta name="description">` in `<svelte:head>` → "84 HTML tags".
- Two tags, two contradictory copies — fixed.

🔧 **Switched the homepage to the docs-kit-native SEO override pattern**
- Removed the hand-rolled `<svelte:head>` block from `+page.svelte`.
- Added a synchronous `getSeoContext()` mutation in the page script. SeoHead renders *after* `{@render children()}` in `RootLayout`, so SSR emits the right tag in one pass — no flash, no post-hydration patch, JS-less crawlers (social-card unfurls, LLM/SEO bots) see the correct copy.
- Counts now interpolate from `rendererKeys.length` / `htmlRendererKeys.length` so they can't drift again.

📦 **`@humanspeak/docs-kit` → `2026.5.39`**
- Carries the upstream SSR-safe `applySeo()` fix to `BlogPost`, `BlogPostV2`, `ComparisonPageV2`, `CompareIndexV2` — those components were setting `seo.*` inside `$effect`, which is client-only, so their SSR'd HTML was shipping the config fallback instead of the per-page copy until hydration patched it.

✏️ **Stale count corrected**
- `docs-config.ts`: `69+ HTML tags` → `84 HTML tags` (used in JSON-LD and as every-other-page's description fallback). The 84 number is the source of truth — `htmlRendererKeys.length` and the actual file count in `src/lib/renderers/html/`.

## Verification after merge

```bash
curl -s https://markdown.svelte.page | grep -c 'name="description"'
# Expect: 1 (was: 2)
```

Ahrefs's duplicate-meta finding should clear on the next crawl.

## Commits

- [`dd4df7a`](https://github.com/humanspeak/svelte-markdown/commit/dd4df7a) fix(docs): drop duplicate `<meta name="description">` on homepage

Supersedes #305 (which carried this fix on a stale branch that already contained squashed-merged work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
