### PR TITLE
docs: document dynamic extension cache behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,51 @@ To find the token type names for any extension, check its source or documentatio
 
 Each snippet/component receives the token's properties as props (e.g., `text`, `displayMode` for KaTeX; `text`, `level` for alerts).
 
+### Dynamic Extension Objects
+
+SvelteMarkdown includes extension identity in its internal parser cache. If you replace an extension object, tokenizer object, or tokenizer function, the parser treats that as a new parsing configuration and re-parses the source.
+
+This means extension factories can safely close over reactive state:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+    import type { MarkedExtension } from 'marked'
+
+    let displayFormat = $state<'decimal' | 'percent'>('decimal')
+
+    const makeDisplayExtension = (format: 'decimal' | 'percent'): MarkedExtension => ({
+        extensions: [
+            {
+                name: 'displayValue',
+                level: 'inline',
+                tokenizer(src) {
+                    const match = /^\((\d+)\)/.exec(src)
+                    if (!match) return
+
+                    return {
+                        type: 'displayValue',
+                        raw: match[0],
+                        text: match[1],
+                        displayFormat: format
+                    }
+                }
+            }
+        ]
+    })
+
+    const extensions = $derived([makeDisplayExtension(displayFormat)])
+</script>
+
+<SvelteMarkdown source="(42)" {extensions}>
+    {#snippet displayValue(props)}
+        <span data-format={props.displayFormat}>{props.text}</span>
+    {/snippet}
+</SvelteMarkdown>
+```
+
+When `displayFormat` changes from `decimal` to `percent`, the new extension object invalidates the cached parse even though the markdown source is unchanged. The updated token props flow into your renderer or snippet without requiring a manual cache key.
+
 See the [full documentation](https://markdown.svelte.page/docs/advanced/marked-extensions) and [interactive demo](https://markdown.svelte.page/examples/marked-extensions).
 
 ### TypeScript

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.2",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.5",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.17.0",
         "marked-code-format": "^1.1.6",

--- a/docs/src/lib/examples/LlmStreaming.svelte
+++ b/docs/src/lib/examples/LlmStreaming.svelte
@@ -135,12 +135,6 @@ For more information, visit the [Svelte documentation](https://svelte.dev/docs) 
     let renderCount = $state(0)
     let droppedFrames = $state(0)
 
-    const avgRenderTime = $derived(renderCount > 0 ? totalRenderTime / renderCount : 0)
-    const progress = $derived(
-        chunks.length > 0 ? Math.round((chunkIndex / chunks.length) * 100) : 0
-    )
-    const chunkedStreamActive = $derived(streamMode === 'chunked' || streamMode === 'offset')
-
     // Internals
     let timeoutId: ReturnType<typeof setTimeout> | null = null
     let chunks: StreamingChunk[] = $state([])
@@ -149,6 +143,12 @@ For more information, visit the [Svelte documentation](https://svelte.dev/docs) 
     let rafId = 0
     let sessionId = 0
     let previewEl: HTMLDivElement | undefined = $state()
+
+    const avgRenderTime = $derived(renderCount > 0 ? totalRenderTime / renderCount : 0)
+    const progress = $derived(
+        chunks.length > 0 ? Math.round((chunkIndex / chunks.length) * 100) : 0
+    )
+    const chunkedStreamActive = $derived(streamMode === 'chunked' || streamMode === 'offset')
 
     // --- Chunking ---
     const splitIntoChunks = (text: string, mode: typeof chunkMode): string[] => {

--- a/docs/src/lib/examples/footnotes/demos/SnippetRendered.svelte
+++ b/docs/src/lib/examples/footnotes/demos/SnippetRendered.svelte
@@ -2,6 +2,14 @@
     import SvelteMarkdown from '@humanspeak/svelte-markdown'
     import { markedFootnote } from '@humanspeak/svelte-markdown/extensions'
 
+    type FootnoteRefProps = {
+        id: string
+    }
+
+    type FootnoteSectionProps = {
+        footnotes: { id: string; text: string }[]
+    }
+
     const markdown = `## Footnotes
 
 Footnotes let you add references without cluttering the main text.
@@ -28,13 +36,13 @@ When documenting APIs, footnotes[^api] help explain edge cases without breaking 
 -->
 <div class="prose prose-sm dark:prose-invert mx-auto max-w-4xl px-6 py-6">
     <SvelteMarkdown source={markdown} extensions={[markedFootnote()]}>
-        {#snippet footnoteRef(props)}
+        {#snippet footnoteRef(props: FootnoteRefProps)}
             <sup class="fn-ref">
                 <a href="#fn-{props.id}" id="fnref-{props.id}">[{props.id}]</a>
             </sup>
         {/snippet}
 
-        {#snippet footnoteSection(props)}
+        {#snippet footnoteSection(props: FootnoteSectionProps)}
             <section class="fn-section" role="doc-endnotes">
                 <h3 class="fn-section-title">Footnotes</h3>
                 <ol>

--- a/docs/src/lib/examples/github-alerts/demos/SnippetRendered.svelte
+++ b/docs/src/lib/examples/github-alerts/demos/SnippetRendered.svelte
@@ -3,6 +3,11 @@
     import { markedAlert } from '@humanspeak/svelte-markdown/extensions'
     import { AlertCircle, AlertTriangle, Info, Lightbulb, ShieldAlert } from '@lucide/svelte'
 
+    type AlertSnippetProps = {
+        alertType: 'note' | 'tip' | 'important' | 'warning' | 'caution'
+        text: string
+    }
+
     const markdown = `## GitHub Alerts
 
 GitHub-style alerts highlight critical information in documentation.
@@ -35,7 +40,7 @@ Regular markdown works alongside alerts: **bold**, *italic*, and \`inline code\`
 -->
 <div class="prose prose-sm dark:prose-invert mx-auto max-w-4xl px-6 py-6">
     <SvelteMarkdown source={markdown} extensions={[markedAlert()]}>
-        {#snippet alert(props)}
+        {#snippet alert(props: AlertSnippetProps)}
             <aside class="ga-alert ga-alert-{props.alertType}" role="note">
                 <span class="ga-alert-icon">
                     {#if props.alertType === 'note'}

--- a/docs/src/lib/examples/llm-streaming/demos/StreamingConsole.svelte
+++ b/docs/src/lib/examples/llm-streaming/demos/StreamingConsole.svelte
@@ -103,12 +103,6 @@ For more information, visit the [Svelte documentation](https://svelte.dev/docs).
     let renderCount = $state(0)
     let droppedFrames = $state(0)
 
-    const avgRenderTime = $derived(renderCount > 0 ? totalRenderTime / renderCount : 0)
-    const progress = $derived(
-        chunks.length > 0 ? Math.round((chunkIndex / chunks.length) * 100) : 0
-    )
-    const chunkedStreamActive = $derived(streamMode === 'chunked' || streamMode === 'offset')
-
     let timeoutId: ReturnType<typeof setTimeout> | null = null
     let chunks: StreamingChunk[] = $state([])
     let chunkIndex = $state(0)
@@ -117,6 +111,12 @@ For more information, visit the [Svelte documentation](https://svelte.dev/docs).
     let sessionId = 0
     let previewEl: HTMLDivElement | undefined = $state()
     let sourceEl: HTMLPreElement | undefined = $state()
+
+    const avgRenderTime = $derived(renderCount > 0 ? totalRenderTime / renderCount : 0)
+    const progress = $derived(
+        chunks.length > 0 ? Math.round((chunkIndex / chunks.length) * 100) : 0
+    )
+    const chunkedStreamActive = $derived(streamMode === 'chunked' || streamMode === 'offset')
 
     const splitIntoChunks = (text: string, mode: typeof chunkMode): string[] => {
         if (mode === 'character') return text.split('')

--- a/docs/src/routes/blog/+page.svelte
+++ b/docs/src/routes/blog/+page.svelte
@@ -2,8 +2,13 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import { BlogIndexV2, loadBlogPostsMdsvex } from '@humanspeak/docs-kit/blog'
 
+    type MdsvexModule = {
+        metadata?: Record<string, unknown>
+        default?: unknown
+    }
+
     const modules = import.meta.glob('/src/routes/blog/*/+page.svx', { eager: true })
-    const posts = loadBlogPostsMdsvex(modules)
+    const posts = loadBlogPostsMdsvex(modules as Record<string, MdsvexModule>)
 
     const seo = getSeoContext()
     if (seo) {

--- a/docs/src/routes/docs/advanced/marked-extensions/+page.svx
+++ b/docs/src/routes/docs/advanced/marked-extensions/+page.svx
@@ -31,6 +31,51 @@ Marked extensions define custom token types, each with a `name` property (e.g., 
 
 Each snippet or component receives the token's own properties as props. For example, the built-in `markedKatex` produces tokens with `text` and `displayMode`, so your renderer gets `{ text: string, displayMode: boolean }`.
 
+### Dynamic Extension Objects
+
+SvelteMarkdown includes extension identity in its internal parser cache. If you replace an extension object, tokenizer object, or tokenizer function, the parser treats that as a new parsing configuration and re-parses the source.
+
+That matters when an extension factory closes over reactive state:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+    import type { MarkedExtension } from 'marked'
+
+    let displayFormat = $state<'decimal' | 'percent'>('decimal')
+
+    const makeDisplayExtension = (format: 'decimal' | 'percent'): MarkedExtension => ({
+        extensions: [
+            {
+                name: 'displayValue',
+                level: 'inline',
+                tokenizer(src) {
+                    const match = /^\((\d+)\)/.exec(src)
+                    if (!match) return
+
+                    return {
+                        type: 'displayValue',
+                        raw: match[0],
+                        text: match[1],
+                        displayFormat: format
+                    }
+                }
+            }
+        ]
+    })
+
+    const extensions = $derived([makeDisplayExtension(displayFormat)])
+</script>
+
+<SvelteMarkdown source="(42)" {extensions}>
+    {#snippet displayValue(props)}
+        <span data-format={props.displayFormat}>{props.text}</span>
+    {/snippet}
+</SvelteMarkdown>
+```
+
+When `displayFormat` changes from `decimal` to `percent`, the new extension object invalidates the cached parse even though the markdown source is unchanged. The updated token props then flow into your renderer or snippet without requiring a manual cache key or workaround.
+
 ### Finding Token Type Names
 
 To discover the snippet/renderer names for any extension, check the `name` field in its `extensions` array:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.6.2
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@internationalized/date@3.12.1)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+        specifier: github:humanspeak/docs-kit#2026.6.5
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/e1198d98213319920f43eceaa83eef3a5b7854b1(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@internationalized/date@3.12.1)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -835,8 +835,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/e1198d98213319920f43eceaa83eef3a5b7854b1':
+    resolution: {gitHosted: true, integrity: sha512-6DRISAXr36xDU6zHqvAmCPZdY3tQJyjljfrj/dv8D6JAu3xrb2IdKbfZjGmRL+ACNpyBeEMyED8ZNJ1Q34RGrQ==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/e1198d98213319920f43eceaa83eef3a5b7854b1}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4574,7 +4574,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@internationalized/date@3.12.1)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/e1198d98213319920f43eceaa83eef3a5b7854b1(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@internationalized/date@3.12.1)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
     dependencies:
       '@humanspeak/svelte-motion': 0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.0(@typescript-eslint/types@8.60.0))


### PR DESCRIPTION
## Summary

Document the new dynamic extension cache behavior so users know extension factories can safely close over reactive state. This also updates the docs site to docs-kit 2026.6.5 and keeps the affected docs examples compatible with the newer checks.

## Changes

📚 Documentation

- Add a Dynamic Extension Objects section to the README and marked extensions docs.
- Show a Svelte example where replacing an extension object invalidates the parser cache without a manual cache key.

📦 Dependency changes

- Update docs-kit from 2026.6.2 to 2026.6.5.
- Refresh the lockfile for the new docs-kit commit.

🔧 Docs compatibility

- Move derived values after their backing state in streaming examples.
- Add explicit snippet prop types for footnote and GitHub alert examples.
- Type the mdsvex blog module map passed into docs-kit.

## Commits

- [`9512bf3`](https://github.com/humanspeak/svelte-markdown/commit/9512bf3de633bf9e9f8a5c6b735941c9f9f2fefa) docs: document dynamic extension cache behavior
- [`4762384`](https://github.com/humanspeak/svelte-markdown/commit/47623842411f2e7bf667974fe138d20d4a9fc335) build(docs): update docs-kit to 2026.6.5
