### PR TITLE
docs: address SEO audit issues

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.9",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.10",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.17.0",
         "marked-code-format": "^1.1.6",

--- a/docs/src/lib/compare-data.ts
+++ b/docs/src/lib/compare-data.ts
@@ -36,7 +36,7 @@ export const competitors: Competitor[] = [
         name: 'MDsveX',
         tagline: 'Build-Time Preprocessor vs Runtime Component',
         description:
-            'MDsveX is the most popular Svelte markdown tool — a preprocessor that lets you write Svelte components inside .svx files at build time. @humanspeak/svelte-markdown renders markdown at runtime as a Svelte component.',
+            'Compare MDsveX and @humanspeak/svelte-markdown: build-time .svx preprocessing versus runtime Svelte 5 markdown rendering, caching, and HTML control.',
         website: 'https://mdsvex.pngwn.io',
         github: 'https://github.com/pngwn/MDsveX',
         npm: 'mdsvex',
@@ -148,7 +148,7 @@ export const competitors: Competitor[] = [
         name: 'Tiptap',
         tagline: 'Heavyweight Editor vs Lightweight Renderer',
         description:
-            'Tiptap is a headless rich text editor built on ProseMirror with Svelte support via svelte-tiptap. @humanspeak/svelte-markdown is a focused markdown renderer — not an editor.',
+            'Compare Tiptap and @humanspeak/svelte-markdown: a ProseMirror rich text editor versus a focused Svelte 5 markdown renderer for display-only content.',
         website: 'https://tiptap.dev',
         github: 'https://github.com/ueberdosis/tiptap',
         npm: '@tiptap/core',
@@ -222,7 +222,7 @@ export const competitors: Competitor[] = [
         name: 'markdown-it',
         tagline: 'Raw Parser vs Svelte Component',
         description:
-            'markdown-it is a fast, pluggable markdown parser that outputs raw HTML strings. @humanspeak/svelte-markdown wraps the marked parser in a native Svelte component with renderers, caching, and HTML control.',
+            'Compare markdown-it and @humanspeak/svelte-markdown: raw HTML string parsing versus typed Svelte 5 renderers with caching, snippets, and HTML control.',
         website: 'https://markdown-it.github.io',
         github: 'https://github.com/markdown-it/markdown-it',
         npm: 'markdown-it',
@@ -320,7 +320,7 @@ export const competitors: Competitor[] = [
         name: 'marked',
         tagline: 'The Engine Under Our Hood',
         description:
-            'marked is the markdown parser that powers @humanspeak/svelte-markdown. Using marked directly gives you a raw HTML string; we wrap it in a full Svelte component system with renderers, caching, and safety controls.',
+            'Compare marked and @humanspeak/svelte-markdown: direct markdown parsing versus a Svelte 5 component layer with renderers, caching, and safety controls.',
         website: 'https://marked.js.org',
         github: 'https://github.com/markedjs/marked',
         npm: 'marked',
@@ -415,7 +415,7 @@ export const competitors: Competitor[] = [
         name: 'Milkdown',
         tagline: 'Plugin-Driven Editor vs Focused Renderer',
         description:
-            'Milkdown is a plugin-driven WYSIWYG markdown editor built on ProseMirror + remark. @humanspeak/svelte-markdown is a lightweight rendering component — not an editor.',
+            'Compare Milkdown and @humanspeak/svelte-markdown: a ProseMirror markdown editor versus a lightweight Svelte 5 component for rendering markdown content.',
         website: 'https://milkdown.dev',
         github: 'https://github.com/Milkdown/milkdown',
         npm: '@milkdown/core',
@@ -495,7 +495,7 @@ export const competitors: Competitor[] = [
         name: 'svelte-exmarkdown',
         tagline: 'Two Runtime Renderers, Different Engines',
         description:
-            'svelte-exmarkdown is an extensible runtime markdown renderer built on unified/remark/rehype. @humanspeak/svelte-markdown is built on marked. Both render markdown as Svelte components at runtime.',
+            'Compare svelte-exmarkdown and @humanspeak/svelte-markdown: unified-based runtime rendering versus marked-powered Svelte 5 renderers and streaming support.',
         github: 'https://github.com/ssssota/svelte-exmarkdown',
         npm: 'svelte-exmarkdown',
         type: 'Runtime Renderer',
@@ -575,7 +575,7 @@ export const competitors: Competitor[] = [
         name: 'Carta',
         tagline: 'Editor + Viewer vs Pure Renderer',
         description:
-            'Carta (carta-md) is a lightweight Svelte markdown editor AND viewer powered by unified/remark/rehype. @humanspeak/svelte-markdown is a focused rendering component.',
+            'Compare Carta and @humanspeak/svelte-markdown: a Svelte markdown editor and viewer versus a focused Svelte 5 renderer with caching and HTML filtering.',
         website: 'https://beartocode.github.io/carta',
         github: 'https://github.com/BearToCode/carta',
         npm: 'carta-md',
@@ -653,7 +653,7 @@ export const competitors: Competitor[] = [
         name: 'ByteMD',
         tagline: 'Full Editor vs Pure Renderer',
         description:
-            'ByteMD is a hackable markdown editor originally built with Svelte by ByteDance. It compiles to framework-agnostic JavaScript. @humanspeak/svelte-markdown is a focused Svelte 5 rendering component.',
+            'Compare ByteMD and @humanspeak/svelte-markdown: a hackable markdown editor from ByteDance versus a focused Svelte 5 renderer for app content.',
         github: 'https://github.com/pd4d10/bytemd',
         npm: 'bytemd',
         type: 'Markdown Editor',
@@ -738,7 +738,7 @@ export const competitors: Competitor[] = [
         name: 'unified / remark',
         tagline: 'AST Pipeline vs Component Renderer',
         description:
-            'unified and remark form an AST-based content processing pipeline used under the hood by MDsveX, svelte-exmarkdown, and Carta. @humanspeak/svelte-markdown uses marked for a more straightforward parse-and-render approach.',
+            'Compare unified/remark and @humanspeak/svelte-markdown: AST content pipelines versus a direct marked-based Svelte 5 renderer with practical defaults.',
         website: 'https://unifiedjs.com',
         github: 'https://github.com/remarkjs/remark',
         npm: 'unified',
@@ -820,7 +820,7 @@ export const competitors: Competitor[] = [
         name: 'ProseMirror',
         tagline: 'Editor Toolkit vs Ready-Made Renderer',
         description:
-            'ProseMirror is the low-level editor framework that powers Tiptap and Milkdown. Using it directly with Svelte requires significant assembly. @humanspeak/svelte-markdown is a ready-to-use rendering component.',
+            'Compare ProseMirror and @humanspeak/svelte-markdown: low-level editor framework assembly versus a ready-to-use Svelte 5 markdown renderer for apps.',
         website: 'https://prosemirror.net',
         github: 'https://github.com/ProseMirror/prosemirror',
         npm: 'prosemirror-model',

--- a/docs/src/lib/docs-config.ts
+++ b/docs/src/lib/docs-config.ts
@@ -7,7 +7,7 @@ export const docsConfig: DocsKitConfig = {
     repo: 'humanspeak/svelte-markdown',
     url: 'https://markdown.svelte.page',
     description:
-        'A powerful, customizable markdown and HTML renderer for Svelte 5 — built for rendering streaming AI agent output from Claude Code, ChatGPT, and agentic workflows. TypeScript-first, 24 renderers, 84 HTML tags, token caching, XSS-safe defaults, and allow/deny utilities.',
+        'Render markdown, raw HTML, and AI streams in Svelte 5 with @humanspeak/svelte-markdown: typed renderers, token caching, and safer HTML controls.',
     keywords: [
         'svelte',
         'markdown',

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -29,7 +29,7 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'svelte-markdown · streaming markdown + HTML renderer for Svelte 5'
-        seo.description = `A streaming-aware markdown + HTML renderer for Svelte 5. ${rendererKeys.length} renderers, ${htmlRendererKeys.length} HTML tags, allow/deny utilities, XSS-safe defaults, and a streaming mode tuned for LLM output. MIT, zero runtime deps.`
+        seo.description = `Render markdown, raw HTML, and LLM streams in Svelte 5 with ${rendererKeys.length} markdown renderers, ${htmlRendererKeys.length} HTML tag renderers, allow/deny utilities, and secure defaults.`
     }
 
     // ── Package stats are fetched from the npm registry at request

--- a/docs/src/routes/blog/+page.svelte
+++ b/docs/src/routes/blog/+page.svelte
@@ -14,7 +14,7 @@
     if (seo) {
         seo.title = 'Blog | Svelte Markdown'
         seo.description =
-            'Notes from the @humanspeak/svelte-markdown team on rendering streaming AI agent output safely in Svelte 5 — security, sanitization, performance, and the patterns that hold up in production.'
+            'Notes from @humanspeak/svelte-markdown on rendering streaming AI agent output safely in Svelte 5, with security, sanitization, and performance patterns.'
         seo.ogTitle = 'Svelte Markdown Blog'
         seo.ogTagline = 'Rendering agent output safely in Svelte 5.'
         seo.ogFeatures = ['Agent Output', 'XSS-Safe', 'Streaming', 'Svelte 5']

--- a/docs/src/routes/blog/rendering-agent-html-safely/+page.svx
+++ b/docs/src/routes/blog/rendering-agent-html-safely/+page.svx
@@ -1,7 +1,7 @@
 ---
 title: Rendering Agent HTML Safely
 date: 2026-05-13
-description: Thariq’s post on the unreasonable effectiveness of HTML changed how we think about agent output. Here’s how to render it safely in Svelte 5 — every defense the library gives you, with worked examples and the known gaps to plan around.
+description: Render AI-generated HTML safely in Svelte 5 with @humanspeak/svelte-markdown, covering XSS defenses, sanitization hooks, examples, and known gaps.
 tags:
     - ai-agents
     - security
@@ -21,7 +21,7 @@ readingTime: 9
         title: 'Rendering Agent HTML Safely',
         date: '2026-05-13',
         description:
-            'Thariq’s post on the unreasonable effectiveness of HTML changed how we think about agent output. Here’s how to render it safely in Svelte 5 — every defense the library gives you, with worked examples and the known gaps to plan around.',
+            'Render AI-generated HTML safely in Svelte 5 with @humanspeak/svelte-markdown, covering XSS defenses, sanitization hooks, examples, and known gaps.',
         tags: ['ai-agents', 'security', 'streaming', 'xss', 'svelte-5'],
         author: 'Jason Kummerl',
         readingTime: 9

--- a/docs/src/routes/docs/advanced/agent-output/+page.svx
+++ b/docs/src/routes/docs/advanced/agent-output/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Rendering AI Agent Output
-description: Render streaming HTML and markdown from Claude Code, ChatGPT, and agentic workflows with XSS-safe defaults, sanitization-aware streaming, and custom HTML tag support.
+description: Render streaming HTML and markdown from AI coding agents with @humanspeak/svelte-markdown, including XSS-safe defaults and custom HTML tag routing.
 ---
 
 <script>
@@ -10,7 +10,7 @@ description: Render streaming HTML and markdown from Claude Code, ChatGPT, and a
     if (seo) {
         seo.title = 'Rendering AI Agent Output | Svelte Markdown'
         seo.description =
-            'Render streaming HTML and markdown output from AI coding agents — Claude Code, ChatGPT, Codex, agentic workflows — with XSS-safe defaults, sanitization-aware streaming, and custom HTML tag routing.'
+            'Render streaming HTML and markdown from AI coding agents with @humanspeak/svelte-markdown, including XSS-safe defaults and custom HTML tag routing.'
         seo.ogTitle = 'Rendering AI Agent Output'
         seo.ogTagline = 'Built for streaming agent HTML and markdown.'
         seo.ogFeatures = [

--- a/docs/src/routes/docs/advanced/allow-deny/+page.svx
+++ b/docs/src/routes/docs/advanced/allow-deny/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Allow/Deny Filtering
-description: Control which markdown elements and HTML tags are rendered
+description: Control which markdown elements and HTML tags render in @humanspeak/svelte-markdown with allow-list and deny-list helpers for safer output in apps.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Control which markdown elements and HTML tags are rendered
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Allow/Deny Filtering | Svelte Markdown'
-        seo.description = 'Control which markdown elements and HTML tags are rendered'
+        seo.description = 'Control which markdown elements and HTML tags render in @humanspeak/svelte-markdown with allow-list and deny-list helpers for safer output in apps.'
         seo.ogTitle = 'Allow/Deny'
         seo.ogTagline = 'Control which elements and HTML tags render.'
         seo.ogFeatures = ['Allowlist', 'Denylist', 'HTML Tags', 'Markdown Tokens']

--- a/docs/src/routes/docs/advanced/headless-parser/+page.svx
+++ b/docs/src/routes/docs/advanced/headless-parser/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Headless Parser
-description: Direct access to the IncrementalParser for headless, non-Svelte, and server-side token streaming
+description: Use IncrementalParser without the Svelte component, powering headless agents, non-Svelte consumers, server pipelines, and streaming token updates.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Direct access to the IncrementalParser for headless, non-Svelte, an
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Headless Parser | Svelte Markdown'
-        seo.description = 'Use IncrementalParser directly without the Svelte component — same streaming-aware engine, exposed as a plain class for headless agents, non-Svelte consumers, and server-side pipelines.'
+        seo.description = 'Use IncrementalParser without the Svelte component, powering headless agents, non-Svelte consumers, server pipelines, and streaming token updates.'
         seo.ogTitle = 'Headless Parser'
         seo.ogTagline = 'IncrementalParser as a standalone class — same engine, no component.'
         seo.ogFeatures = ['Headless API', 'Streaming Tokens', 'divergeAt Diffing', 'Framework-Agnostic']

--- a/docs/src/routes/docs/advanced/llm-streaming/+page.svx
+++ b/docs/src/routes/docs/advanced/llm-streaming/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: LLM Streaming
-description: Render AI chat responses in real-time with token-by-token markdown streaming
+description: Render AI chat responses in real time with @humanspeak/svelte-markdown, using token-by-token streaming for ChatGPT-style Svelte app interfaces.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Render AI chat responses in real-time with token-by-token markdown 
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'LLM Streaming | Svelte Markdown'
-        seo.description = 'Render AI chat responses in real-time with token-by-token markdown streaming. Build ChatGPT-style streaming UIs with SvelteMarkdown.'
+        seo.description = 'Render AI chat responses in real time with @humanspeak/svelte-markdown, using token-by-token streaming for ChatGPT-style Svelte app interfaces.'
         seo.ogTitle = 'LLM Streaming'
         seo.ogTagline = 'Real-time AI response rendering for Svelte apps.'
         seo.ogFeatures = ['Token Streaming', 'SSE Support', 'Sub-10ms Renders', 'Zero Config']

--- a/docs/src/routes/docs/advanced/marked-extensions/+page.svx
+++ b/docs/src/routes/docs/advanced/marked-extensions/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Marked Extensions
-description: How to use built-in and third-party marked extensions like KaTeX math rendering with @humanspeak/svelte-markdown
+description: Use built-in and third-party marked extensions with @humanspeak/svelte-markdown for KaTeX math, custom tokens, syntax tools, and async rendering.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: How to use built-in and third-party marked extensions like KaTeX ma
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Marked Extensions | Svelte Markdown'
-        seo.description = 'How to use built-in and third-party marked extensions like KaTeX math rendering with @humanspeak/svelte-markdown'
+        seo.description = 'Use built-in and third-party marked extensions with @humanspeak/svelte-markdown for KaTeX math, custom tokens, syntax tools, and async rendering.'
         seo.ogTitle = 'Marked Extensions'
         seo.ogTagline = 'Add KaTeX, syntax highlighting, and more.'
         seo.ogFeatures = ['KaTeX Math', 'Custom Tokens', 'Third Party', 'Plugin System']

--- a/docs/src/routes/docs/advanced/security/+page.svx
+++ b/docs/src/routes/docs/advanced/security/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Security
-description: Security considerations, XSS protection, and sanitization guidance for @humanspeak/svelte-markdown
+description: Review security guidance for @humanspeak/svelte-markdown, including XSS protection, URL and attribute sanitization, HTML filtering, and safe usage.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Security considerations, XSS protection, and sanitization guidance 
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Security | Svelte Markdown'
-        seo.description = 'Security considerations, XSS protection, and sanitization guidance for @humanspeak/svelte-markdown'
+        seo.description = 'Review security guidance for @humanspeak/svelte-markdown, including XSS protection, URL and attribute sanitization, HTML filtering, and safe usage.'
         seo.ogTitle = 'Security'
         seo.ogTagline = 'XSS protection and sanitization guidance.'
         seo.ogFeatures = ['XSS Protection', 'URL Sanitization', 'Attribute Sanitization', 'Secure Parsing', 'Best Practices']

--- a/docs/src/routes/docs/advanced/token-caching/+page.svx
+++ b/docs/src/routes/docs/advanced/token-caching/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Token Caching
-description: Performance optimization through built-in LRU token caching
+description: Use built-in LRU token caching in @humanspeak/svelte-markdown to speed repeat renders, tune TTL and cache size, and inspect parse performance.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Performance optimization through built-in LRU token caching
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Token Caching | Svelte Markdown'
-        seo.description = 'Performance optimization through built-in LRU token caching'
+        seo.description = 'Use built-in LRU token caching in @humanspeak/svelte-markdown to speed repeat renders, tune TTL and cache size, and inspect parse performance.'
         seo.ogTitle = 'Token Caching'
         seo.ogTagline = '50-200x faster re-renders with built-in LRU caching.'
         seo.ogFeatures = ['50-200x Faster', 'LRU Cache', 'Auto Caching', 'TTL Expiry']

--- a/docs/src/routes/docs/advanced/tree-shaking/+page.svx
+++ b/docs/src/routes/docs/advanced/tree-shaking/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Tree Shaking
-description: Import paths and bundler best practices for keeping @humanspeak/svelte-markdown bundles lean
+description: Keep @humanspeak/svelte-markdown bundles lean with subpath imports, optional peer dependencies, and bundler practices for KaTeX and Mermaid.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Import paths and bundler best practices for keeping @humanspeak/sve
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Tree Shaking | Svelte Markdown'
-        seo.description = 'Import paths and bundler best practices for keeping @humanspeak/svelte-markdown bundles lean'
+        seo.description = 'Keep @humanspeak/svelte-markdown bundles lean with subpath imports, optional peer dependencies, and bundler practices for KaTeX and Mermaid.'
         seo.ogTitle = 'Tree Shaking'
         seo.ogTagline = 'Keep optional renderers and heavy peers out until you use them.'
         seo.ogFeatures = ['Subpath Imports', 'Optional Peers', 'KaTeX', 'Mermaid', 'Bundle Checks']

--- a/docs/src/routes/docs/api/svelte-markdown/+page.svx
+++ b/docs/src/routes/docs/api/svelte-markdown/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: SvelteMarkdown Component
-description: Complete API reference for the SvelteMarkdown component
+description: Use the SvelteMarkdown component API: props, renderers, snippets, extensions, parsed callbacks, inline mode, token input, and TypeScript types.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Complete API reference for the SvelteMarkdown component
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'SvelteMarkdown Component API | Svelte Markdown'
-        seo.description = 'Complete API reference for the SvelteMarkdown component'
+        seo.description = 'Use the SvelteMarkdown component API: props, renderers, snippets, extensions, parsed callbacks, inline mode, token input, and TypeScript types.'
         seo.ogTitle = 'Component API'
         seo.ogTagline = 'Props, events, and configuration for SvelteMarkdown.'
         seo.ogFeatures = ['Props Reference', 'Event Callbacks', 'Token Input', 'Inline Mode']

--- a/docs/src/routes/docs/api/types/+page.svx
+++ b/docs/src/routes/docs/api/types/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Types & Exports
-description: All exported types, functions, constants, and utilities from @humanspeak/svelte-markdown
+description: Explore exported types, functions, constants, cache classes, renderer keys, and utility helpers from @humanspeak/svelte-markdown for Svelte 5.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: All exported types, functions, constants, and utilities from @human
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Types & Exports | Svelte Markdown'
-        seo.description = 'All exported types, functions, constants, and utilities from @humanspeak/svelte-markdown'
+        seo.description = 'Explore exported types, functions, constants, cache classes, renderer keys, and utility helpers from @humanspeak/svelte-markdown for Svelte 5.'
         seo.ogTitle = 'Types & Exports'
         seo.ogTagline = 'All exported types, functions, and utilities.'
         seo.ogFeatures = ['Type Safety', 'Utility Functions', 'Constants', 'Cache Classes']

--- a/docs/src/routes/docs/examples/+page.svelte
+++ b/docs/src/routes/docs/examples/+page.svelte
@@ -6,7 +6,7 @@
     if (seo) {
         seo.title = 'Usage Examples | Svelte Markdown'
         seo.description =
-            'Real-world usage examples for @humanspeak/svelte-markdown covering basic rendering, custom renderers, HTML filtering, inline rendering, and the parsed callback.'
+            'Explore real-world @humanspeak/svelte-markdown examples covering basic rendering, custom renderers, HTML filtering, inline mode, and parsed callbacks.'
         seo.ogTitle = 'Usage Examples'
         seo.ogTagline = 'Real-world patterns for rendering markdown.'
         seo.ogFeatures = ['Basic Rendering', 'Custom Renderers', 'HTML Filtering', 'Inline Mode']

--- a/docs/src/routes/docs/examples/basic-rendering/+page.svx
+++ b/docs/src/routes/docs/examples/basic-rendering/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Basic Rendering
-description: Common markdown rendering examples with @humanspeak/svelte-markdown
+description: Learn common @humanspeak/svelte-markdown rendering patterns for strings, token arrays, reactive updates, SvelteKit usage, and default output.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Common markdown rendering examples with @humanspeak/svelte-markdown
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Basic Rendering Examples | Svelte Markdown'
-        seo.description = 'Common markdown rendering examples with @humanspeak/svelte-markdown'
+        seo.description = 'Learn common @humanspeak/svelte-markdown rendering patterns for strings, token arrays, reactive updates, SvelteKit usage, and default output.'
         seo.ogTitle = 'Basic Rendering'
         seo.ogTagline = 'Common markdown rendering patterns and examples.'
         seo.ogFeatures = ['String Input', 'Token Input', 'Reactive Updates', 'SvelteKit']

--- a/docs/src/routes/docs/examples/custom-renderers/+page.svx
+++ b/docs/src/routes/docs/examples/custom-renderers/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Custom Renderers Examples
-description: Practical examples of creating and using custom renderer components
+description: See practical custom renderer examples for @humanspeak/svelte-markdown, including links, code blocks, images, typed props, and reusable components.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Practical examples of creating and using custom renderer components
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Custom Renderers Examples | Svelte Markdown'
-        seo.description = 'Practical examples of creating and using custom renderer components'
+        seo.description = 'See practical custom renderer examples for @humanspeak/svelte-markdown, including links, code blocks, images, typed props, and reusable components.'
         seo.ogTitle = 'Custom Renderers'
         seo.ogTagline = 'Practical examples of custom renderer components.'
         seo.ogFeatures = ['Link Override', 'Code Blocks', 'Image Renderer', 'Practical Code']

--- a/docs/src/routes/docs/examples/html-filtering/+page.svx
+++ b/docs/src/routes/docs/examples/html-filtering/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: HTML Filtering Examples
-description: Practical examples of filtering HTML tags in markdown content
+description: Filter HTML tags in markdown content with @humanspeak/svelte-markdown examples for blocking all HTML, allow-listing tags, and deny-list rules.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Practical examples of filtering HTML tags in markdown content
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'HTML Filtering Examples | Svelte Markdown'
-        seo.description = 'Practical examples of filtering HTML tags in markdown content'
+        seo.description = 'Filter HTML tags in markdown content with @humanspeak/svelte-markdown examples for blocking all HTML, allow-listing tags, and deny-list rules.'
         seo.ogTitle = 'HTML Filtering'
         seo.ogTagline = 'Control which HTML tags render from markdown.'
         seo.ogFeatures = ['Block All HTML', 'Allowlist Tags', 'Denylist Tags', 'Safe Rendering']

--- a/docs/src/routes/docs/examples/inline-rendering/+page.svx
+++ b/docs/src/routes/docs/examples/inline-rendering/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Inline Rendering
-description: Examples of using the isInline prop for inline markdown rendering
+description: Render inline markdown with @humanspeak/svelte-markdown using the isInline prop for span-friendly text, links, emphasis, and compact UI contexts.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Examples of using the isInline prop for inline markdown rendering
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Inline Rendering Examples | Svelte Markdown'
-        seo.description = 'Examples of using the isInline prop for inline markdown rendering'
+        seo.description = 'Render inline markdown with @humanspeak/svelte-markdown using the isInline prop for span-friendly text, links, emphasis, and compact UI contexts.'
         seo.ogTitle = 'Inline Rendering'
         seo.ogTagline = 'Render markdown inline without block-level elements.'
         seo.ogFeatures = ['isInline Prop', 'No Block Elements', 'Inline Context', 'Span Friendly']

--- a/docs/src/routes/docs/examples/linked-headings/+page.svx
+++ b/docs/src/routes/docs/examples/linked-headings/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Linked Headings Examples
-description: How to add clickable anchor links to markdown headings using snippet overrides and custom renderers
+description: Add clickable anchor links to markdown headings with @humanspeak/svelte-markdown using snippet overrides, custom renderers, and slugged IDs.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: How to add clickable anchor links to markdown headings using snippe
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Linked Headings Examples | Svelte Markdown'
-        seo.description = 'How to add clickable anchor links to markdown headings using snippet overrides and custom renderers'
+        seo.description = 'Add clickable anchor links to markdown headings with @humanspeak/svelte-markdown using snippet overrides, custom renderers, and slugged IDs.'
         seo.ogTitle = 'Linked Headings'
         seo.ogTagline = 'Clickable anchor links for headings.'
         seo.ogFeatures = ['Snippet Override', 'Custom Renderer', 'Hover Reveal', 'Permalink']

--- a/docs/src/routes/docs/examples/parsed-callback/+page.svx
+++ b/docs/src/routes/docs/examples/parsed-callback/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Parsed Callback
-description: Examples of using the parsed callback prop to inspect and use token data
+description: Use the parsed callback prop in @humanspeak/svelte-markdown to inspect token data, build tables of contents, count words, and analyze content.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Examples of using the parsed callback prop to inspect and use token
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Parsed Callback Examples | Svelte Markdown'
-        seo.description = 'Examples of using the parsed callback prop to inspect and use token data'
+        seo.description = 'Use the parsed callback prop in @humanspeak/svelte-markdown to inspect token data, build tables of contents, count words, and analyze content.'
         seo.ogTitle = 'Parsed Callback'
         seo.ogTagline = 'Inspect and use token data at parse time.'
         seo.ogFeatures = ['Token Inspector', 'Word Count', 'TOC Builder', 'Content Analysis']

--- a/docs/src/routes/docs/examples/snippet-overrides/+page.svx
+++ b/docs/src/routes/docs/examples/snippet-overrides/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Snippet Overrides Examples
-description: Practical examples of using Svelte 5 snippet overrides to customize markdown rendering inline
+description: Use Svelte 5 snippet overrides in @humanspeak/svelte-markdown to customize markdown rendering inline for links, code, images, and paragraphs.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Practical examples of using Svelte 5 snippet overrides to customize
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Snippet Overrides Examples | Svelte Markdown'
-        seo.description = 'Practical examples of using Svelte 5 snippet overrides to customize markdown rendering inline'
+        seo.description = 'Use Svelte 5 snippet overrides in @humanspeak/svelte-markdown to customize markdown rendering inline for links, code, images, and paragraphs.'
         seo.ogTitle = 'Snippet Overrides'
         seo.ogTagline = 'Inline rendering customization examples.'
         seo.ogFeatures = ['Paragraph Style', 'Link Target', 'Code Highlight', 'Image Wrap']

--- a/docs/src/routes/docs/getting-started/+page.svx
+++ b/docs/src/routes/docs/getting-started/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Get started with @humanspeak/svelte-markdown, a powerful markdown renderer for Svelte 5
+description: Get started fast with @humanspeak/svelte-markdown in Svelte 5: install the package, render markdown, enable TypeScript, and customize output.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Get started with @humanspeak/svelte-markdown, a powerful markdown r
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Getting Started | Svelte Markdown'
-        seo.description = 'Get started with @humanspeak/svelte-markdown, a powerful markdown renderer for Svelte 5'
+        seo.description = 'Get started fast with @humanspeak/svelte-markdown in Svelte 5: install the package, render markdown, enable TypeScript, and customize output.'
         seo.ogTitle = 'Getting Started'
         seo.ogTagline = 'Install, configure, and render your first markdown in minutes.'
         seo.ogFeatures = ['Quick Install', 'Svelte 5', 'TypeScript', 'SvelteKit Ready']

--- a/docs/src/routes/docs/migration/+page.svx
+++ b/docs/src/routes/docs/migration/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Migration Guide
-description: Migrate from svelte-markdown to @humanspeak/svelte-markdown for Svelte 5 with improved TypeScript support, caching, and new features
+description: Migrate from svelte-markdown to @humanspeak/svelte-markdown for Svelte 5 with TypeScript support, token caching, streaming, and new renderer APIs.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Migrate from svelte-markdown to @humanspeak/svelte-markdown for Sve
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Migration Guide | Svelte Markdown'
-        seo.description = 'Migrate from svelte-markdown to @humanspeak/svelte-markdown for Svelte 5 with improved TypeScript support, caching, and new features'
+        seo.description = 'Migrate from svelte-markdown to @humanspeak/svelte-markdown for Svelte 5 with TypeScript support, token caching, streaming, and new renderer APIs.'
         seo.ogTitle = 'Migration Guide'
         seo.ogTagline = 'Upgrade from svelte-markdown to Svelte 5.'
         seo.ogFeatures = ['Svelte 5 Upgrade', 'API Changes', 'New Features', 'Step by Step']

--- a/docs/src/routes/docs/renderers/custom-renderers/+page.svx
+++ b/docs/src/routes/docs/renderers/custom-renderers/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Custom Renderers
-description: Guide to creating custom renderer components for @humanspeak/svelte-markdown
+description: Create custom renderer components for @humanspeak/svelte-markdown, override built-ins, pass typed props, and tailor markdown output in Svelte 5.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Guide to creating custom renderer components for @humanspeak/svelte
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Custom Renderers | Svelte Markdown'
-        seo.description = 'Guide to creating custom renderer components for @humanspeak/svelte-markdown'
+        seo.description = 'Create custom renderer components for @humanspeak/svelte-markdown, override built-ins, pass typed props, and tailor markdown output in Svelte 5.'
         seo.ogTitle = 'Custom Renderers'
         seo.ogTagline = 'Build your own Svelte renderer components.'
         seo.ogFeatures = ['Component Override', 'Full Control', 'Type Safe', 'Svelte 5']

--- a/docs/src/routes/docs/renderers/html-renderers/+page.svx
+++ b/docs/src/routes/docs/renderers/html-renderers/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: HTML Renderers
-description: Documentation for all 69+ built-in HTML tag renderer components
+description: Browse all built-in HTML tag renderer components in @humanspeak/svelte-markdown, with tag coverage, override patterns, and allow/deny filtering.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Documentation for all 69+ built-in HTML tag renderer components
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'HTML Renderers | Svelte Markdown'
-        seo.description = 'Documentation for all 69+ built-in HTML tag renderer components'
+        seo.description = 'Browse all built-in HTML tag renderer components in @humanspeak/svelte-markdown, with tag coverage, override patterns, and allow/deny filtering.'
         seo.ogTitle = 'HTML Renderers'
         seo.ogTagline = '69+ built-in HTML tag renderer components.'
         seo.ogFeatures = ['69+ HTML Tags', 'Allow/Deny', 'Custom Override', 'Secure Parsing']

--- a/docs/src/routes/docs/renderers/markdown-renderers/+page.svx
+++ b/docs/src/routes/docs/renderers/markdown-renderers/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Markdown Renderers
-description: Documentation for all 24 built-in markdown renderer components
+description: Browse all built-in markdown renderer components in @humanspeak/svelte-markdown, including token props, override patterns, and Svelte 5 examples.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Documentation for all 24 built-in markdown renderer components
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Markdown Renderers | Svelte Markdown'
-        seo.description = 'Documentation for all 24 built-in markdown renderer components'
+        seo.description = 'Browse all built-in markdown renderer components in @humanspeak/svelte-markdown, including token props, override patterns, and Svelte 5 examples.'
         seo.ogTitle = 'Markdown Renderers'
         seo.ogTagline = '24 built-in token renderer components.'
         seo.ogFeatures = ['24 Renderers', 'Custom Override', 'Snippet Overrides', 'Full GFM']

--- a/docs/src/routes/docs/renderers/snippet-overrides/+page.svx
+++ b/docs/src/routes/docs/renderers/snippet-overrides/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Snippet Overrides
-description: Customize markdown rendering inline using Svelte 5 snippets — no separate files needed
+description: Customize markdown rendering inline with Svelte 5 snippets in @humanspeak/svelte-markdown, no separate renderer files required for common overrides.
 ---
 
 <script>
@@ -9,7 +9,7 @@ description: Customize markdown rendering inline using Svelte 5 snippets — no 
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Snippet Overrides | Svelte Markdown'
-        seo.description = 'Customize markdown rendering inline using Svelte 5 snippets — no separate files needed'
+        seo.description = 'Customize markdown rendering inline with Svelte 5 snippets in @humanspeak/svelte-markdown, no separate renderer files required for common overrides.'
         seo.ogTitle = 'Snippet Overrides'
         seo.ogTagline = 'Customize rendering inline with Svelte 5 snippets.'
         seo.ogFeatures = ['Svelte 5 Snippets', 'Inline Override', 'No Extra Files', 'Type Safe']

--- a/docs/src/routes/examples/agent-output/+page.svelte
+++ b/docs/src/routes/examples/agent-output/+page.svelte
@@ -13,8 +13,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'AI Agent Output | Examples | Svelte Markdown'
+        seo.h1 = { title: 'AI Agent Output' }
         seo.description =
-            'Watch @humanspeak/svelte-markdown render streaming HTML from a simulated AI agent — with live sanitization that blocks javascript: URLs and on*= event handlers as they arrive.'
+            'Watch @humanspeak/svelte-markdown render streaming HTML from a simulated AI agent, with live sanitization blocking unsafe URLs and event handlers.'
         seo.ogTitle = 'AI Agent Output Demo'
         seo.ogTagline = 'Streaming agent HTML with live XSS sanitization.'
         seo.ogFeatures = [

--- a/docs/src/routes/examples/caching-performance/+page.svelte
+++ b/docs/src/routes/examples/caching-performance/+page.svelte
@@ -13,8 +13,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Caching Performance | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Caching Performance' }
         seo.description =
-            'Explore the built-in LRU TokenCache in @humanspeak/svelte-markdown — measure cold vs warm render times, watch the cache size grow, and see the 50–200× speedup on repeat renders.'
+            'Explore the built-in LRU TokenCache in @humanspeak/svelte-markdown, measuring cold and warm render times plus repeat-render speedups in the demo.'
         seo.ogTitle = 'Caching Performance'
         seo.ogTagline = 'Measure the LRU token cache live — cold render vs cached render.'
         seo.ogFeatures = ['LRU Cache', '50–200× Speedup', 'Live Metrics', 'Render Log']

--- a/docs/src/routes/examples/code-formatting/+page.svelte
+++ b/docs/src/routes/examples/code-formatting/+page.svelte
@@ -14,8 +14,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Code Formatting | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Code Formatting' }
         seo.description =
-            'Two ways to format code blocks in @humanspeak/svelte-markdown — the async marked-code-format walkTokens extension (Prettier-powered) and an inline {#snippet code} override.'
+            'Format code blocks in @humanspeak/svelte-markdown with an async marked-code-format walkTokens extension or an inline Svelte 5 code snippet override.'
         seo.ogTitle = 'Code Formatting'
         seo.ogTagline = 'walkTokens extension vs snippet override on code fences.'
         seo.ogFeatures = ['Prettier walkTokens', 'Snippet Override', 'Language Badge', 'Lazy Load']

--- a/docs/src/routes/examples/custom-renderers/+page.svelte
+++ b/docs/src/routes/examples/custom-renderers/+page.svelte
@@ -14,8 +14,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Custom Renderers | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Custom Renderers' }
         seo.description =
-            'Two renderer policies for @humanspeak/svelte-markdown — see the same markdown rendered with the default renderer set vs an allow-list via allowRenderersOnly.'
+            'Compare renderer policies in @humanspeak/svelte-markdown, rendering the same markdown with defaults and an allow-list via allowRenderersOnly.'
         seo.ogTitle = 'Custom Renderers'
         seo.ogTagline = 'Default vs filtered renderers — side by side.'
         seo.ogFeatures = ['Default Renderers', 'Filtered Renderers', 'allowRenderersOnly']

--- a/docs/src/routes/examples/footnotes/+page.svelte
+++ b/docs/src/routes/examples/footnotes/+page.svelte
@@ -14,8 +14,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Footnotes | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Footnotes' }
         seo.description =
-            'Academic-style footnotes in @humanspeak/svelte-markdown via the markedFootnote extension, rendered two ways: built-in FootnoteRef + FootnoteSection components vs inline Svelte 5 snippet overrides.'
+            'Render academic-style footnotes in @humanspeak/svelte-markdown with markedFootnote, using built-in components or inline Svelte 5 snippet overrides.'
         seo.ogTitle = 'Footnotes'
         seo.ogTagline = 'Component renderers vs snippet overrides on the markedFootnote extension.'
         seo.ogFeatures = [

--- a/docs/src/routes/examples/github-alerts/+page.svelte
+++ b/docs/src/routes/examples/github-alerts/+page.svelte
@@ -14,8 +14,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'GitHub Alerts | Examples | Svelte Markdown'
+        seo.h1 = { title: 'GitHub Alerts' }
         seo.description =
-            'GitHub-style alert admonitions in @humanspeak/svelte-markdown — five severity levels (NOTE / TIP / IMPORTANT / WARNING / CAUTION) via the markedAlert extension, rendered two ways: built-in AlertRenderer component vs inline Svelte 5 snippet.'
+            'Render GitHub-style alert admonitions in @humanspeak/svelte-markdown with markedAlert, using AlertRenderer components or inline Svelte 5 snippets.'
         seo.ogTitle = 'GitHub Alerts'
         seo.ogTagline = 'Component renderer vs snippet override on the markedAlert extension.'
         seo.ogFeatures = [

--- a/docs/src/routes/examples/html-filtering/+page.svelte
+++ b/docs/src/routes/examples/html-filtering/+page.svelte
@@ -14,8 +14,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'HTML Filtering | Examples | Svelte Markdown'
+        seo.h1 = { title: 'HTML Filtering' }
         seo.description =
-            'Three HTML filtering policies for @humanspeak/svelte-markdown — see the same markdown rendered under unrestricted, safe-only, and blocked policies side-by-side.'
+            'Compare HTML filtering policies in @humanspeak/svelte-markdown, rendering the same markdown with unrestricted, safe-only, and blocked tag rules.'
         seo.ogTitle = 'HTML Filtering'
         seo.ogTagline = 'Allow all, allow only safe, block all — three policies, three sheets.'
         seo.ogFeatures = ['Unrestricted', 'Safe Only', 'Blocked']

--- a/docs/src/routes/examples/linked-headings/+page.svelte
+++ b/docs/src/routes/examples/linked-headings/+page.svelte
@@ -15,8 +15,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Linked Headings | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Linked Headings' }
         seo.description =
-            'Three ways to add clickable anchor links to markdown headings with @humanspeak/svelte-markdown — default rendering, a dedicated heading component, and an inline Svelte 5 snippet.'
+            'Add clickable anchor links to markdown headings with @humanspeak/svelte-markdown using default output, a custom heading renderer, or Svelte 5 snippets.'
         seo.ogTitle = 'Linked Headings'
         seo.ogTagline = 'Default vs custom-renderer vs snippet — three takes on heading anchors.'
         seo.ogFeatures = ['Default Headings', 'Custom Renderer', 'Snippet Override']

--- a/docs/src/routes/examples/llm-streaming/+page.svelte
+++ b/docs/src/routes/examples/llm-streaming/+page.svelte
@@ -13,8 +13,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'LLM Streaming | Examples | Svelte Markdown'
+        seo.h1 = { title: 'LLM Streaming' }
         seo.description =
-            'Simulate real model streaming with @humanspeak/svelte-markdown — out-of-order offset patches, adjustable speed and jitter, live render metrics. See how SvelteMarkdown converges as ChatGPT / Claude / Gemini-style chunks arrive.'
+            'Simulate model streaming with @humanspeak/svelte-markdown: offset patches, speed and jitter controls, live metrics, and converging markdown output.'
         seo.ogTitle = 'LLM Streaming Demo'
         seo.ogTagline = 'Out-of-order offset patches with live render metrics.'
         seo.ogFeatures = [

--- a/docs/src/routes/examples/marked-extensions/+page.svelte
+++ b/docs/src/routes/examples/marked-extensions/+page.svelte
@@ -14,8 +14,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Marked Extensions | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Marked Extensions' }
         seo.description =
-            'Live KaTeX math rendering with @humanspeak/svelte-markdown via the markedKatex extension. Two takes: built-in KatexRenderer component vs an inline Svelte 5 snippet that calls katex.renderToString directly.'
+            'Render live KaTeX math in @humanspeak/svelte-markdown with markedKatex, using a built-in KatexRenderer component or an inline Svelte 5 snippet.'
         seo.ogTitle = 'Marked Extensions'
         seo.ogTagline = 'KaTeX math via the extensions prop — component vs snippet.'
         seo.ogFeatures = ['KaTeX Math', 'Live Preview', 'Component Renderer', 'Snippet Override']

--- a/docs/src/routes/examples/mermaid/+page.svelte
+++ b/docs/src/routes/examples/mermaid/+page.svelte
@@ -14,8 +14,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Mermaid Diagrams | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Mermaid Diagrams' }
         seo.description =
-            'Live Mermaid diagram rendering with @humanspeak/svelte-markdown via the markedMermaid extension. Two takes: built-in MermaidRenderer component vs an inline Svelte 5 snippet that wraps it with custom chrome.'
+            'Render live Mermaid diagrams in @humanspeak/svelte-markdown with markedMermaid, using a MermaidRenderer component or an inline Svelte 5 snippet.'
         seo.ogTitle = 'Mermaid Diagrams'
         seo.ogTagline = 'Async diagram rendering with editable markdown — component vs snippet.'
         seo.ogFeatures = [

--- a/docs/src/routes/examples/playground/+page.svelte
+++ b/docs/src/routes/examples/playground/+page.svelte
@@ -12,8 +12,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Live Playground | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Live Playground' }
         seo.description =
-            'Interactive markdown playground with live preview. Edit markdown and HTML in real-time, powered by @humanspeak/svelte-markdown.'
+            'Try an interactive @humanspeak/svelte-markdown playground with live preview, editable markdown and HTML, renderer behavior, and Svelte 5 output.'
         seo.ogTitle = 'Live Playground'
         seo.ogTagline = 'Edit markdown and HTML with real-time preview.'
         seo.ogFeatures = ['Edit & Preview', 'Real-Time', 'Markdown + HTML', 'Full Editor']

--- a/docs/src/routes/examples/reactive-extensions/+page.svelte
+++ b/docs/src/routes/examples/reactive-extensions/+page.svelte
@@ -13,8 +13,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Reactive Extensions | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Reactive Extensions' }
         seo.description =
-            'A live Svelte 5 example showing how to dynamically rebuild marked extensions for @humanspeak/svelte-markdown when extension state changes.'
+            'Build reactive marked extensions for @humanspeak/svelte-markdown in Svelte 5, dynamically rebuilding extension state without duplicate token handlers.'
         seo.ogTitle = 'Reactive Extensions'
         seo.ogTagline = 'Dynamic marked extension state without pushing duplicate extensions.'
         seo.ogFeatures = ['Svelte 5 Runes', 'Marked Extensions', 'Custom Tokens', 'Live Preview']

--- a/docs/src/routes/examples/snippet-overrides/+page.svelte
+++ b/docs/src/routes/examples/snippet-overrides/+page.svelte
@@ -14,8 +14,9 @@
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Snippet Overrides | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Snippet Overrides' }
         seo.description =
-            'Two renderings for @humanspeak/svelte-markdown — default output vs inline Svelte 5 snippet overrides customizing paragraphs, headings, links, blockquotes, list items, code blocks, and table cells.'
+            'Customize @humanspeak/svelte-markdown output with inline Svelte 5 snippet overrides for paragraphs, headings, links, blockquotes, lists, code, and tables.'
         seo.ogTitle = 'Snippet Overrides'
         seo.ogTagline = 'Default vs snippet-customized rendering — same source, two looks.'
         seo.ogFeatures = ['Default Rendering', 'Snippet Overrides', 'Svelte 5 Snippets']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.6.9
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/480c160c9839e47f0856b707dff70147167ea845(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@internationalized/date@3.12.1)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+        specifier: github:humanspeak/docs-kit#2026.6.10
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5de65c4bb341e77aab593032d895ae2f1c7ad325(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@internationalized/date@3.12.1)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -835,8 +835,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/480c160c9839e47f0856b707dff70147167ea845':
-    resolution: {gitHosted: true, integrity: sha512-cj8pvPuLCOcf/taA8hR2P96xQgHqk3Pw8xPj6QTyyRE/ySiUJTrS4uEWSeFOF1MY8HfDsV1gnCehqeUaEV2cyQ==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/480c160c9839e47f0856b707dff70147167ea845}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5de65c4bb341e77aab593032d895ae2f1c7ad325':
+    resolution: {gitHosted: true, integrity: sha512-RJn8cNWkjdSYvk5D8ekOnI0ROAWvtkp1K4JLnpgTW96Iq0qq9UWZQsKgEqYETMf1ejzwO7oYB771kl7e9Q2b1w==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5de65c4bb341e77aab593032d895ae2f1c7ad325}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4574,7 +4574,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/480c160c9839e47f0856b707dff70147167ea845(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@internationalized/date@3.12.1)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5de65c4bb341e77aab593032d895ae2f1c7ad325(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@internationalized/date@3.12.1)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
     dependencies:
       '@humanspeak/svelte-motion': 0.6.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.0(@typescript-eslint/types@8.60.0))


### PR DESCRIPTION
## Summary

Addresses the Ahrefs SEO audit findings for the docs site by adding context-driven H1 metadata for example pages and normalizing rendered meta descriptions to the 140-155 character target range.

## Changes

📚 Documentation
- Updates the docs app to `@humanspeak/docs-kit#2026.6.10` so pages can provide `seo.h1` metadata through docs-kit.
- Replaces temporary manual hidden H1s on the example detail pages with `seo.h1 = { title }`.
- Rewrites docs, blog, examples, compare, and docs config descriptions so they fit the 140-155 character SEO target.

🧪 Testing
- Verified `pnpm --filter docs check` passes.
- Verified `pnpm --filter docs build` passes.
- Verified description length checks and example H1 coverage locally.

## Commits

- [`846a4d8`](https://github.com/humanspeak/svelte-markdown/commit/846a4d8dc12d73048c45cdfe35f6d2a3e4b716cb) docs: address SEO audit issues
