### PR TITLE
ci: drop Node 20 from CI matrix

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -16,7 +16,7 @@ jobs:
         environment: ci
         strategy:
             matrix:
-                node-version: [20, 22, 24]
+                node-version: [22, 24]
         steps:
             - name: Checkout
               uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -206,7 +206,7 @@ jobs:
         environment: ci
         strategy:
             matrix:
-                node-version: [20, 22, 24]
+                node-version: [22, 24]
         permissions:
             contents: read
             packages: write


### PR DESCRIPTION
## What

Removes **Node 20** from the CI test matrix (`node-version: [20, 22, 24]` → `[22, 24]`) across every workflow that defines it (`npm-publish.yml`, `coveralls.yml`, and `run-tests.yml` where present).

## Why

Node 20 is EOL and the pinned `pnpm` (via `packageManager`) no longer supports it — the Node 20 matrix leg fails at install with `ERR_PNPM_UNSUPPORTED_ENGINE` (seen on the svelte-purify publish run). Keeping 22 + 24 covers current LTS and current. The Coveralls gate that keys on Node 22 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)