### PR TITLE
feat: vite 8 support

### DIFF
--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -50,9 +50,6 @@ function parseStats(s) {
         renderOnlyMs: num(grab('renderOnlyMs')),
         domNodes: num(grab('domNodes')),
         charsPerSec: num(grab('charsPerSec')),
-        // Dev-mode Parser-instance counter — the non-wall-clock signal
-        // that cracked open the original render investigation.
-        parserInstances: num(grab('parserInstances')),
         // Per-scenario observer snapshots (filtered to the scenario's
         // [start, end] window — not the rolling-10s aggregate below).
         scenarioLongestTaskMs: num(grab('scenarioLongestTaskMs')),

--- a/src/lib/Parser.branches.test.ts
+++ b/src/lib/Parser.branches.test.ts
@@ -34,18 +34,13 @@ const baseRenderers = {
 } as const
 
 /**
- * Helper to create a snippet override that renders a wrapper element with a data-testid,
- * and renders its children inside.
+ * Helper to wrap a single token shape as the root `tokens` array Parser now
+ * consumes. After the snippet-recursion refactor, Parser no longer accepts a
+ * `type` prop — instead every token (including the "root" one in these
+ * branch tests) flows through `renderToken` via the top-level `tokens` array.
  */
-function makeSnippet(testId: string) {
-    return createRawSnippet(() => ({
-        render: () => `<div data-testid="${testId}"></div>`,
-        setup(node: Element) {
-            // Access the children snippet from the props that will be set
-            // Since createRawSnippet doesn't get props with children,
-            // we just verify the element is mounted
-        }
-    }))
+function root(token: Record<string, unknown>): { tokens: Record<string, unknown>[] } {
+    return { tokens: [token] }
 }
 
 describe('Parser branch coverage', () => {
@@ -60,12 +55,14 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'table',
-                header,
-                rows,
-                align: ['left'],
+                ...root({
+                    type: 'table',
+                    header,
+                    rows,
+                    align: ['left']
+                }),
                 renderers
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -108,13 +105,15 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'table',
-                header,
-                rows,
-                align: ['left'],
+                ...root({
+                    type: 'table',
+                    header,
+                    rows,
+                    align: ['left']
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { table: tableSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -132,13 +131,15 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'table',
-                header,
-                rows,
-                align: ['left'],
+                ...root({
+                    type: 'table',
+                    header,
+                    rows,
+                    align: ['left']
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { tablehead: theadSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -156,13 +157,15 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'table',
-                header,
-                rows,
-                align: ['left'],
+                ...root({
+                    type: 'table',
+                    header,
+                    rows,
+                    align: ['left']
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { tablebody: tbodySnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -180,13 +183,15 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'table',
-                header,
-                rows,
-                align: ['left'],
+                ...root({
+                    type: 'table',
+                    header,
+                    rows,
+                    align: ['left']
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { tablerow: rowSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -206,13 +211,15 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'table',
-                header,
-                rows,
-                align: ['left'],
+                ...root({
+                    type: 'table',
+                    header,
+                    rows,
+                    align: ['left']
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { tablecell: cellSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -228,12 +235,14 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'list',
-                ordered: true,
-                items: [{ tokens: [{ type: 'text', raw: 'item', text: 'item' }] }],
+                ...root({
+                    type: 'list',
+                    ordered: true,
+                    items: [{ tokens: [{ type: 'text', raw: 'item', text: 'item' }] }]
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { list: listSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -248,12 +257,14 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'list',
-                ordered: false,
-                items: [{ tokens: [{ type: 'text', raw: 'item', text: 'item' }] }],
+                ...root({
+                    type: 'list',
+                    ordered: false,
+                    items: [{ tokens: [{ type: 'text', raw: 'item', text: 'item' }] }]
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { list: listSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -268,12 +279,14 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'list',
-                ordered: true,
-                items: [{ tokens: [{ type: 'text', raw: 'a', text: 'a' }] }],
+                ...root({
+                    type: 'list',
+                    ordered: true,
+                    items: [{ tokens: [{ type: 'text', raw: 'a', text: 'a' }] }]
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { orderedlistitem: itemSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -288,12 +301,14 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'list',
-                ordered: false,
-                items: [{ tokens: [{ type: 'text', raw: 'a', text: 'a' }] }],
+                ...root({
+                    type: 'list',
+                    ordered: false,
+                    items: [{ tokens: [{ type: 'text', raw: 'a', text: 'a' }] }]
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { unorderedlistitem: itemSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -308,11 +323,13 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'paragraph',
-                tokens: [{ type: 'text', raw: 'hello', text: 'hello' }],
+                ...root({
+                    type: 'paragraph',
+                    tokens: [{ type: 'text', raw: 'hello', text: 'hello' }]
+                }),
                 renderers: baseRenderers,
                 snippetOverrides: { paragraph: paraSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -327,13 +344,15 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'html',
-                tag: 'div',
-                raw: '<div>content</div>',
-                tokens: [{ type: 'text', raw: 'content', text: 'content' }],
+                ...root({
+                    type: 'html',
+                    tag: 'div',
+                    raw: '<div>content</div>',
+                    tokens: [{ type: 'text', raw: 'content', text: 'content' }]
+                }),
                 renderers: baseRenderers,
                 htmlSnippetOverrides: { div: divSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -348,13 +367,15 @@ describe('Parser branch coverage', () => {
 
         const { container } = render(Parser, {
             props: {
-                type: 'html',
-                tag: 'div',
-                raw: '<div></div>',
-                tokens: [],
+                ...root({
+                    type: 'html',
+                    tag: 'div',
+                    raw: '<div></div>',
+                    tokens: []
+                }),
                 renderers: baseRenderers,
                 htmlSnippetOverrides: { div: divSnippet }
-            }
+            } as any
         })
 
         await vi.runAllTimersAsync()
@@ -369,11 +390,13 @@ describe('Parser branch coverage', () => {
             delete renderers.unorderedlistitem
             const { container } = render(Parser, {
                 props: {
-                    type: 'list',
-                    ordered: false,
-                    items: [{ tokens: [{ type: 'text', raw: 'a', text: 'a' }] }],
+                    ...root({
+                        type: 'list',
+                        ordered: false,
+                        items: [{ tokens: [{ type: 'text', raw: 'a', text: 'a' }] }]
+                    }),
                     renderers
-                }
+                } as any
             })
             await vi.runAllTimersAsync()
             expect(container.querySelector('li')).toBeInTheDocument()
@@ -385,11 +408,13 @@ describe('Parser branch coverage', () => {
             delete renderers.orderedlistitem
             const { container } = render(Parser, {
                 props: {
-                    type: 'list',
-                    ordered: true,
-                    items: [{ tokens: [{ type: 'text', raw: 'b', text: 'b' }] }],
+                    ...root({
+                        type: 'list',
+                        ordered: true,
+                        items: [{ tokens: [{ type: 'text', raw: 'b', text: 'b' }] }]
+                    }),
                     renderers
-                }
+                } as any
             })
             await vi.runAllTimersAsync()
             expect(container.querySelector('li')).toBeInTheDocument()

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -21,66 +21,7 @@
         'track',
         'wbr'
     ])
-</script>
 
-<script lang="ts">
-    /**
-     * @component Parser
-     *
-     * Recursive markdown token parser that transforms tokens into Svelte components.
-     * This component is the core rendering engine of the markdown system, handling
-     * the transformation of parsed markdown tokens into their corresponding Svelte components.
-     *
-     * @example
-     * ```svelte
-     * <Parser
-     *   tokens={parsedTokens}
-     *   renderers={customRenderers}
-     *   type="paragraph"
-     * />
-     * ```
-     *
-     * Features:
-     * - Recursive token parsing
-     * - Custom renderer support
-     * - Snippet-based renderer overrides (snippet > component > default)
-     * - Special handling for tables, lists, and HTML content
-     * - Type-safe component rendering
-     *
-     * @typedef {Object} Props
-     * @property {string} [type] - Token type for direct component rendering
-     * @property {Token[] | TokensList} [tokens] - Markdown tokens to be rendered
-     * @property {Tokens.TableCell[]} [header] - Table header cells for table rendering
-     * @property {Tokens.TableCell[][]} [rows] - Table row cells for table rendering
-     * @property {boolean} [ordered=false] - Whether the list is ordered (for list rendering)
-     * @property {Renderers} renderers - Component mapping for markdown elements
-     * @property {Record<string, any>} [snippetOverrides] - Snippet overrides for markdown renderers
-     * @property {Record<string, any>} [htmlSnippetOverrides] - Snippet overrides for HTML tag renderers
-     *
-     * Implementation Notes:
-     * - Uses recursive rendering for nested tokens
-     * - Implements special logic for tables, lists, and HTML content
-     * - Handles component prop spreading carefully to avoid conflicts
-     * - Maintains type safety through TypeScript interfaces
-     * - HTML token handling in table cells uses type assertions for better type safety
-     * - Table cell HTML content is processed with proper token nesting and attribute preservation
-     * - Improved HTML component rendering with proper type checking for tag properties
-     * - Added support for nested markdown within HTML table cells (see test at lines 311-343 in SvelteMarkdown.test.ts)
-     * - Token cleanup utilities handle complex nested structures (see lines 105-127 in token-cleanup.test.ts)
-     * - HTML parsing maintains proper structure for both simple and complex nested elements
-     *
-     */
-
-    import Parser from '$lib/Parser.svelte'
-    import Html from '$lib/renderers/html/index.js'
-    import {
-        defaultRenderers,
-        type Renderers,
-        type Token,
-        type TokensList,
-        type Tokens,
-        type RendererComponent
-    } from '$lib/utils/markdown-parser.js'
     import {
         defaultSanitizeAttributes,
         defaultSanitizeUrl,
@@ -88,90 +29,37 @@
         type SanitizeUrlFn
     } from '$lib/utils/sanitize.js'
 
-    // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
-    type AnySnippet = (..._args: any[]) => any
-
-    interface Props<T extends Renderers = Renderers> {
-        type?: string
-        tokens?: Token[] | TokensList
-        header?: Tokens.TableCell[]
-        rows?: Tokens.TableCell[][]
-        ordered?: boolean
-        renderers: T
-        snippetOverrides?: Record<string, AnySnippet>
-        htmlSnippetOverrides?: Record<string, AnySnippet>
-        sanitizeUrl?: SanitizeUrlFn
-        sanitizeAttributes?: SanitizeAttributesFn
+    /**
+     * Strip the structural fields SvelteMarkdown uses to select a renderer
+     * (type/tokens/header/rows/ordered) and return the token's remaining
+     * fields. The caller merges these with the inherited passthrough props,
+     * reproducing the legacy `<Parser {...rest} {...token}>` rest bag without
+     * spawning a component per token.
+     */
+    function tokenExtra(token: Record<string, unknown>): Record<string, unknown> {
+        const {
+            type: _type,
+            tokens: _tokens,
+            header: _header,
+            rows: _rows,
+            ordered: _ordered,
+            ...extra
+        } = token
+        return extra
     }
-
-    const {
-        type = undefined,
-        tokens = undefined,
-        header = undefined,
-        rows = undefined,
-        ordered = false,
-        renderers,
-        snippetOverrides = {},
-        htmlSnippetOverrides = {},
-        sanitizeUrl = defaultSanitizeUrl,
-        sanitizeAttributes = defaultSanitizeAttributes,
-        ...rest
-    }: Props & {
-        [key: string]: unknown
-    } = $props()
 
     /**
-     * Dev-only Parser-instance counter. Exposed via `window.__svmParserCount`
-     * and `window.__svmParserByType` so the perf-bench harness can attribute
-     * render cost to component allocations without a Chrome profile. The
-     * `import.meta.env.DEV` guard is resolved at build time by Vite, so
-     * production bundles drop this block entirely (zero overhead). Reset by
-     * the perf-bench page at scenario start.
-     *
-     * `type` is read once at script init — Parser instances are remounted
-     * (not re-keyed) when their type changes, so the initial value is the
-     * effective lifetime value for counting purposes.
+     * Per-token URL/attribute sanitization, lifted verbatim from the former
+     * component-level `$derived sanitizedRest`. Remains the single enforcement
+     * point — every renderer still receives sanitized props; custom renderers
+     * cannot bypass it.
      */
-    if (import.meta.env.DEV && typeof window !== 'undefined') {
-        interface SVMWindow extends Window {
-            __svmParserCount?: number
-            __svmParserByType?: Record<string, number>
-        }
-        const w = window as SVMWindow
-        const initialType: string = type ?? '<root>'
-        w.__svmParserCount = (w.__svmParserCount ?? 0) + 1
-        const byType = (w.__svmParserByType = w.__svmParserByType ?? {})
-        byType[initialType] = (byType[initialType] ?? 0) + 1
-    }
-
-    // Inline-render eligibility flags (issue #286): leaf text, space, and
-    // default-renderer html tokens are by far the most common token
-    // shapes. Their default render path is a no-op wrapper chain (Parser
-    // → Text/RawText/HtmlComponent → `{text}` or `<tag>...</tag>`). For
-    // space tokens it's even worse: Parser is instantiated, hits no
-    // branch, and renders nothing. Detect once whether the user has kept
-    // the default renderers / has no snippet override so we can render
-    // these inline at the call site without spawning a Parser.
-    const inlineTextOk = $derived(
-        renderers.text === defaultRenderers.text &&
-            !snippetOverrides.text &&
-            // The inline path skips the leaf-text `rawtext` fallback that
-            // the general-branch dispatch uses, so we must also keep the
-            // optimization off when the user has provided their own
-            // `rawtext` renderer or snippet — otherwise their override is
-            // silently bypassed for plain text inside paragraphs/headings.
-            renderers.rawtext === defaultRenderers.rawtext &&
-            !snippetOverrides.rawtext
-    )
-    const inlineSpaceOk = $derived(
-        // No default renderer for `space`; only safe to skip when nothing
-        // has been added by the user.
-        !(renderers as Record<string, unknown>).space && !snippetOverrides.space
-    )
-
-    // Sanitize rest props before they reach any renderer or snippet.
-    // This is the single enforcement point — custom renderers cannot bypass it.
-    const sanitizedRest = $derived.by(() => {
+    function sanitizeTokenRest(
+        rest: Record<string, unknown>,
+        type: string,
+        sanitizeUrl: SanitizeUrlFn,
+        sanitizeAttributes: SanitizeAttributesFn
+    ): Record<string, unknown> {
         if ((type === 'link' || type === 'image') && typeof rest.href === 'string') {
             const tag = type === 'link' ? 'a' : 'img'
             const sanitized = sanitizeUrl(rest.href, { type, tag })
@@ -189,68 +77,161 @@
             }
         }
         return rest
-    })
+    }
 </script>
 
-{#snippet dispatch(token: Token, restProps: Record<string, unknown>)}
-    {@const htmlTok = token as Token & {
+<script lang="ts">
+    /**
+     * @component Parser
+     *
+     * Recursive markdown token parser that transforms tokens into Svelte components.
+     * This component is the core rendering engine of the markdown system, handling
+     * the transformation of parsed markdown tokens into their corresponding Svelte components.
+     *
+     * @example
+     * ```svelte
+     * <Parser
+     *   tokens={parsedTokens}
+     *   renderers={customRenderers}
+     * />
+     * ```
+     *
+     * Features:
+     * - Recursive token parsing (via a self-referencing snippet, no self-import)
+     * - Custom renderer support
+     * - Snippet-based renderer overrides (snippet > component > default)
+     * - Special handling for tables, lists, and HTML content
+     * - Type-safe component rendering
+     *
+     * Implementation Notes:
+     * - Recursion is handled by the `renderToken` snippet, which references itself.
+     *   Svelte 5 explicitly supports self-referencing snippets (see the snippet
+     *   scope docs). This keeps `Parser.svelte` free of a self-`import`, which
+     *   previously produced a self-referential module that some bundlers
+     *   (notably the Vite 8 / rolldown optimizer) could not pre-bundle.
+     * - Implements special logic for tables, lists, and HTML content
+     * - Handles component prop spreading carefully to avoid conflicts
+     * - Maintains type safety through TypeScript interfaces
+     * - HTML token handling in table cells uses type assertions for better type safety
+     * - Table cell HTML content is processed with proper token nesting and attribute preservation
+     * - HTML parsing maintains proper structure for both simple and complex nested elements
+     *
+     * @typedef {Object} Props
+     * @property {Token[] | TokensList} [tokens] - Markdown tokens to be rendered
+     * @property {Renderers} renderers - Component mapping for markdown elements
+     * @property {Record<string, any>} [snippetOverrides] - Snippet overrides for markdown renderers
+     * @property {Record<string, any>} [htmlSnippetOverrides] - Snippet overrides for HTML tag renderers
+     *
+     */
+
+    import Html from '$lib/renderers/html/index.js'
+    import {
+        defaultRenderers,
+        type Renderers,
+        type Token,
+        type TokensList,
+        type Tokens,
+        type RendererComponent
+    } from '$lib/utils/markdown-parser.js'
+
+    // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
+    type AnySnippet = (..._args: any[]) => any
+
+    interface Props<T extends Renderers = Renderers> {
+        tokens?: Token[] | TokensList
+        renderers: T
+        snippetOverrides?: Record<string, AnySnippet>
+        htmlSnippetOverrides?: Record<string, AnySnippet>
+        sanitizeUrl?: SanitizeUrlFn
+        sanitizeAttributes?: SanitizeAttributesFn
+    }
+
+    const {
+        tokens = undefined,
+        renderers,
+        snippetOverrides = {},
+        htmlSnippetOverrides = {},
+        sanitizeUrl = defaultSanitizeUrl,
+        sanitizeAttributes = defaultSanitizeAttributes,
+        ...rest
+    }: Props & {
+        [key: string]: unknown
+    } = $props()
+
+    // Inline-render eligibility flags (issue #286): leaf text, space, and
+    // default-renderer html tokens are by far the most common token shapes.
+    // Their default render path is a no-op wrapper chain (renderToken
+    // → Text/RawText/HtmlComponent → `{text}` or `<tag>...</tag>`). For
+    // space tokens it's even worse: a token with no branch renders nothing.
+    // Detect once whether the user has kept the default renderers / has no
+    // snippet override so we can render these inline without recursing.
+    const inlineTextOk = $derived(
+        renderers.text === defaultRenderers.text &&
+            !snippetOverrides.text &&
+            // The inline path skips the leaf-text `rawtext` fallback that
+            // the general-branch dispatch uses, so we must also keep the
+            // optimization off when the user has provided their own
+            // `rawtext` renderer or snippet — otherwise their override is
+            // silently bypassed for plain text inside paragraphs/headings.
+            renderers.rawtext === defaultRenderers.rawtext &&
+            !snippetOverrides.rawtext
+    )
+    const inlineSpaceOk = $derived(
+        // No default renderer for `space`; only safe to skip when nothing
+        // has been added by the user.
+        !(renderers as Record<string, unknown>).space && !snippetOverrides.space
+    )
+</script>
+
+{#snippet renderToken(token: Token, restProps: Record<string, unknown>)}
+    {@const t = token as Token & {
+        header?: Tokens.TableCell[]
+        rows?: Tokens.TableCell[][]
+        items?: Tokens.ListItem[]
+        ordered?: boolean
+        tokens?: Token[]
         tag?: string
         attributes?: Record<string, string>
-        tokens?: Token[]
+        href?: string
+        raw?: string
+        text?: string
     }}
+    {@const tokenType = t.type}
+    {@const sanitizedRest = sanitizeTokenRest(
+        { ...restProps, ...tokenExtra(t as Record<string, unknown>) },
+        tokenType,
+        sanitizeUrl,
+        sanitizeAttributes
+    )}
     {@const inlineHtmlOk =
-        token.type === 'html' &&
-        !!htmlTok.tag &&
+        tokenType === 'html' &&
+        !!t.tag &&
         !!renderers.html &&
-        renderers.html[htmlTok.tag] === Html[htmlTok.tag] &&
-        !htmlSnippetOverrides[htmlTok.tag]}
-    {#if token.type === 'space' && inlineSpaceOk}
+        renderers.html[t.tag] === Html[t.tag] &&
+        !htmlSnippetOverrides[t.tag]}
+
+    {#if tokenType === 'space' && inlineSpaceOk}
         <!-- inlined: space tokens render nothing -->
-    {:else if token.type === 'text' && inlineTextOk && !(token as Tokens.Text).tokens}
-        {(token as Tokens.Text).text ?? token.raw}
-    {:else if inlineHtmlOk && htmlTok.tag}
-        {@const sanitizedAttrs = htmlTok.attributes
-            ? sanitizeAttributes(
-                  htmlTok.attributes,
-                  { type: 'html', tag: htmlTok.tag },
-                  sanitizeUrl
-              )
+    {:else if tokenType === 'text' && inlineTextOk && !(t as Tokens.Text).tokens}
+        {(t as Tokens.Text).text ?? t.raw}
+    {:else if inlineHtmlOk && t.tag}
+        {@const sanitizedAttrs = t.attributes
+            ? sanitizeAttributes(t.attributes, { type: 'html', tag: t.tag }, sanitizeUrl)
             : undefined}
-        {#if SELF_CLOSING_HTML.has(htmlTok.tag)}
-            <svelte:element this={htmlTok.tag} {...sanitizedAttrs} />
+        {#if SELF_CLOSING_HTML.has(t.tag)}
+            <svelte:element this={t.tag} {...sanitizedAttrs} />
         {:else}
-            <svelte:element this={htmlTok.tag} {...sanitizedAttrs}>
-                {#if htmlTok.tokens && htmlTok.tokens.length}
-                    {#each htmlTok.tokens as childToken, i (i)}
-                        {@render dispatch(childToken, restProps)}
+            <svelte:element this={t.tag} {...sanitizedAttrs}>
+                {#if t.tokens && t.tokens.length}
+                    {#each t.tokens as childToken, i (i)}
+                        {@render renderToken(childToken, restProps)}
                     {/each}
                 {/if}
             </svelte:element>
         {/if}
-    {:else}
-        <Parser
-            {...restProps}
-            {...token}
-            {renderers}
-            {snippetOverrides}
-            {htmlSnippetOverrides}
-            {sanitizeUrl}
-            {sanitizeAttributes}
-        />
-    {/if}
-{/snippet}
-
-{#if !type}
-    {#if tokens}
-        {@const { text: _text, raw: _raw, tokens: _tokens, ...parserRest } = rest}
-        {#each tokens as token, index (index)}
-            {@render dispatch(token, parserRest)}
-        {/each}
-    {/if}
-{:else if type in renderers || type in snippetOverrides}
-    {#if type === 'table'}
+    {:else if tokenType === 'table'}
         {#if renderers.table && renderers.tablerow && renderers.tablecell}
-            {@const tableSnippet = snippetOverrides[type]}
+            {@const tableSnippet = snippetOverrides[tokenType]}
             {@const theadSnippet = snippetOverrides['tablehead']}
             {@const tbodySnippet = snippetOverrides['tablebody']}
             {@const rowSnippet = snippetOverrides['tablerow']}
@@ -260,11 +241,11 @@
                 {#if renderers.tablehead}
                     {#snippet theadContent()}
                         {#snippet headerRowContent()}
-                            {#each header ?? [] as headerItem, i (i)}
+                            {#each t.header ?? [] as headerItem, i (i)}
                                 {@const { align: _align, ...cellRest } = sanitizedRest}
                                 {#snippet headerCellContent()}
                                     {#each headerItem.tokens ?? [] as headerCellToken, k (k)}
-                                        {@render dispatch(headerCellToken, {})}
+                                        {@render renderToken(headerCellToken, {})}
                                     {/each}
                                 {/snippet}
                                 {#if cellSnippet}
@@ -306,13 +287,13 @@
                 {/if}
                 {#if renderers.tablebody}
                     {#snippet tbodyContent()}
-                        {#each rows ?? [] as row, i (i)}
+                        {#each t.rows ?? [] as row, i (i)}
                             {#snippet bodyRowContent()}
                                 {#each row ?? [] as cells, j (j)}
                                     {@const { align: _align, ...cellRest } = sanitizedRest}
                                     {#snippet bodyCellContent()}
                                         {#each cells.tokens ?? [] as cellToken, index (index)}
-                                            {@render dispatch(cellToken, cellRest)}
+                                            {@render renderToken(cellToken, cellRest)}
                                         {/each}
                                     {/snippet}
                                     {#if cellSnippet}
@@ -365,20 +346,20 @@
                 </renderers.table>
             {/if}
         {/if}
-    {:else if type === 'list' && renderers.list}
+    {:else if tokenType === 'list' && renderers.list}
         {@const listSnippet = snippetOverrides['list']}
 
-        {#if ordered}
+        {#if t.ordered}
             {#snippet orderedListContent()}
                 {@const { items: _items, ...parserRest } = sanitizedRest}
-                {@const items = (_items as Props[] | undefined) ?? []}
+                {@const items = (_items as Tokens.ListItem[] | undefined) ?? []}
                 {#each items as item, index (index)}
                     {@const OrderedListComponent = renderers.orderedlistitem || renderers.listitem}
                     {@const orderedItemSnippet =
                         snippetOverrides['orderedlistitem'] || snippetOverrides['listitem']}
                     {#snippet orderedItemContent()}
                         {#each item.tokens ?? [] as itemToken, k (k)}
-                            {@render dispatch(itemToken, parserRest)}
+                            {@render renderToken(itemToken, parserRest)}
                         {/each}
                     {/snippet}
                     {#if orderedItemSnippet}
@@ -391,16 +372,20 @@
                 {/each}
             {/snippet}
             {#if listSnippet}
-                {@render listSnippet({ ordered, ...sanitizedRest, children: orderedListContent })}
+                {@render listSnippet({
+                    ordered: t.ordered,
+                    ...sanitizedRest,
+                    children: orderedListContent
+                })}
             {:else}
-                <renderers.list {ordered} {...sanitizedRest}>
+                <renderers.list ordered={t.ordered} {...sanitizedRest}>
                     {@render orderedListContent()}
                 </renderers.list>
             {/if}
         {:else}
             {#snippet unorderedListContent()}
                 {@const { items: _items, ...parserRest } = sanitizedRest}
-                {@const items = (_items as Props[] | undefined) ?? []}
+                {@const items = (_items as Tokens.ListItem[] | undefined) ?? []}
                 {#each items as item, index (index)}
                     {@const UnorderedListComponent =
                         renderers.unorderedlistitem || renderers.listitem}
@@ -408,7 +393,7 @@
                         snippetOverrides['unorderedlistitem'] || snippetOverrides['listitem']}
                     {#snippet unorderedItemContent()}
                         {#each item.tokens ?? [] as itemToken, k (k)}
-                            {@render dispatch(itemToken, parserRest)}
+                            {@render renderToken(itemToken, parserRest)}
                         {/each}
                     {/snippet}
                     {#if unorderedItemSnippet}
@@ -421,14 +406,18 @@
                 {/each}
             {/snippet}
             {#if listSnippet}
-                {@render listSnippet({ ordered, ...sanitizedRest, children: unorderedListContent })}
+                {@render listSnippet({
+                    ordered: t.ordered,
+                    ...sanitizedRest,
+                    children: unorderedListContent
+                })}
             {:else}
-                <renderers.list {ordered} {...sanitizedRest}>
+                <renderers.list ordered={t.ordered} {...sanitizedRest}>
                     {@render unorderedListContent()}
                 </renderers.list>
             {/if}
         {/if}
-    {:else if type === 'html'}
+    {:else if tokenType === 'html'}
         {@const { tag, ...localRest } = sanitizedRest}
         {@const htmlTag = sanitizedRest.tag as keyof typeof Html}
         {@const htmlSnippet = htmlSnippetOverrides[htmlTag as string]}
@@ -437,9 +426,9 @@
         )}
         {#if htmlSnippet}
             {#snippet htmlSnippetChildren()}
-                {#if tokens && (tokens as Token[]).length}
-                    {#each tokens as childToken, index (index)}
-                        {@render dispatch(childToken, localRestForChildren)}
+                {#if t.tokens && (t.tokens as Token[]).length}
+                    {#each t.tokens as childToken, index (index)}
+                        {@render renderToken(childToken, localRestForChildren)}
                     {/each}
                 {:else}
                     <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
@@ -453,9 +442,9 @@
             {@const HtmlComponent = renderers.html[htmlTag as keyof typeof renderers.html]}
             {#if HtmlComponent}
                 <HtmlComponent {...sanitizedRest}>
-                    {#if tokens && (tokens as Token[]).length}
-                        {#each tokens as childToken, index (index)}
-                            {@render dispatch(childToken, localRestForChildren)}
+                    {#if t.tokens && (t.tokens as Token[]).length}
+                        {#each t.tokens as childToken, index (index)}
+                            {@render renderToken(childToken, localRestForChildren)}
                         {/each}
                     {:else}
                         <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
@@ -466,20 +455,22 @@
             {@const fallbackRest = Object.fromEntries(
                 Object.entries(localRest).filter(([key]) => key !== 'tokens')
             )}
-            {@const fallbackTokens = (tokens as Token[]) ?? ([] as Token[])}
+            {@const fallbackTokens = (t.tokens as Token[]) ?? ([] as Token[])}
             {#each fallbackTokens as fallbackToken, index (index)}
-                {@render dispatch(fallbackToken, fallbackRest)}
+                {@render renderToken(fallbackToken, fallbackRest)}
             {/each}
         {/if}
     {:else}
-        {@const GeneralComponent = renderers[type as keyof typeof renderers] as RendererComponent}
-        {@const typeSnippet = snippetOverrides[type]}
+        {@const GeneralComponent = renderers[
+            tokenType as keyof typeof renderers
+        ] as RendererComponent}
+        {@const typeSnippet = snippetOverrides[tokenType]}
 
         {#snippet renderChildren()}
-            {#if tokens}
+            {#if t.tokens}
                 {@const { text: _text, raw: _raw, ...parserRest } = sanitizedRest}
-                {#each tokens as childToken, index (index)}
-                    {@render dispatch(childToken, parserRest)}
+                {#each t.tokens as childToken, index (index)}
+                    {@render renderToken(childToken, parserRest)}
                 {/each}
             {:else}
                 <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
@@ -494,4 +485,11 @@
             </GeneralComponent>
         {/if}
     {/if}
+{/snippet}
+
+{#if tokens}
+    {@const { text: _text, raw: _raw, ...parserRest } = rest}
+    {#each tokens as token, index (index)}
+        {@render renderToken(token, parserRest)}
+    {/each}
 {/if}

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -19,16 +19,6 @@
     const ROLLING_WINDOW_MS = 10_000
     const LONG_TASK_THRESHOLD_MS = 50
 
-    // Dev-only Parser-instance counters that `Parser.svelte` writes into
-    // `window` when running outside production. Mirroring the shape here
-    // lets us read/reset them without `any` casts.
-    interface SVMWindow extends Window {
-        __svmParserCount?: number
-        __svmParserByType?: Record<string, number>
-    }
-    const svmWindow = (): SVMWindow | undefined =>
-        typeof window === 'undefined' ? undefined : (window as SVMWindow)
-
     // ---- Corpus generators ----------------------------------------------------
 
     const generateLarge = (sections: number, blocksPerSection: number): string => {
@@ -258,11 +248,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         renderOnlyMs: 0,
         domNodes: 0,
         charsPerSec: 0,
-        // Parser-instance allocation count (dev-only window counter,
-        // captured per scenario from `__svmParserCount` /
-        // `__svmParserByType` in Parser.svelte). Tracks render-cost
-        // drivers that wall-clock alone misses.
-        parserInstances: 0,
         // Per-scenario observer snapshots: filtered to the scenario's
         // time window, not the rolling-10s window. Catch the
         // longest-task / mutation / LoAF count attributable to *this*
@@ -352,7 +337,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             renderOnlyMs: 0,
             domNodes: 0,
             charsPerSec: 0,
-            parserInstances: 0,
             scenarioLongestTaskMs: 0,
             scenarioMutations: 0,
             scenarioLoafScriptMaxMs: 0,
@@ -373,28 +357,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             streamGapAvgMs: 0,
             streamGapP95Ms: 0,
             streamGapPeakMs: 0
-        }
-    }
-
-    /**
-     * Resets the dev-mode Parser-instance counter so a fresh scenario gets
-     * a clean total. The window globals are populated by the dev-only
-     * block at the top of `Parser.svelte` and stay 0/empty in production
-     * builds (Vite drops the block).
-     */
-    const resetParserCounter = () => {
-        const w = svmWindow()
-        if (!w) return
-        w.__svmParserCount = 0
-        w.__svmParserByType = {}
-    }
-
-    const readParserCounter = (): { total: number; byType: Record<string, number> } => {
-        const w = svmWindow()
-        if (!w) return { total: 0, byType: {} }
-        return {
-            total: w.__svmParserCount ?? 0,
-            byType: w.__svmParserByType ?? {}
         }
     }
 
@@ -493,7 +455,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         // Let any pending unmount mutations from `source = ''` settle so
         // they aren't attributed to *this* scenario's window.
         await tick()
-        resetParserCounter()
         const scenarioStart = performance.now()
         const paintPromise = waitForPaint()
         const tPaint0 = performance.now()
@@ -504,7 +465,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         await tick()
         const scenarioEnd = performance.now()
         const domNodes = previewEl ? previewEl.querySelectorAll('*').length : 0
-        const parserCounter = readParserCounter()
         const observerSnap = snapshotScenarioObservers(scenarioStart, scenarioEnd)
 
         const srcKb = round(corpus.length / 1024, 1)
@@ -523,7 +483,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             renderOnlyMs: round(Math.max(0, firstPaintMs - parseColdMs)),
             domNodes,
             charsPerSec,
-            parserInstances: parserCounter.total,
             scenarioLongestTaskMs: observerSnap.longestTaskMs,
             scenarioMutations: observerSnap.mutations,
             scenarioLoafScriptMaxMs: observerSnap.loafScriptMaxMs
@@ -779,7 +738,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         source = ''
         tokenCache.clearAllTokens()
         resetStat()
-        resetParserCounter()
         longTaskEntries = []
         rafIntervals = []
         mutationEvents = []
@@ -998,7 +956,7 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         scenario={scenario} srcKb={stat.srcKb} tokenCount={stat.tokenCount} parseColdMs={stat.parseColdMs}
         parseWarmMs={stat.parseWarmMs} lexMs={stat.lexMs} cleanupMs={stat.cleanupMs} hashMs={stat.hashMs}
         firstPaintMs={stat.firstPaintMs} renderOnlyMs={stat.renderOnlyMs} domNodes={stat.domNodes}
-        charsPerSec={stat.charsPerSec} parserInstances={stat.parserInstances} scenarioLongestTaskMs={stat.scenarioLongestTaskMs}
+        charsPerSec={stat.charsPerSec} scenarioLongestTaskMs={stat.scenarioLongestTaskMs}
         scenarioMutations={stat.scenarioMutations} scenarioLoafScriptMaxMs={stat.scenarioLoafScriptMaxMs}
         · cacheIters={stat.cacheIters} cacheTotalMs={stat.cacheTotalMs} cacheAvgMs={stat.cacheAvgMs} cacheP95Ms={stat.cacheP95Ms}
         cachePeakMs={stat.cachePeakMs} · streamChunks={stat.streamChunks} streamTotalMs={stat.streamTotalMs}

--- a/tests/issues/issue-192.test.ts
+++ b/tests/issues/issue-192.test.ts
@@ -16,7 +16,13 @@ test.describe('Issue 192: Image inside link rendering', () => {
         // Find the image inside the link
         const img = await link.locator('img[alt="image"]')
         expect(await img.count()).toBe(1)
-        expect(await img.getAttribute('src')).toBe(
+        // Image.svelte lazy-loads: `src` is only populated once the
+        // IntersectionObserver fires, but `data-src` always carries the
+        // canonical href. Asserting `data-src` (auto-retrying) verifies href
+        // propagation through the link->image nesting without coupling to
+        // viewport or observer timing. Same pattern as lazy-images.test.ts.
+        await expect(img).toHaveAttribute(
+            'data-src',
             'https://avatars.githubusercontent.com/u/162604590?s=64&u=548f358e716a223731ab372776a09723cf815f4d&v=4'
         )
         expect(await img.getAttribute('alt')).toBe('image')


### PR DESCRIPTION
Vite 8 replaced the esbuild dependency optimizer with rolldown. rolldown drops the binding of a module that imports itself during pre-bundling, so Parser.svelte — which recursed via `import Parser from './Parser.svelte'` and instantiating `<Parser>` — surfaced at runtime as `ReferenceError: Parser is not defined` for any consumer on Vite 8. The same code pre-bundled cleanly on Vite <=7 (esbuild), which is why this only surfaced now.

The usual workaround (`optimizeDeps.exclude`) trades the pre-bundle path for on-the-fly compilation and cascades from there: it triggers the CSS-metadata miss for node_modules `.svelte` components and, on the next cache rebuild, SSR deps-optimizer errors (e.g. `Cannot find module 'clsx'`). The self-import is the single root cause behind all three.

Fix: the recursion now lives in a self-referencing `renderToken` snippet — Svelte 5 supports snippet self-reference — so Parser.svelte no longer imports itself. The token walk is unchanged; token fields are read directly off the token rather than re-spread onto a spawned child component.

Changes:

- src/lib/Parser.svelte — merge the `dispatch` snippet and the main-body type-dispatch into one `renderToken(token, restProps)` snippet; lift per-token URL/attribute sanitization into a module-scoped `sanitizeTokenRest` helper (still the single enforcement point); drop the dev-only `window.__svmParserCount` counter and the `type`/`header`/`rows`/`ordered` props that only existed to feed the recursive spawn.
- src/lib/Parser.branches.test.ts — drive each case through a single-token root, since Parser no longer accepts a `type` prop.
- src/routes/test/perf-bench/+page.svelte, scripts/perf-bench.mjs — remove the `parserInstances` metric and its helpers.
- tests/issues/issue-192.test.ts — assert `data-src` (always emitted by Image.svelte) instead of `src`, which is null until the lazy-load observer fires. Pre-existing flakiness from when lazy loading landed; included to keep the e2e suite green.

Validation: svelte-check 0 errors; 851/851 unit tests; production build clean; `dist/Parser.svelte` contains no self-import. Confirmed in a throwaway
Vite 8.1.3 + @sveltejs/vite-plugin-svelte 7.1.2 consumer with zero optimizeDeps/ssr config: the pre-bundle chunk defines `Parser` correctly and
the dev server logs no errors.