### PR TITLE
perf(parser): narrow streaming tail-window kill switches (#325)

### DIFF
--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -268,11 +268,11 @@ describe('IncrementalParser', () => {
             expect(result.canReuse).toBe(true)
         })
 
-        // KNOWN FAILING (#325 follow-up): a reference *definition* that already
-        // sits in the stable prefix is invisible to a tail-only re-lex, so a new
-        // shortcut *use* appended in the tail renders as plain text instead of a
-        // link. The tail-window reference gate only covers "use in prefix +
-        // definition in tail", not "definition in prefix + use in tail".
+        // (#325) A reference *definition* already in the stable prefix is
+        // invisible to a tail-only re-lex, so a shortcut *use* appended in the
+        // tail must force a full parse — otherwise it renders as plain text
+        // instead of a link. Guards the "definition in prefix + use in tail"
+        // direction (the mirror of "use in prefix + definition in tail").
         it('resolves shortcut references whose definition sits in the stable prefix', () => {
             const parser = new IncrementalParser(createDefaultOptions())
             const base = '[docs]: /docs\n\nIntro paragraph.\n\n'

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -260,10 +260,12 @@ describe('IncrementalParser', () => {
             expect(boundary.reparseOffset).toBeGreaterThan(0)
             expect(internalParser.canUseTailWindow(appended, boundary)).toBe(true)
 
-            parser.update(appended)
+            const result = parser.update(appended)
 
             expect(lexSpy.mock.calls[2]?.[0]).toBe(appended.slice(boundary.reparseOffset))
             expect((lexSpy.mock.calls[2]?.[0] as string).length).toBeLessThan(appended.length)
+            expect(result.divergeAt).toBeGreaterThan(0)
+            expect(result.canReuse).toBe(true)
         })
 
         it('keeps full reference syntax conservative until its definition arrives', () => {

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -3,6 +3,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { IncrementalParser } from './incremental-parser.js'
 import * as parseAndCacheModule from './parse-and-cache.js'
 
+/** Private surface of `IncrementalParser` exercised by the tail-window tests. */
+interface InternalParser {
+    prevSource: string
+    getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+    canUseTailWindow: (
+        source: string,
+        boundary: { prefixCount: number; reparseOffset: number }
+    ) => boolean
+}
+
+/** Expose the private tail-window internals without repeating the cast per test. */
+const asInternalParser = (parser: IncrementalParser): InternalParser =>
+    parser as unknown as InternalParser
+
 describe('IncrementalParser', () => {
     const createDefaultOptions = (): SvelteMarkdownOptions => ({ gfm: true })
 
@@ -176,14 +190,7 @@ describe('IncrementalParser', () => {
             const parser = new IncrementalParser(createDefaultOptions())
 
             parser.update('# Title\n\nFirst paragraph')
-            const internalParser = parser as unknown as {
-                prevSource: string
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             // heading + space are stable prefix (2 tokens), reparse from offset 9
@@ -247,13 +254,7 @@ describe('IncrementalParser', () => {
 
             parser.update(source)
             parser.update(withDefinition)
-            const internalParser = parser as unknown as {
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             expect(lexSpy.mock.calls[1]?.[0]).toBe(withDefinition)
@@ -305,13 +306,7 @@ describe('IncrementalParser', () => {
             const appended = `${source}\n\nNext`
 
             parser.update(source)
-            const internalParser = parser as unknown as {
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             expect(boundary.reparseOffset).toBeGreaterThan(0)
@@ -331,13 +326,7 @@ describe('IncrementalParser', () => {
             const appended = `${source}\n\nNext`
 
             parser.update(source)
-            const internalParser = parser as unknown as {
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             expect(boundary.reparseOffset).toBeGreaterThan(0)
@@ -356,13 +345,7 @@ describe('IncrementalParser', () => {
             const appended = `${source}\n\nNext`
 
             parser.update(source)
-            const internalParser = parser as unknown as {
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             expect(boundary.reparseOffset).toBeGreaterThan(0)
@@ -381,13 +364,7 @@ describe('IncrementalParser', () => {
             const appended = `${source}\n\nNext`
 
             parser.update(source)
-            const internalParser = parser as unknown as {
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             expect(boundary.reparseOffset).toBeGreaterThan(0)
@@ -406,13 +383,7 @@ describe('IncrementalParser', () => {
             const appended = `${source} more`
 
             parser.update(source)
-            const internalParser = parser as unknown as {
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             expect(boundary).toEqual({ prefixCount: 0, reparseOffset: 0 })
@@ -430,13 +401,7 @@ describe('IncrementalParser', () => {
             const appended = `${source}\n\nNext`
 
             parser.update(source)
-            const internalParser = parser as unknown as {
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             expect(boundary.reparseOffset).toBeGreaterThan(0)
@@ -456,13 +421,7 @@ describe('IncrementalParser', () => {
             const appended = `${source}\n\nNext`
 
             parser.update(source)
-            const internalParser = parser as unknown as {
-                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
-                canUseTailWindow: (
-                    source: string,
-                    boundary: { prefixCount: number; reparseOffset: number }
-                ) => boolean
-            }
+            const internalParser = asInternalParser(parser)
             const boundary = internalParser.getTailWindowBoundary()
 
             expect(boundary.reparseOffset).toBeGreaterThan(0)

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -238,6 +238,224 @@ describe('IncrementalParser', () => {
             expect(result.divergeAt).toBe(0)
         })
 
+        it('re-enables tail-window reparsing after a one-time shortcut definition re-lex', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = 'See [docs]\n\nTail'
+            const withDefinition = `${source}\n\n[docs]: /docs`
+            const appended = `${withDefinition}\n\nNext`
+
+            parser.update(source)
+            parser.update(withDefinition)
+            const internalParser = parser as unknown as {
+                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+                canUseTailWindow: (
+                    source: string,
+                    boundary: { prefixCount: number; reparseOffset: number }
+                ) => boolean
+            }
+            const boundary = internalParser.getTailWindowBoundary()
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(withDefinition)
+            expect(boundary.reparseOffset).toBeGreaterThan(0)
+            expect(internalParser.canUseTailWindow(appended, boundary)).toBe(true)
+
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls[2]?.[0]).toBe(appended.slice(boundary.reparseOffset))
+            expect((lexSpy.mock.calls[2]?.[0] as string).length).toBeLessThan(appended.length)
+        })
+
+        it('keeps full reference syntax conservative until its definition arrives', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = 'See [docs][ref]\n\nTail'
+            const appended = `${source}\n\n[ref]: /docs`
+
+            parser.update(source)
+            const result = parser.update(appended)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended)
+            expect(result.divergeAt).toBe(0)
+        })
+
+        it('keeps tail-window reparsing enabled for inline links', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = 'See [docs](/docs)\n\nTail'
+            const appended = `${source}\n\nNext`
+
+            parser.update(source)
+            const internalParser = parser as unknown as {
+                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+                canUseTailWindow: (
+                    source: string,
+                    boundary: { prefixCount: number; reparseOffset: number }
+                ) => boolean
+            }
+            const boundary = internalParser.getTailWindowBoundary()
+
+            expect(boundary.reparseOffset).toBeGreaterThan(0)
+            expect(source.slice(0, boundary.reparseOffset)).toContain('[docs](/docs)')
+            expect(internalParser.canUseTailWindow(appended, boundary)).toBe(true)
+
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended.slice(boundary.reparseOffset))
+            expect((lexSpy.mock.calls[1]?.[0] as string).length).toBeLessThan(appended.length)
+        })
+
+        it('does not permanently disable tail-window reparsing after closed HTML blocks', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = '<details><summary>One</summary><p>Body</p></details>\n\nTail'
+            const appended = `${source}\n\nNext`
+
+            parser.update(source)
+            const internalParser = parser as unknown as {
+                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+                canUseTailWindow: (
+                    source: string,
+                    boundary: { prefixCount: number; reparseOffset: number }
+                ) => boolean
+            }
+            const boundary = internalParser.getTailWindowBoundary()
+
+            expect(boundary.reparseOffset).toBeGreaterThan(0)
+            expect(internalParser.canUseTailWindow(appended, boundary)).toBe(true)
+
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended.slice(boundary.reparseOffset))
+            expect((lexSpy.mock.calls[1]?.[0] as string).length).toBeLessThan(appended.length)
+        })
+
+        it('keeps tail-window reparsing enabled after multiple closed HTML blocks', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = '<div>One</div>\n\n<details><summary>Two</summary>Body</details>\n\nTail'
+            const appended = `${source}\n\nNext`
+
+            parser.update(source)
+            const internalParser = parser as unknown as {
+                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+                canUseTailWindow: (
+                    source: string,
+                    boundary: { prefixCount: number; reparseOffset: number }
+                ) => boolean
+            }
+            const boundary = internalParser.getTailWindowBoundary()
+
+            expect(boundary.reparseOffset).toBeGreaterThan(0)
+            expect(internalParser.canUseTailWindow(appended, boundary)).toBe(true)
+
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended.slice(boundary.reparseOffset))
+            expect((lexSpy.mock.calls[1]?.[0] as string).length).toBeLessThan(appended.length)
+        })
+
+        it('keeps tail-window reparsing enabled after self-closing HTML tags', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = '<br/>\n\nTail'
+            const appended = `${source}\n\nNext`
+
+            parser.update(source)
+            const internalParser = parser as unknown as {
+                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+                canUseTailWindow: (
+                    source: string,
+                    boundary: { prefixCount: number; reparseOffset: number }
+                ) => boolean
+            }
+            const boundary = internalParser.getTailWindowBoundary()
+
+            expect(boundary.reparseOffset).toBeGreaterThan(0)
+            expect(internalParser.canUseTailWindow(appended, boundary)).toBe(true)
+
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended.slice(boundary.reparseOffset))
+            expect((lexSpy.mock.calls[1]?.[0] as string).length).toBeLessThan(appended.length)
+        })
+
+        it('keeps tail-window reparsing disabled while HTML spans are still open', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = '<details><summary>One'
+            const appended = `${source} more`
+
+            parser.update(source)
+            const internalParser = parser as unknown as {
+                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+                canUseTailWindow: (
+                    source: string,
+                    boundary: { prefixCount: number; reparseOffset: number }
+                ) => boolean
+            }
+            const boundary = internalParser.getTailWindowBoundary()
+
+            expect(boundary).toEqual({ prefixCount: 0, reparseOffset: 0 })
+            expect(internalParser.canUseTailWindow(appended, boundary)).toBe(false)
+
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended)
+        })
+
+        it('keeps tail-window reparsing enabled for shortcut-looking citations without definitions', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = 'Citation [1]\n\nTail'
+            const appended = `${source}\n\nNext`
+
+            parser.update(source)
+            const internalParser = parser as unknown as {
+                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+                canUseTailWindow: (
+                    source: string,
+                    boundary: { prefixCount: number; reparseOffset: number }
+                ) => boolean
+            }
+            const boundary = internalParser.getTailWindowBoundary()
+
+            expect(boundary.reparseOffset).toBeGreaterThan(0)
+            expect(source.slice(0, boundary.reparseOffset)).toContain('[1]')
+            expect(internalParser.canUseTailWindow(appended, boundary)).toBe(true)
+
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended.slice(boundary.reparseOffset))
+            expect((lexSpy.mock.calls[1]?.[0] as string).length).toBeLessThan(appended.length)
+        })
+
+        it('keeps tail-window reparsing enabled for task lists without definitions', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = '- [ ] First task\n\nTail'
+            const appended = `${source}\n\nNext`
+
+            parser.update(source)
+            const internalParser = parser as unknown as {
+                getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+                canUseTailWindow: (
+                    source: string,
+                    boundary: { prefixCount: number; reparseOffset: number }
+                ) => boolean
+            }
+            const boundary = internalParser.getTailWindowBoundary()
+
+            expect(boundary.reparseOffset).toBeGreaterThan(0)
+            expect(source.slice(0, boundary.reparseOffset)).toContain('[ ]')
+            expect(internalParser.canUseTailWindow(appended, boundary)).toBe(true)
+
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended.slice(boundary.reparseOffset))
+            expect((lexSpy.mock.calls[1]?.[0] as string).length).toBeLessThan(appended.length)
+        })
+
         it('falls back to a full re-lex when walkTokens is configured', () => {
             const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
             const parser = new IncrementalParser({

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -268,6 +268,23 @@ describe('IncrementalParser', () => {
             expect(result.canReuse).toBe(true)
         })
 
+        // KNOWN FAILING (#325 follow-up): a reference *definition* that already
+        // sits in the stable prefix is invisible to a tail-only re-lex, so a new
+        // shortcut *use* appended in the tail renders as plain text instead of a
+        // link. The tail-window reference gate only covers "use in prefix +
+        // definition in tail", not "definition in prefix + use in tail".
+        it('resolves shortcut references whose definition sits in the stable prefix', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            const base = '[docs]: /docs\n\nIntro paragraph.\n\n'
+            parser.update(base)
+            const next = `${base}See [docs] for details.\n`
+
+            const incremental = parser.update(next)
+            const full = parseAndCacheModule.lexAndClean(next, createDefaultOptions(), false)
+
+            expect(incremental.tokens).toEqual(full)
+        })
+
         it('keeps full reference syntax conservative until its definition arrives', () => {
             const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
             const parser = new IncrementalParser(createDefaultOptions())

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -19,6 +19,7 @@ import { lexAndClean } from '$lib/utils/parse-and-cache.js'
  * are surfaced here for the few places we need to read them.
  */
 type HtmlToken = Token & {
+    sourceLength?: number
     tag?: string
     tokens?: Token[]
 }
@@ -79,12 +80,11 @@ export class IncrementalParser {
     /** Whether caller-supplied parser hooks make tail-window reparsing unsafe */
     private tailWindowDisabled: boolean
 
-    /** True iff any token in `prevTokens` is an HTML opening (closed or
-     *  unclosed) whose `.raw` is shorter than its actual source span. The
-     *  tail-window's sum-of-raws offset arithmetic only works when token
-     *  raws sum to the source length; this flag detects when that
-     *  invariant is broken so we fall through to a full re-parse. Cached
-     *  to keep `getTailWindowBoundary` O(1) on the hot path. */
+    /** True iff any token in `prevTokens` is an HTML opening whose actual
+     *  source span is unknown. Closed HTML spans record `sourceLength`
+     *  during cleanup and remain safe for tail-window offset arithmetic;
+     *  unclosed spans do not. Cached to keep `getTailWindowBoundary` O(1)
+     *  on the hot path. */
     private prevHasHtmlSpanMismatch = false
 
     /**
@@ -112,21 +112,18 @@ export class IncrementalParser {
             return { prefixCount: 0, reparseOffset: 0 }
         }
 
-        // (#291) If any prev token is an HTML opening (closed or
-        // unclosed), the tail-window prefix is unsound: our offset
-        // accounting sums token raws, but an html opening token's
-        // `.raw` is only the opening tag itself — children and closing
-        // tag are tracked separately on `.tokens`. Sum-of-raws therefore
-        // underestimates the true source position once any html block
-        // has been parsed, so we fall through to a full re-parse
-        // instead of serving a corrupt prefix.
+        // (#291) If any previous HTML opening has no known source span,
+        // the tail-window prefix is unsound: `.raw` is only the opening
+        // tag itself, while children and the closing tag live elsewhere.
+        // Closed HTML tokens carry `sourceLength`, so only truly partial
+        // HTML needs to fall through to a full re-parse.
         if (this.prevHasHtmlSpanMismatch) {
             return { prefixCount: 0, reparseOffset: 0 }
         }
 
         let offset = 0
         for (let i = 0; i < this.prevTokens.length - 1; i++) {
-            offset += this.prevTokens[i].raw.length
+            offset += this.getTokenSourceLength(this.prevTokens[i])
         }
 
         const lastToken = this.prevTokens[this.prevTokens.length - 1]
@@ -145,13 +142,11 @@ export class IncrementalParser {
     }
 
     /**
-     * True for an HTML opening tag whose `.raw` is shorter than its
-     * actual source span. After token-cleanup, a non-self-closing html
-     * opening token's `.raw` is only the opening tag itself (e.g.
-     * `<div>`); its children and closing tag (if any) live on
-     * `.tokens`. The tail-window's `reparseOffset = sum(raws)` math is
-     * unsound any time such a token sits in `prevTokens`, regardless
-     * of whether the close has arrived yet.
+     * True for an HTML opening tag whose actual source span is unknown.
+     * After token cleanup, closed HTML tokens keep children on `.tokens`
+     * and record their full source span as `sourceLength`. Unclosed HTML
+     * openings have neither a full span nor a closing tag yet, so serving
+     * them as a stable tail-window prefix would corrupt the offset math.
      */
     private hasHtmlSpanMismatch = (token: Token): boolean => {
         if (token.type !== 'html') return false
@@ -159,7 +154,11 @@ export class IncrementalParser {
         if (!html.tag) return false
         if (html.raw.endsWith('/>')) return false
         if (html.raw.startsWith('</')) return false
-        return true
+        return html.sourceLength == null
+    }
+
+    private getTokenSourceLength = (token: Token): number => {
+        return (token as Token & { sourceLength?: number }).sourceLength ?? token.raw.length
     }
 
     private isStableAtSourceEnd = (token: Token): boolean => {
@@ -177,14 +176,20 @@ export class IncrementalParser {
         }
     }
 
-    private hasAppendSensitiveReferenceSyntax = (source: string): boolean => {
+    private hasPotentialReferenceUse = (source: string): boolean => {
         if (!source.includes('[') || !source.includes(']')) return false
 
-        return (
-            LINK_REFERENCE_RE.test(source) ||
-            SHORTCUT_REFERENCE_RE.test(source) ||
-            REFERENCE_DEFINITION_RE.test(source)
-        )
+        return LINK_REFERENCE_RE.test(source) || SHORTCUT_REFERENCE_RE.test(source)
+    }
+
+    private hasReferenceDefinition = (source: string): boolean => {
+        if (!source.includes('[') || !source.includes(']')) return false
+        return REFERENCE_DEFINITION_RE.test(source)
+    }
+
+    private hasNewReferenceDefinition = (source: string): boolean => {
+        if (!source.startsWith(this.prevSource)) return false
+        return this.hasReferenceDefinition(source.slice(this.prevSource.length))
     }
 
     private canUseTailWindow = (source: string, boundary: TailWindowBoundary): boolean => {
@@ -193,8 +198,12 @@ export class IncrementalParser {
         if (!source.startsWith(this.prevSource)) return false
         if (boundary.reparseOffset <= 0) return false
 
-        const stablePrefix = this.prevSource.slice(0, boundary.reparseOffset)
-        if (this.hasAppendSensitiveReferenceSyntax(stablePrefix)) return false
+        if (
+            this.hasPotentialReferenceUse(this.prevSource) &&
+            this.hasNewReferenceDefinition(source)
+        ) {
+            return false
+        }
 
         return true
     }
@@ -224,12 +233,17 @@ export class IncrementalParser {
         }
 
         // Reference definitions can change inline children without changing raw,
-        // so force a full rerender when reference syntax is present
-        const referenceSensitive =
-            this.hasAppendSensitiveReferenceSyntax(this.prevSource) ||
-            this.hasAppendSensitiveReferenceSyntax(source)
-        const canReuse =
-            this.prevSource !== '' && source.startsWith(this.prevSource) && !referenceSensitive
+        // so force a full rerender when definitions are present alongside
+        // reference-style uses. Shortcut-looking text alone stays reusable.
+        const isAppendOnly = this.prevSource !== '' && source.startsWith(this.prevSource)
+        const referenceSensitive = isAppendOnly
+            ? this.hasPotentialReferenceUse(this.prevSource) &&
+              this.hasNewReferenceDefinition(source)
+            : (this.hasReferenceDefinition(this.prevSource) ||
+                  this.hasReferenceDefinition(source)) &&
+              (this.hasPotentialReferenceUse(this.prevSource) ||
+                  this.hasPotentialReferenceUse(source))
+        const canReuse = isAppendOnly && !referenceSensitive
 
         // Find first divergence point. We compare `.raw` for fast equality,
         // and for html tokens we also check the structural shape — an

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -181,17 +181,35 @@ export class IncrementalParser {
         }
     }
 
+    /**
+     * True when `source` contains reference-style link syntax that could
+     * resolve against a definition — either a full reference (`[text][id]`)
+     * or a shortcut (`[text]`). It says nothing about whether a matching
+     * definition exists; pair it with `hasReferenceDefinition` for that.
+     */
     private hasPotentialReferenceUse = (source: string): boolean => {
         if (!source.includes('[') || !source.includes(']')) return false
 
         return LINK_REFERENCE_RE.test(source) || SHORTCUT_REFERENCE_RE.test(source)
     }
 
+    /**
+     * True when `source` contains a link reference definition line
+     * (`[label]: url`). A definition can retroactively change how reference
+     * uses elsewhere in the document render, which is what makes it relevant
+     * to tail-window safety.
+     */
     private hasReferenceDefinition = (source: string): boolean => {
         if (!source.includes('[') || !source.includes(']')) return false
         return REFERENCE_DEFINITION_RE.test(source)
     }
 
+    /**
+     * True when appending to `prevSource` introduces a reference definition
+     * that was not already present — i.e. the definition lives entirely in the
+     * newly appended tail. Returns false for any update that is not a pure
+     * append of `prevSource`.
+     */
     private hasNewReferenceDefinition = (source: string): boolean => {
         if (!source.startsWith(this.prevSource)) return false
         return this.hasReferenceDefinition(source.slice(this.prevSource.length))
@@ -209,6 +227,14 @@ export class IncrementalParser {
     private appendedDefinitionInvalidatesTail = (source: string): boolean =>
         this.hasPotentialReferenceUse(this.prevSource) && this.hasNewReferenceDefinition(source)
 
+    /**
+     * Decides whether an update may reuse the stable token prefix and re-lex
+     * only the appended tail (`boundary.reparseOffset` onward) instead of the
+     * whole document. Returns false whenever that shortcut could diverge from a
+     * full parse: caller parser hooks are active, the update is not append-only,
+     * the boundary is empty, or reference syntax straddles the prefix/tail split
+     * in a way a tail-only re-lex cannot resolve.
+     */
     private canUseTailWindow = (
         source: string,
         boundary: TailWindowBoundary,

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -185,7 +185,16 @@ export class IncrementalParser {
      * True when `source` contains reference-style link syntax that could
      * resolve against a definition — either a full reference (`[text][id]`)
      * or a shortcut (`[text]`). It says nothing about whether a matching
-     * definition exists; pair it with `hasReferenceDefinition` for that.
+     * definition exists; pair it with {@link hasReferenceDefinition} for that.
+     *
+     * @param source - Markdown source to scan
+     * @returns `true` if a full or shortcut reference use is present
+     * @example
+     * ```typescript
+     * this.hasPotentialReferenceUse('see [docs]')   // true  (shortcut)
+     * this.hasPotentialReferenceUse('see [a][b]')   // true  (full ref)
+     * this.hasPotentialReferenceUse('see [x](/y)')  // false (inline link)
+     * ```
      */
     private hasPotentialReferenceUse = (source: string): boolean => {
         if (!source.includes('[') || !source.includes(']')) return false
@@ -198,6 +207,14 @@ export class IncrementalParser {
      * (`[label]: url`). A definition can retroactively change how reference
      * uses elsewhere in the document render, which is what makes it relevant
      * to tail-window safety.
+     *
+     * @param source - Markdown source to scan
+     * @returns `true` if a reference definition line is present
+     * @example
+     * ```typescript
+     * this.hasReferenceDefinition('[docs]: /docs')  // true
+     * this.hasReferenceDefinition('see [docs]')     // false
+     * ```
      */
     private hasReferenceDefinition = (source: string): boolean => {
         if (!source.includes('[') || !source.includes(']')) return false
@@ -209,6 +226,15 @@ export class IncrementalParser {
      * that was not already present — i.e. the definition lives entirely in the
      * newly appended tail. Returns false for any update that is not a pure
      * append of `prevSource`.
+     *
+     * @param source - The full new source, expected to start with `prevSource`
+     * @returns `true` if the appended tail contains a new reference definition
+     * @example
+     * ```typescript
+     * // prevSource === 'see [docs]\n\n'
+     * this.hasNewReferenceDefinition('see [docs]\n\n[docs]: /d')  // true
+     * this.hasNewReferenceDefinition('see [docs]\n\nmore text')   // false
+     * ```
      */
     private hasNewReferenceDefinition = (source: string): boolean => {
         if (!source.startsWith(this.prevSource)) return false
@@ -223,6 +249,15 @@ export class IncrementalParser {
      * `parseSource`/`canUseTailWindow` so the hot path evaluates it a single
      * time rather than recomputing the regexes for both the tail-window
      * decision and the reuse decision.
+     *
+     * @param source - The full new source string for this update
+     * @returns `true` if a newly appended definition can change how the reused
+     *   prefix renders, meaning the tail window must be bypassed
+     * @example
+     * ```typescript
+     * // prevSource === 'see [docs]\n\n' (a shortcut use already rendered)
+     * this.appendedDefinitionInvalidatesTail('see [docs]\n\n[docs]: /d') // true
+     * ```
      */
     private appendedDefinitionInvalidatesTail = (source: string): boolean =>
         this.hasPotentialReferenceUse(this.prevSource) && this.hasNewReferenceDefinition(source)
@@ -234,6 +269,20 @@ export class IncrementalParser {
      * full parse: caller parser hooks are active, the update is not append-only,
      * the boundary is empty, or reference syntax straddles the prefix/tail split
      * in a way a tail-only re-lex cannot resolve.
+     *
+     * @param source - The full new source string for this update
+     * @param boundary - The stable-prefix boundary from `getTailWindowBoundary`
+     * @param referenceInvalidatesTail - Precomputed reference-safety flag;
+     *   defaults to `appendedDefinitionInvalidatesTail(source)` for standalone
+     *   callers that have not computed it already
+     * @returns `true` if the appended tail can be re-lexed in isolation
+     * @example
+     * ```typescript
+     * const boundary = this.getTailWindowBoundary()
+     * if (this.canUseTailWindow(source, boundary)) {
+     *     // safe to re-lex only source.slice(boundary.reparseOffset)
+     * }
+     * ```
      */
     private canUseTailWindow = (
         source: string,

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -157,8 +157,13 @@ export class IncrementalParser {
         return html.sourceLength == null
     }
 
+    /**
+     * Source characters this token consumed. Closed HTML tokens record
+     * their full span as `sourceLength` during cleanup; every other token's
+     * `.raw` already equals its source span, so we fall back to `raw.length`.
+     */
     private getTokenSourceLength = (token: Token): number => {
-        return (token as Token & { sourceLength?: number }).sourceLength ?? token.raw.length
+        return (token as HtmlToken).sourceLength ?? token.raw.length
     }
 
     private isStableAtSourceEnd = (token: Token): boolean => {
@@ -192,24 +197,38 @@ export class IncrementalParser {
         return this.hasReferenceDefinition(source.slice(this.prevSource.length))
     }
 
-    private canUseTailWindow = (source: string, boundary: TailWindowBoundary): boolean => {
+    /**
+     * True when a reference definition arriving in the appended tail can
+     * retroactively change how existing reference-style uses in the stable
+     * prefix render — the one case where an append-only stream is not safe
+     * to serve incrementally. Computed once per `update` and threaded through
+     * `parseSource`/`canUseTailWindow` so the hot path evaluates it a single
+     * time rather than recomputing the regexes for both the tail-window
+     * decision and the reuse decision.
+     */
+    private appendedDefinitionInvalidatesTail = (source: string): boolean =>
+        this.hasPotentialReferenceUse(this.prevSource) && this.hasNewReferenceDefinition(source)
+
+    private canUseTailWindow = (
+        source: string,
+        boundary: TailWindowBoundary,
+        referenceInvalidatesTail = this.appendedDefinitionInvalidatesTail(source)
+    ): boolean => {
         if (this.tailWindowDisabled) return false
         if (this.prevSource === '' || this.prevTokens.length === 0) return false
         if (!source.startsWith(this.prevSource)) return false
         if (boundary.reparseOffset <= 0) return false
-
-        if (
-            this.hasPotentialReferenceUse(this.prevSource) &&
-            this.hasNewReferenceDefinition(source)
-        ) {
-            return false
-        }
+        if (referenceInvalidatesTail) return false
 
         return true
     }
 
-    private parseSource = (source: string, boundary: TailWindowBoundary): Token[] => {
-        if (!this.canUseTailWindow(source, boundary)) {
+    private parseSource = (
+        source: string,
+        boundary: TailWindowBoundary,
+        referenceInvalidatesTail: boolean
+    ): Token[] => {
+        if (!this.canUseTailWindow(source, boundary, referenceInvalidatesTail)) {
             return lexAndClean(source, this.options, false)
         }
 
@@ -225,7 +244,8 @@ export class IncrementalParser {
      */
     update = (source: string): IncrementalUpdateResult => {
         const boundary = this.getTailWindowBoundary()
-        const newTokens = this.parseSource(source, boundary)
+        const referenceInvalidatesTail = this.appendedDefinitionInvalidatesTail(source)
+        const newTokens = this.parseSource(source, boundary, referenceInvalidatesTail)
 
         // Apply walkTokens if configured
         if (typeof this.options.walkTokens === 'function') {
@@ -235,10 +255,10 @@ export class IncrementalParser {
         // Reference definitions can change inline children without changing raw,
         // so force a full rerender when definitions are present alongside
         // reference-style uses. Shortcut-looking text alone stays reusable.
+        // The append-only case reuses `referenceInvalidatesTail` computed above.
         const isAppendOnly = this.prevSource !== '' && source.startsWith(this.prevSource)
         const referenceSensitive = isAppendOnly
-            ? this.hasPotentialReferenceUse(this.prevSource) &&
-              this.hasNewReferenceDefinition(source)
+            ? referenceInvalidatesTail
             : (this.hasReferenceDefinition(this.prevSource) ||
                   this.hasReferenceDefinition(source)) &&
               (this.hasPotentialReferenceUse(this.prevSource) ||

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -220,6 +220,20 @@ export class IncrementalParser {
         if (boundary.reparseOffset <= 0) return false
         if (referenceInvalidatesTail) return false
 
+        // A reference definition living in the reused prefix is invisible to a
+        // tail-only re-lex (marked's link map is per-lex), so any reference use
+        // in the tail slice would render unresolved. `]:` is the cheap, no-alloc
+        // prefilter for "a definition marker exists at all" — task lists and
+        // bare citations never hit it, so the O(n) slice + regex is paid only by
+        // documents that actually carry reference definitions.
+        if (this.prevSource.includes(']:')) {
+            const prefix = source.slice(0, boundary.reparseOffset)
+            const tail = source.slice(boundary.reparseOffset)
+            if (this.hasReferenceDefinition(prefix) && this.hasPotentialReferenceUse(tail)) {
+                return false
+            }
+        }
+
         return true
     }
 

--- a/src/lib/utils/token-cleanup.ts
+++ b/src/lib/utils/token-cleanup.ts
@@ -342,7 +342,7 @@ const hasMultipleTags = (html: string): boolean => {
 const expandHtmlBlockNested = (html: string): Token[] => {
     const root: Token[] = []
     const stack: Token[][] = [root]
-    const opens: { tag: string; opening: Token; childTokens: Token[] }[] = []
+    const opens: { tag: string; opening: Token; childTokens: Token[]; startIndex: number }[] = []
     let currentText = ''
 
     const flushText = () => {
@@ -379,7 +379,7 @@ const expandHtmlBlockNested = (html: string): Token[] => {
                 } as Token
                 stack[stack.length - 1].push(opening)
                 stack.push(childTokens)
-                opens.push({ tag: name, opening, childTokens })
+                opens.push({ tag: name, opening, childTokens, startIndex: parser.startIndex })
             },
             ontext: (text) => {
                 currentText += text
@@ -393,7 +393,12 @@ const expandHtmlBlockNested = (html: string): Token[] => {
                 stack.pop()
                 if (!implied) {
                     // Real `</tag>` in source — fully resolved nested token.
-                    ;(top.opening as Token & { tokens?: Token[] }).tokens = top.childTokens
+                    const resolvedOpening = top.opening as Token & {
+                        sourceLength?: number
+                        tokens?: Token[]
+                    }
+                    resolvedOpening.sourceLength = parser.endIndex - top.startIndex + 1
+                    resolvedOpening.tokens = top.childTokens
                 } else {
                     // Auto-closed by htmlparser2 at end-of-input — this
                     // opening tag is unclosed in the source. Leave `.tokens`
@@ -492,12 +497,21 @@ const pairFlatHtmlTokens = (tokens: Token[]): Token[] => {
             const startIndex = lastOpen.startIndex
             const innerTokens = result.splice(startIndex + 1, result.length - startIndex - 1)
             const openingToken = result.pop()!
+            const sourceLength =
+                openingToken.raw.length +
+                innerTokens.reduce((sum, innerToken) => {
+                    const sourceLength = (innerToken as Token & { sourceLength?: number })
+                        .sourceLength
+                    return sum + (sourceLength ?? innerToken.raw.length)
+                }, 0) +
+                token.raw.length
             result.push({
                 type: 'html',
                 raw: openingToken.raw,
                 tag: tagInfo.tag,
                 tokens: innerTokens,
-                attributes: extractAttributes(openingToken.raw)
+                attributes: extractAttributes(openingToken.raw),
+                sourceLength
             } as Token)
         }
     }


### PR DESCRIPTION
## Summary

Two heuristics in `IncrementalParser` disabled the streaming tail-window optimization for content that is extremely common in LLM output (task lists, `[1]`-style citations, collapsible `<details>` blocks), turning each streamed frame into a full re-parse of the whole growing document — O(n²) over the life of a stream (#325). This branch narrows both kill switches so typical output stays on the fast path, while keeping output byte-for-byte identical to a full parse.

## Changes

🔧 **Kill switch 1 — closed HTML no longer disables the tail window.** Token cleanup now records a `sourceLength` on closed HTML tokens (both the nested-inline and flat open/close-pairing paths), so the tail-window offset arithmetic stays sound. Only genuinely unclosed HTML still falls back to a full re-parse.

🔧 **Kill switch 2 — shortcut references no longer force a full re-render per chunk.** A `[text]` reference can only change rendering once a matching `[label]:` definition exists, so the gate now keys on definitions rather than any bracket syntax. Task lists and bare citations stay reusable; a full re-render is paid once, only when a definition actually invalidates prior uses.

🐛 **Correctness fix (review follow-up).** Closed the mirror case the new gate first missed: a reference definition sitting in the reused prefix is invisible to a tail-only re-lex, so a use appended in the tail would have rendered as plain text instead of a link. Now gated behind a cheap `]:` prefilter so definition-free streams keep the optimization.

🔧 **Efficiency.** The reference predicate is computed once per `update()` and threaded through `parseSource`/`canUseTailWindow` instead of being evaluated twice per frame.

🧪 **Testing.** Added coverage for closed/unclosed/self-closing HTML tail windows, citations and task lists without definitions, and both directions of the definition↔use ordering. The `test`→`fix` commit pair for the follow-up is intentionally ordered so the regression is visible red before it goes green.

## Commits

- [`818fe31`](https://github.com/humanspeak/svelte-markdown/commit/818fe31b42d5f29c3504ce7d8b27c4b6b71dd53c) test(parser): cover tail-window kill switches
- [`4b5e78f`](https://github.com/humanspeak/svelte-markdown/commit/4b5e78f2cd811fa92d9ca65fa9a08607730c60fb) fix(parser): narrow tail-window kill switches
- [`bc96032`](https://github.com/humanspeak/svelte-markdown/commit/bc960326084543813530e0bbbdcc0323e3707dca) refactor(parser): compute tail-window reference predicate once
- [`5a1188b`](https://github.com/humanspeak/svelte-markdown/commit/5a1188b1b1c10e194663f2a052b09c9d23caa825) fix(parser): resolve prefix reference defs for tail-window uses

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
