### PR TITLE
fix(docs): make IndexNow submission non-blocking for deploys

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -121,7 +121,11 @@ export default defineConfig({
         indexNowPlugin({
             siteUrl: docsConfig.url,
             key: indexNowKey,
-            productionMode: 'indexnow'
+            productionMode: 'indexnow',
+            // IndexNow is a best-effort search-engine ping; a rejected submission
+            // (e.g. transient 403 UserForbiddedToAccessSite) must not fail the
+            // build and block the docs deploy. Log and continue instead.
+            failOnError: false
         }),
         tailwindcss(),
         sveltekit()


### PR DESCRIPTION
## Summary

The production docs deploy has failed on the last two merges to `main` (#330, #334) — not because of anything in those PRs, but because a transient IndexNow rejection is treated as a fatal build error. This makes the IndexNow ping non-blocking so a flaky third-party response can't stop the site from shipping.

## Root cause

`docs` deploy runs `vite build --mode indexnow` → the `@humanspeak/docs-kit` `indexnow` plugin POSTs sitemap URLs to `api.indexnow.org` in `closeBundle`. Its `failOnError` defaults to `true`, so a non-2xx response **throws and fails the Vite build before `wrangler deploy` runs**. IndexNow returned `403 UserForbiddedToAccessSite`, so the docs never deployed.

Verified the setup is otherwise correct:
- ✅ `static/71d77690-….txt` exists and its contents equal the key
- ✅ `https://markdown.svelte.page/71d77690-….txt` serves `HTTP 200` with the correct key
- ✅ host / `keyLocation` are correct

So the 403 is an IndexNow-side decision (most likely transient abuse/ownership throttling after several submissions in a short window), not a misconfiguration. The real defect is that a best-effort search ping gates production deploys.

## Changes

🐛 Set `failOnError: false` on the `indexNowPlugin(...)` options in `docs/vite.config.ts`. A rejected submission now logs a warning and the build/deploy proceeds. IndexNow success paths are unchanged.

## Validation

- `pnpm run check` in `docs/` → 0 errors (`failOnError?: boolean` is a documented plugin option).
- Default `vite build` mode never submits to IndexNow; only `--mode indexnow` does, and it now degrades to a warning on failure.

## Follow-up

The IndexNow 403 itself is likely transient. If it persists, the key may need re-registering with Bing/IndexNow — tracked separately, not required for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
