### PR TITLE
perf(parser): keep streaming bookkeeping proportional to the chunk

### DIFF
--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -333,6 +333,21 @@ describe('IncrementalParser', () => {
             expect(result.tokens).toEqual(full)
         })
 
+        it('resolves a full reference use split across the append boundary', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            // A full reference `[a][b]` (LINK_REFERENCE_RE, a different path
+            // than a shortcut `[docs]`) straddles the boundary: `See [a][` then
+            // `b]`. The definition arrives afterward and must force a full parse.
+            parser.update('See [a][')
+            parser.update('See [a][b]\n\nTail')
+            const final = 'See [a][b]\n\nTail\n\n[b]: /x'
+
+            const result = parser.update(final)
+            const full = parseAndCacheModule.lexAndClean(final, createDefaultOptions(), false)
+
+            expect(result.tokens).toEqual(full)
+        })
+
         it('keeps stable token reuse for appended definitions when no reference use exists', () => {
             const parser = new IncrementalParser(createDefaultOptions())
             // Definition labels look like shortcut references, but they are not

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -12,7 +12,7 @@ interface InternalParser {
     hasHtmlSpanMismatch: (token: Token) => boolean
     hasPotentialReferenceUse: (source: string) => boolean
     hasReferenceDefinition: (source: string) => boolean
-    appendIntroducesMatch: (source: string, matches: (candidate: string) => boolean) => boolean
+    appendIntroducesMatch: (source: string, matches: (_candidate: string) => boolean) => boolean
     canUseTailWindow: (
         source: string,
         boundary: { prefixCount: number; reparseOffset: number }

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -1,12 +1,17 @@
 import type { SvelteMarkdownOptions } from '$lib/types.js'
+import type { Token } from '$lib/utils/markdown-parser.js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { IncrementalParser } from './incremental-parser.js'
 import * as parseAndCacheModule from './parse-and-cache.js'
 
 /** Private surface of `IncrementalParser` exercised by the tail-window tests. */
 interface InternalParser {
+    prevTokens: Token[]
     prevSource: string
     getTailWindowBoundary: () => { prefixCount: number; reparseOffset: number }
+    hasHtmlSpanMismatch: (token: Token) => boolean
+    hasPotentialReferenceUse: (source: string) => boolean
+    hasReferenceDefinition: (source: string) => boolean
     canUseTailWindow: (
         source: string,
         boundary: { prefixCount: number; reparseOffset: number }
@@ -447,6 +452,138 @@ describe('IncrementalParser', () => {
             parser.update(appended)
 
             expect(lexSpy.mock.calls[1]?.[0]).toBe(appended)
+        })
+    })
+
+    describe('Streaming Bookkeeping Performance', () => {
+        it('does not rescan every stable prefix token to compute the tail-window offset', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = Array.from(
+                { length: 40 },
+                (_, index) => `# Heading ${index}\n\nParagraph ${index}`
+            ).join('\n\n')
+
+            parser.update(source)
+
+            const internalParser = asInternalParser(parser)
+            let sourceLengthReads = 0
+
+            for (const token of internalParser.prevTokens.slice(0, -1)) {
+                const sourceLength = token.raw.length
+                Object.defineProperty(token, 'sourceLength', {
+                    configurable: true,
+                    get() {
+                        sourceLengthReads++
+                        return sourceLength
+                    }
+                })
+            }
+
+            parser.update(`${source}\n\nAppended tail`)
+
+            expect(sourceLengthReads).toBeLessThanOrEqual(1)
+        })
+
+        it('does not rescan stable closed HTML tokens when updating span-mismatch state', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = `${Array.from(
+                { length: 40 },
+                (_, index) => `<div><span>HTML ${index}</span></div>`
+            ).join('\n\n')}\n\nTail`
+
+            parser.update(source)
+
+            const internalParser = asInternalParser(parser)
+            const originalHasHtmlSpanMismatch = internalParser.hasHtmlSpanMismatch
+            let spanMismatchChecks = 0
+
+            internalParser.hasHtmlSpanMismatch = (token) => {
+                spanMismatchChecks++
+                return originalHasHtmlSpanMismatch(token)
+            }
+
+            parser.update(`${source}\n\nAppended tail`)
+
+            expect(spanMismatchChecks).toBeLessThanOrEqual(3)
+        })
+
+        it('does not scan the full previous source for reference uses when no definitions exist', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = Array.from(
+                { length: 120 },
+                (_, index) => `Citation [${index}] and task - [ ] item ${index}.`
+            ).join('\n')
+
+            parser.update(source)
+
+            const internalParser = asInternalParser(parser)
+            const originalHasPotentialReferenceUse = internalParser.hasPotentialReferenceUse
+            const scannedLengths: number[] = []
+
+            internalParser.hasPotentialReferenceUse = (scannedSource) => {
+                scannedLengths.push(scannedSource.length)
+                return originalHasPotentialReferenceUse(scannedSource)
+            }
+
+            parser.update(`${source}\n\nPlain appended tail without definitions.`)
+
+            expect(Math.max(...scannedLengths)).toBeLessThan(source.length / 4)
+        })
+
+        it('keeps the tail-window offset correct across closed HTML source spans', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = '<div><section><p>Nested</p></section></div>\n\nTail'
+
+            parser.update(source)
+
+            const boundary = asInternalParser(parser).getTailWindowBoundary()
+
+            expect(boundary.reparseOffset).toBe(source.length - 'Tail'.length)
+            expect(source.slice(boundary.reparseOffset)).toBe('Tail')
+        })
+
+        it('keeps reference definitions in the prefix visible to appended shortcut uses', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = '[docs]: /docs\n\nIntro paragraph.\n\n'
+            const appended = `${source}See [docs] for details.`
+
+            parser.update(source)
+            const result = parser.update(appended)
+            const full = parseAndCacheModule.lexAndClean(appended, createDefaultOptions(), false)
+
+            expect(lexSpy.mock.calls[1]?.[0]).toBe(appended)
+            expect(result.tokens).toEqual(full)
+        })
+
+        it('does not rescan the stable prefix after a full-relex fallback has refreshed state', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = `${Array.from(
+                { length: 40 },
+                (_, index) => `# Heading ${index}\n\nParagraph with [docs] ${index}`
+            ).join('\n\n')}\n\nTail`
+            const withDefinition = `${source}\n\n[docs]: /docs`
+
+            parser.update(source)
+            parser.update(withDefinition)
+
+            const internalParser = asInternalParser(parser)
+            let sourceLengthReads = 0
+
+            for (const token of internalParser.prevTokens.slice(0, -1)) {
+                const sourceLength = token.raw.length
+                Object.defineProperty(token, 'sourceLength', {
+                    configurable: true,
+                    get() {
+                        sourceLengthReads++
+                        return sourceLength
+                    }
+                })
+            }
+
+            parser.update(`${withDefinition}\n\nAppended tail after fallback`)
+
+            expect(sourceLengthReads).toBeLessThanOrEqual(1)
         })
     })
 })

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -291,6 +291,31 @@ describe('IncrementalParser', () => {
             expect(incremental.tokens).toEqual(full)
         })
 
+        it('falls back to a full re-lex when reference syntax is split across chunks', () => {
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const options = createDefaultOptions()
+
+            const splitUseParser = new IncrementalParser(options)
+            splitUseParser.update('See [do')
+            splitUseParser.update('See [docs]\n\nTail')
+            const splitUseWithDefinition = 'See [docs]\n\nTail\n\n[docs]: /docs'
+
+            splitUseParser.update(splitUseWithDefinition)
+
+            expect(lexSpy.mock.calls[2]?.[0]).toBe(splitUseWithDefinition)
+
+            lexSpy.mockClear()
+
+            const splitDefinitionParser = new IncrementalParser(options)
+            splitDefinitionParser.update('See [docs]\n\nTail')
+            splitDefinitionParser.update('See [docs]\n\nTail\n\n[do')
+            const splitDefinition = 'See [docs]\n\nTail\n\n[docs]: /docs'
+
+            splitDefinitionParser.update(splitDefinition)
+
+            expect(lexSpy.mock.calls[2]?.[0]).toBe(splitDefinition)
+        })
+
         it('keeps full reference syntax conservative until its definition arrives', () => {
             const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
             const parser = new IncrementalParser(createDefaultOptions())

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -12,6 +12,7 @@ interface InternalParser {
     hasHtmlSpanMismatch: (token: Token) => boolean
     hasPotentialReferenceUse: (source: string) => boolean
     hasReferenceDefinition: (source: string) => boolean
+    appendIntroducesMatch: (source: string, matches: (candidate: string) => boolean) => boolean
     canUseTailWindow: (
         source: string,
         boundary: { prefixCount: number; reparseOffset: number }
@@ -316,6 +317,38 @@ describe('IncrementalParser', () => {
             expect(lexSpy.mock.calls[2]?.[0]).toBe(splitDefinition)
         })
 
+        it('resolves a reference definition completed across several partial appends', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            // The `[docs]:` marker is built one character-run at a time, so the
+            // boundary-crossing line grows across three appends before it first
+            // parses as a definition.
+            parser.update('[d')
+            parser.update('[doc')
+            parser.update('[docs]: /x\n\n')
+            const final = '[docs]: /x\n\nSee [docs].'
+
+            const result = parser.update(final)
+            const full = parseAndCacheModule.lexAndClean(final, createDefaultOptions(), false)
+
+            expect(result.tokens).toEqual(full)
+        })
+
+        it('keeps stable token reuse for appended definitions when no reference use exists', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            // Definition labels look like shortcut references, but they are not
+            // renderable uses — appending another definition cannot change any
+            // rendered link, so the tail window stays usable.
+            const source = '[a]: /1\n\nIntro paragraph.\n\n'
+            parser.update(source)
+
+            const appended = `${source}[b]: /2`
+            const result = parser.update(appended)
+            const full = parseAndCacheModule.lexAndClean(appended, createDefaultOptions(), false)
+
+            expect(result.canReuse).toBe(true)
+            expect(result.tokens).toEqual(full)
+        })
+
         it('keeps full reference syntax conservative until its definition arrives', () => {
             const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
             const parser = new IncrementalParser(createDefaultOptions())
@@ -609,6 +642,52 @@ describe('IncrementalParser', () => {
             parser.update(`${withDefinition}\n\nAppended tail after fallback`)
 
             expect(sourceLengthReads).toBeLessThanOrEqual(1)
+        })
+
+        it('scans the definition boundary at most once per append', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            // A reference use is present but its definition has not arrived yet:
+            // the state where the tail-window decision and the cached-state
+            // refresh both need to know whether the append added a definition.
+            parser.update('See [docs]\n\n')
+
+            const internalParser = asInternalParser(parser)
+            const originalAppendIntroducesMatch = internalParser.appendIntroducesMatch
+            const definitionMatcher = internalParser.hasReferenceDefinition
+            let definitionBoundaryScans = 0
+
+            internalParser.appendIntroducesMatch = (scannedSource, matches) => {
+                if (matches === definitionMatcher) definitionBoundaryScans++
+                return originalAppendIntroducesMatch(scannedSource, matches)
+            }
+
+            parser.update('See [docs]\n\nmore streamed text')
+
+            expect(definitionBoundaryScans).toBe(1)
+        })
+
+        it('reuses the cached definition flag instead of rescanning prevSource on in-place edits', () => {
+            const parser = new IncrementalParser(createDefaultOptions())
+            const source = `${Array.from({ length: 60 }, (_, index) => `See [ref${index}]`).join(
+                '\n\n'
+            )}\n\n[ref0]: /a`
+
+            parser.update(source)
+
+            const internalParser = asInternalParser(parser)
+            const originalHasReferenceDefinition = internalParser.hasReferenceDefinition
+            const scannedLengths: number[] = []
+
+            internalParser.hasReferenceDefinition = (scannedSource) => {
+                scannedLengths.push(scannedSource.length)
+                return originalHasReferenceDefinition(scannedSource)
+            }
+
+            // Non-append (in-place) edit: the reference-sensitivity check must
+            // read the cached flag for the previous source rather than rescan it.
+            parser.update('Rewritten [ref0] content\n\n[ref0]: /b')
+
+            expect(Math.max(...scannedLengths)).toBeLessThan(source.length)
         })
     })
 })

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -257,7 +257,7 @@ export class IncrementalParser {
      */
     private appendIntroducesMatch = (
         source: string,
-        matches: (candidate: string) => boolean
+        matches: (_candidate: string) => boolean
     ): boolean => {
         if (matches(source.slice(this.prevSource.length))) return true
 

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -123,15 +123,9 @@ export class IncrementalParser {
     }
 
     private getTailWindowBoundary = (): TailWindowBoundary => {
-        // (#291) If any previous HTML opening has no known source span,
-        // the tail-window prefix is unsound: `.raw` is only the opening
-        // tag itself, while children and the closing tag live elsewhere.
-        // Closed HTML tokens carry `sourceLength`, so only truly partial
-        // HTML needs to fall through to a full re-parse.
-        if (this.prevHasHtmlSpanMismatch) {
-            return { prefixCount: 0, reparseOffset: 0 }
-        }
-
+        // Precomputed at commit time by `getNextTailWindowBoundary` (which
+        // already collapses to the empty boundary on an HTML span mismatch),
+        // so the hot path is a single field read.
         return this.prevTailWindowBoundary
     }
 
@@ -243,33 +237,64 @@ export class IncrementalParser {
     }
 
     /**
-     * True when appending to `prevSource` introduces a reference definition
-     * that was not already present — i.e. the definition lives entirely in the
-     * newly appended tail. Returns false for any update that is not a pure
-     * append of `prevSource`.
+     * True when an append-only update newly introduces text accepted by
+     * `matches`. Reference uses and definitions cannot span newlines, so a
+     * token split across the append boundary can only complete on the line
+     * that straddles it; checking the appended slice plus that single boundary
+     * line catches every case without rescanning the accumulated source.
+     * Assumes `source` starts with `prevSource` — callers guard the non-append
+     * case. (The one unbounded input is a document streamed as a single
+     * newline-free line, where the boundary line grows with the document.)
      *
-     * @param source - The full new source, expected to start with `prevSource`
-     * @returns `true` if the appended tail contains a new reference definition
+     * @param source - Full source string for an append-only update
+     * @param matches - Predicate identifying the reference syntax of interest
+     * @returns `true` if the append introduces a match not already present
      * @example
      * ```typescript
-     * // prevSource === 'see [docs]\n\n'
-     * this.hasNewReferenceDefinition('see [docs]\n\n[docs]: /d')  // true
-     * this.hasNewReferenceDefinition('see [docs]\n\nmore text')   // false
+     * // prevSource === 'see [do'
+     * this.appendIntroducesMatch('see [docs]', this.hasPotentialReferenceUseOutsideDefinitions) // true
+     * ```
+     */
+    private appendIntroducesMatch = (
+        source: string,
+        matches: (candidate: string) => boolean
+    ): boolean => {
+        if (matches(source.slice(this.prevSource.length))) return true
+
+        const lineStart = this.prevSource.lastIndexOf('\n') + 1
+        // Already present on the boundary line before the append ⇒ not new.
+        if (matches(this.prevSource.slice(lineStart))) return false
+        return matches(source.slice(lineStart))
+    }
+
+    /**
+     * True when appending to `prevSource` introduces a reference definition
+     * that was not already present. Definitions can arrive wholly in the
+     * appended slice or be completed across the append boundary, such as
+     * `[do` followed by `cs]: /docs`. Returns false for any update that is not
+     * a pure append of `prevSource`.
+     *
+     * @param source - The full new source, expected to start with `prevSource`
+     * @returns `true` if the appended update adds a reference definition
+     * @example
+     * ```typescript
+     * // prevSource === '[do'
+     * this.hasNewReferenceDefinition('[docs]: /d') // true
      * ```
      */
     private hasNewReferenceDefinition = (source: string): boolean => {
         if (!source.startsWith(this.prevSource)) return false
-        return this.hasReferenceDefinition(source.slice(this.prevSource.length))
+        return this.appendIntroducesMatch(source, this.hasReferenceDefinition)
     }
 
     /**
      * True when a reference definition arriving in the appended tail can
      * retroactively change how existing reference-style uses in the stable
      * prefix render — the one case where an append-only stream is not safe
-     * to serve incrementally. Computed once per `update` and threaded through
-     * `parseSource`/`canUseTailWindow` so the hot path evaluates it a single
-     * time rather than recomputing the regexes for both the tail-window
-     * decision and the reuse decision.
+     * to serve incrementally. This is the standalone form used as
+     * `canUseTailWindow`'s default argument; the hot path in `update` computes
+     * the same value inline (reusing `appendAddsDefinition`) so the boundary
+     * scan runs a single time per update.
      *
      * @param source - The full new source string for this update
      * @returns `true` if a newly appended definition can change how the reused
@@ -388,6 +413,11 @@ export class IncrementalParser {
         sourceLength: number,
         hasHtmlSpanMismatch: boolean
     ): TailWindowBoundary => {
+        // (#291) If any token is an HTML opening with no known source span,
+        // the tail-window prefix is unsound: `.raw` is only the opening tag
+        // itself, while children and the closing tag live elsewhere. Closed
+        // HTML tokens carry `sourceLength`, so only truly partial HTML forces
+        // the empty boundary that falls through to a full re-parse.
         if (tokens.length === 0 || hasHtmlSpanMismatch) {
             return { prefixCount: 0, reparseOffset: 0 }
         }
@@ -413,28 +443,37 @@ export class IncrementalParser {
      * @param parseResult - Parsed tokens plus metadata describing whether the
      *   tail-window shortcut was used
      * @param isAppendOnly - Whether `source` appended to the previous source
+     * @param appendAddsDefinition - Whether the append introduced a reference
+     *   definition, already computed by `update` so the boundary scan is not
+     *   repeated here
      * @returns Nothing; updates `prevSource`, `prevTokens`, and cached flags
      * @example
      * ```typescript
-     * this.updateCachedState(source, parseResult, source.startsWith(this.prevSource))
+     * this.updateCachedState(source, parseResult, isAppendOnly, appendAddsDefinition)
      * ```
      */
     private updateCachedState = (
         source: string,
         parseResult: ParseSourceResult,
-        isAppendOnly: boolean
+        isAppendOnly: boolean,
+        appendAddsDefinition: boolean
     ): void => {
-        const appendedSource = isAppendOnly ? source.slice(this.prevSource.length) : source
+        // HTML-span-mismatch keys on `usedTailWindow` (a fact about the tokens,
+        // recomputed whenever the tail window is bypassed), while the reference
+        // facts key on `isAppendOnly` (facts about the source, which accumulate
+        // monotonically under a pure append regardless of parse strategy).
         const hasHtmlSpanMismatch = parseResult.usedTailWindow
             ? this.prevHasHtmlSpanMismatch || this.hasAnyHtmlSpanMismatch(parseResult.tailTokens)
             : this.hasAnyHtmlSpanMismatch(parseResult.tokens)
 
+        // `isAppendOnly` already guarantees `source.startsWith(prevSource)`, so
+        // call `appendIntroducesMatch` directly rather than re-checking it.
         this.prevHasPotentialReferenceUse = isAppendOnly
             ? this.prevHasPotentialReferenceUse ||
-              this.hasPotentialReferenceUseOutsideDefinitions(appendedSource)
+              this.appendIntroducesMatch(source, this.hasPotentialReferenceUseOutsideDefinitions)
             : this.hasPotentialReferenceUseOutsideDefinitions(source)
         this.prevHasReferenceDefinition = isAppendOnly
-            ? this.prevHasReferenceDefinition || this.hasReferenceDefinition(appendedSource)
+            ? this.prevHasReferenceDefinition || appendAddsDefinition
             : this.hasReferenceDefinition(source)
 
         this.prevSource = source
@@ -456,7 +495,14 @@ export class IncrementalParser {
     update = (source: string): IncrementalUpdateResult => {
         const boundary = this.getTailWindowBoundary()
         const isAppendOnly = this.prevSource !== '' && source.startsWith(this.prevSource)
-        const referenceInvalidatesTail = this.appendedDefinitionInvalidatesTail(source)
+        // Whether this append introduces a reference definition. Both the
+        // tail-window decision (via `referenceInvalidatesTail`) and the cached
+        // -state refresh need it, so compute the boundary scan once here. When
+        // `prevSource` is empty this is the first update, where no cached use
+        // exists yet, so `referenceInvalidatesTail` is false either way.
+        const appendAddsDefinition =
+            isAppendOnly && this.appendIntroducesMatch(source, this.hasReferenceDefinition)
+        const referenceInvalidatesTail = this.prevHasPotentialReferenceUse && appendAddsDefinition
         const parseResult = this.parseSource(source, boundary, referenceInvalidatesTail)
         const newTokens = parseResult.tokens
 
@@ -471,8 +517,7 @@ export class IncrementalParser {
         // The append-only case reuses `referenceInvalidatesTail` computed above.
         const referenceSensitive = isAppendOnly
             ? referenceInvalidatesTail
-            : (this.hasReferenceDefinition(this.prevSource) ||
-                  this.hasReferenceDefinition(source)) &&
+            : (this.prevHasReferenceDefinition || this.hasReferenceDefinition(source)) &&
               (this.hasPotentialReferenceUse(this.prevSource) ||
                   this.hasPotentialReferenceUse(source))
         const canReuse = isAppendOnly && !referenceSensitive
@@ -500,7 +545,7 @@ export class IncrementalParser {
             }
         }
 
-        this.updateCachedState(source, parseResult, isAppendOnly)
+        this.updateCachedState(source, parseResult, isAppendOnly, appendAddsDefinition)
         return { tokens: newTokens, divergeAt, canReuse }
     }
 }

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -29,6 +29,12 @@ interface TailWindowBoundary {
     reparseOffset: number
 }
 
+interface ParseSourceResult {
+    tokens: Token[]
+    tailTokens: Token[]
+    usedTailWindow: boolean
+}
+
 const CLOSED_FENCE_RE = /^ {0,3}(`{3,}|~{3,}).*\n[\s\S]*\n {0,3}\1[ \t]*\n*$/
 const LINK_REFERENCE_RE = /\[[^\]\n]+\]\[[^\]\n]*\]/
 const SHORTCUT_REFERENCE_RE = /\[[^\]\n]+\](?![[(])/ // Excludes inline links/images and full refs
@@ -87,6 +93,15 @@ export class IncrementalParser {
      *  on the hot path. */
     private prevHasHtmlSpanMismatch = false
 
+    /** Cached boundary for the next append-only update. Computed when
+     * parser state is committed so `getTailWindowBoundary` stays O(1). */
+    private prevTailWindowBoundary: TailWindowBoundary = { prefixCount: 0, reparseOffset: 0 }
+
+    /** Cached reference-syntax facts for `prevSource`. These avoid scanning
+     * the accumulated stream on every append. */
+    private prevHasPotentialReferenceUse = false
+    private prevHasReferenceDefinition = false
+
     /**
      * Creates a new incremental parser instance.
      *
@@ -108,10 +123,6 @@ export class IncrementalParser {
     }
 
     private getTailWindowBoundary = (): TailWindowBoundary => {
-        if (this.prevTokens.length === 0) {
-            return { prefixCount: 0, reparseOffset: 0 }
-        }
-
         // (#291) If any previous HTML opening has no known source span,
         // the tail-window prefix is unsound: `.raw` is only the opening
         // tag itself, while children and the closing tag live elsewhere.
@@ -121,24 +132,7 @@ export class IncrementalParser {
             return { prefixCount: 0, reparseOffset: 0 }
         }
 
-        let offset = 0
-        for (let i = 0; i < this.prevTokens.length - 1; i++) {
-            offset += this.getTokenSourceLength(this.prevTokens[i])
-        }
-
-        const lastToken = this.prevTokens[this.prevTokens.length - 1]
-
-        if (this.isStableAtSourceEnd(lastToken)) {
-            return {
-                prefixCount: this.prevTokens.length,
-                reparseOffset: this.prevSource.length
-            }
-        }
-
-        return {
-            prefixCount: this.prevTokens.length - 1,
-            reparseOffset: offset
-        }
+        return this.prevTailWindowBoundary
     }
 
     /**
@@ -203,6 +197,33 @@ export class IncrementalParser {
     }
 
     /**
+     * True when `source` contains reference-style link syntax outside
+     * reference definition lines. Definition labels (`[docs]: /docs`) look
+     * like shortcut references to `SHORTCUT_REFERENCE_RE`, but they are not
+     * renderable uses and should not keep a stream reference-sensitive after
+     * the definition has already been handled.
+     *
+     * @param source - Markdown source or source slice to scan
+     * @returns `true` if a full or shortcut reference use appears on a
+     *   non-definition line
+     * @example
+     * ```typescript
+     * this.hasPotentialReferenceUseOutsideDefinitions('[docs]: /docs') // false
+     * this.hasPotentialReferenceUseOutsideDefinitions('see [docs]')     // true
+     * ```
+     */
+    private hasPotentialReferenceUseOutsideDefinitions = (source: string): boolean => {
+        if (!source.includes('[') || !source.includes(']')) return false
+
+        for (const line of source.split('\n')) {
+            if (REFERENCE_DEFINITION_RE.test(line)) continue
+            if (this.hasPotentialReferenceUse(line)) return true
+        }
+
+        return false
+    }
+
+    /**
      * True when `source` contains a link reference definition line
      * (`[label]: url`). A definition can retroactively change how reference
      * uses elsewhere in the document render, which is what makes it relevant
@@ -260,7 +281,7 @@ export class IncrementalParser {
      * ```
      */
     private appendedDefinitionInvalidatesTail = (source: string): boolean =>
-        this.hasPotentialReferenceUse(this.prevSource) && this.hasNewReferenceDefinition(source)
+        this.prevHasPotentialReferenceUse && this.hasNewReferenceDefinition(source)
 
     /**
      * Decides whether an update may reuse the stable token prefix and re-lex
@@ -297,14 +318,11 @@ export class IncrementalParser {
 
         // A reference definition living in the reused prefix is invisible to a
         // tail-only re-lex (marked's link map is per-lex), so any reference use
-        // in the tail slice would render unresolved. `]:` is the cheap, no-alloc
-        // prefilter for "a definition marker exists at all" — task lists and
-        // bare citations never hit it, so the O(n) slice + regex is paid only by
-        // documents that actually carry reference definitions.
-        if (this.prevSource.includes(']:')) {
-            const prefix = source.slice(0, boundary.reparseOffset)
+        // in the tail slice would render unresolved. The cached definition flag
+        // keeps definition-free streams on the cheap path.
+        if (this.prevHasReferenceDefinition) {
             const tail = source.slice(boundary.reparseOffset)
-            if (this.hasReferenceDefinition(prefix) && this.hasPotentialReferenceUse(tail)) {
+            if (this.hasPotentialReferenceUseOutsideDefinitions(tail)) {
                 return false
             }
         }
@@ -316,13 +334,117 @@ export class IncrementalParser {
         source: string,
         boundary: TailWindowBoundary,
         referenceInvalidatesTail: boolean
-    ): Token[] => {
+    ): ParseSourceResult => {
         if (!this.canUseTailWindow(source, boundary, referenceInvalidatesTail)) {
-            return lexAndClean(source, this.options, false)
+            return {
+                tokens: lexAndClean(source, this.options, false),
+                tailTokens: [],
+                usedTailWindow: false
+            }
         }
 
         const tailTokens = lexAndClean(source.slice(boundary.reparseOffset), this.options, false)
-        return [...this.prevTokens.slice(0, boundary.prefixCount), ...tailTokens]
+        return {
+            tokens: [...this.prevTokens.slice(0, boundary.prefixCount), ...tailTokens],
+            tailTokens,
+            usedTailWindow: true
+        }
+    }
+
+    /**
+     * True when any token in `tokens` has an unknown HTML source span. Tail
+     * reparsing can reuse a prefix only when prefix token lengths still map to
+     * source offsets; unclosed HTML openings break that invariant.
+     *
+     * @param tokens - Tokens to inspect for unknown HTML spans
+     * @returns `true` if at least one token makes tail-window offsets unsafe
+     * @example
+     * ```typescript
+     * this.hasAnyHtmlSpanMismatch(tailTokens) // scan only the reparsed tail
+     * ```
+     */
+    private hasAnyHtmlSpanMismatch = (tokens: Token[]): boolean => {
+        return tokens.some(this.hasHtmlSpanMismatch)
+    }
+
+    /**
+     * Computes and caches the next stable-prefix boundary once per committed
+     * parser state. The hot-path `getTailWindowBoundary` then returns this
+     * object without summing every prefix token on every append.
+     *
+     * @param tokens - Latest token array after parsing the current source
+     * @param sourceLength - Character length of the current source
+     * @param hasHtmlSpanMismatch - Whether any current token has an unknown
+     *   source span
+     * @returns The prefix token count and source offset to reuse on the next
+     *   append-only update
+     * @example
+     * ```typescript
+     * this.prevTailWindowBoundary = this.getNextTailWindowBoundary(tokens, source.length, false)
+     * ```
+     */
+    private getNextTailWindowBoundary = (
+        tokens: Token[],
+        sourceLength: number,
+        hasHtmlSpanMismatch: boolean
+    ): TailWindowBoundary => {
+        if (tokens.length === 0 || hasHtmlSpanMismatch) {
+            return { prefixCount: 0, reparseOffset: 0 }
+        }
+
+        const lastToken = tokens[tokens.length - 1]
+        if (this.isStableAtSourceEnd(lastToken)) {
+            return { prefixCount: tokens.length, reparseOffset: sourceLength }
+        }
+
+        return {
+            prefixCount: tokens.length - 1,
+            reparseOffset: sourceLength - this.getTokenSourceLength(lastToken)
+        }
+    }
+
+    /**
+     * Commits parser state and refreshes cached bookkeeping facts for the next
+     * update. When the current parse reused a stable prefix, only the reparsed
+     * tail is inspected for HTML span mismatches so append-only streaming stays
+     * proportional to the newly parsed region.
+     *
+     * @param source - Full source string for the just-completed update
+     * @param parseResult - Parsed tokens plus metadata describing whether the
+     *   tail-window shortcut was used
+     * @param isAppendOnly - Whether `source` appended to the previous source
+     * @returns Nothing; updates `prevSource`, `prevTokens`, and cached flags
+     * @example
+     * ```typescript
+     * this.updateCachedState(source, parseResult, source.startsWith(this.prevSource))
+     * ```
+     */
+    private updateCachedState = (
+        source: string,
+        parseResult: ParseSourceResult,
+        isAppendOnly: boolean
+    ): void => {
+        const appendedSource = isAppendOnly ? source.slice(this.prevSource.length) : source
+        const hasHtmlSpanMismatch = parseResult.usedTailWindow
+            ? this.prevHasHtmlSpanMismatch || this.hasAnyHtmlSpanMismatch(parseResult.tailTokens)
+            : this.hasAnyHtmlSpanMismatch(parseResult.tokens)
+
+        this.prevHasPotentialReferenceUse = isAppendOnly
+            ? this.prevHasPotentialReferenceUse ||
+              this.hasPotentialReferenceUseOutsideDefinitions(appendedSource)
+            : this.hasPotentialReferenceUseOutsideDefinitions(source)
+        this.prevHasReferenceDefinition = isAppendOnly
+            ? this.prevHasReferenceDefinition || this.hasReferenceDefinition(appendedSource)
+            : this.hasReferenceDefinition(source)
+
+        this.prevSource = source
+        this.prevTokens = parseResult.tokens
+        this.prevHasHtmlSpanMismatch = hasHtmlSpanMismatch
+        this.prevTailWindowBoundary = this.getNextTailWindowBoundary(
+            parseResult.tokens,
+            source.length,
+            hasHtmlSpanMismatch
+        )
     }
 
     /**
@@ -333,8 +455,10 @@ export class IncrementalParser {
      */
     update = (source: string): IncrementalUpdateResult => {
         const boundary = this.getTailWindowBoundary()
+        const isAppendOnly = this.prevSource !== '' && source.startsWith(this.prevSource)
         const referenceInvalidatesTail = this.appendedDefinitionInvalidatesTail(source)
-        const newTokens = this.parseSource(source, boundary, referenceInvalidatesTail)
+        const parseResult = this.parseSource(source, boundary, referenceInvalidatesTail)
+        const newTokens = parseResult.tokens
 
         // Apply walkTokens if configured
         if (typeof this.options.walkTokens === 'function') {
@@ -345,7 +469,6 @@ export class IncrementalParser {
         // so force a full rerender when definitions are present alongside
         // reference-style uses. Shortcut-looking text alone stays reusable.
         // The append-only case reuses `referenceInvalidatesTail` computed above.
-        const isAppendOnly = this.prevSource !== '' && source.startsWith(this.prevSource)
         const referenceSensitive = isAppendOnly
             ? referenceInvalidatesTail
             : (this.hasReferenceDefinition(this.prevSource) ||
@@ -377,9 +500,7 @@ export class IncrementalParser {
             }
         }
 
-        this.prevSource = source
-        this.prevTokens = newTokens
-        this.prevHasHtmlSpanMismatch = newTokens.some(this.hasHtmlSpanMismatch)
+        this.updateCachedState(source, parseResult, isAppendOnly)
         return { tokens: newTokens, divergeAt, canReuse }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the quadratic streaming path described in #326. Each `update()` call
previously did bookkeeping proportional to the **entire accumulated document**
— re-summing every prefix token to find the tail-window boundary, re-scanning
the full previous source for reference syntax, and re-validating every token
for HTML span mismatches. For a long streamed response (many small flushes)
this made even the happy path O(n²). This PR makes per-chunk bookkeeping
proportional to the **appended chunk** by caching state at commit time and only
scanning the newly appended region (plus the single line that straddles the
append boundary, since reference syntax cannot span newlines).

Behavior is unchanged: the full unit suite passes (888 tests), and each new
invariant test was mutation-verified to fail when its guarantee is broken.

Closes #326

## Changes

🔧 **O(chunk) streaming bookkeeping**
- Cache the tail-window boundary at commit time; `getTailWindowBoundary` is now
  an O(1) field read instead of summing every prefix token per append.
- Cache reference-syntax facts (`prevHasReferenceDefinition`,
  `prevHasPotentialReferenceUse`) and accumulate them from the appended chunk
  instead of rescanning the full previous source.
- Scan only the reparsed tail for HTML span mismatches when the tail window is
  reused, rather than re-validating the whole token array.

🐛 **Correctness under split streaming**
- Reference syntax (`[a]`, `[a][b]`, `[label]: url`) whose characters straddle
  an append boundary is now caught by re-scanning the boundary-crossing line,
  so a definition or use completed across chunks still forces a full parse
  instead of rendering as unresolved literal text.

🔧 **Consolidation / cleanup**
- Replace duplicated boundary-scan scaffolding with a single
  predicate-parameterized `appendIntroducesMatch` helper.
- Collapse the redundant HTML-mismatch guard so the boundary rule has one owner.
- Reuse the cached definition flag in the reuse decision, and compute the
  definition boundary scan once per update (removing a double evaluation in the
  "reference use present, definition not yet arrived" streaming state).

🧪 **Testing**
- Streaming bookkeeping perf guards (offset/HTML/reference scans stay bounded).
- Reference syntax split across chunks — including a full reference `[a][b]`
  and a definition completed across several partial appends.
- Cached-flag reuse on in-place edits; definitions without a use stay reusable.

## Commits

- [`7a6d9da`](https://github.com/humanspeak/svelte-markdown/commit/7a6d9da5523d1cafa76239b548df1ebf83620d29) perf(parser): cache streaming bookkeeping state
- [`3510869`](https://github.com/humanspeak/svelte-markdown/commit/35108698bdbd775d21a476586d88ff5b599298e4) test(parser): cover streaming bookkeeping perf
- [`025b2c7`](https://github.com/humanspeak/svelte-markdown/commit/025b2c74e99ccb3d2ec911ca8fea9e3981ffdaae) refactor(parser): consolidate streaming bookkeeping helpers
- [`011deaf`](https://github.com/humanspeak/svelte-markdown/commit/011deaff2d67b9e2c4900f1b1ad416143830e931) test(parser): guard streaming bookkeeping invariants
- [`95ad2d8`](https://github.com/humanspeak/svelte-markdown/commit/95ad2d8e1c3b635a02848d042e1f856a9d37f05b) test(parser): cover full reference use split across append boundary
