### PR TITLE
fix(streaming): stable heading ids and flash-free token splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,8 @@ Appending directly to `source` is still supported:
 
 When `streaming` is `false` (default), existing behavior is unchanged. The `streaming` prop skips cache lookups (always a miss during streaming) and uses in-place token array mutation so Svelte only re-renders components for tokens that actually changed.
 
+Default heading ids are precomputed per render pass during streaming, so duplicate-heading suffixes and `headerPrefix` stay stable across reparses. Custom heading renderers should use the provided `id` prop for this behavior; calling the `slug` prop directly advances renderer-local slug state.
+
 **Note:** `streaming` is automatically disabled when async extensions (e.g., `markedMermaid`) are used. A console warning is logged in this case.
 
 See the [full streaming documentation](https://markdown.svelte.page/docs/advanced/llm-streaming) and [interactive demo](https://markdown.svelte.page/examples/llm-streaming).
@@ -982,18 +984,18 @@ This package takes a defense-in-depth approach to security. The defaults below a
 
 Part of the [Humanspeak](https://humanspeak.com) family of runes-native Svelte 5 packages:
 
-| Package | Description |
-| --- | --- |
+| Package                                                                          | Description                          |
+| -------------------------------------------------------------------------------- | ------------------------------------ |
 | **[@humanspeak/svelte-markdown](https://markdown.svelte.page)** — _this package_ | Runtime markdown renderer for Svelte |
-| [@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page) | Virtual scrolling for Svelte |
-| [@humanspeak/svelte-motion](https://motion.svelte.page) | Framer Motion for Svelte 5 |
-| [@humanspeak/svelte-headless-table](https://table.svelte.page) | Headless data tables for Svelte |
-| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page) | Diff comparison for Svelte |
-| [@humanspeak/svelte-purify](https://purify.svelte.page) | HTML sanitisation for Svelte |
-| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page) | Virtual chat viewport for Svelte 5 |
-| [@humanspeak/memory-cache](https://memory.svelte.page) | In-memory cache for TypeScript |
-| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page) | JSON tree viewer for Svelte 5 |
-| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page) | Scoped class props for Svelte |
+| [@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)               | Virtual scrolling for Svelte         |
+| [@humanspeak/svelte-motion](https://motion.svelte.page)                          | Framer Motion for Svelte 5           |
+| [@humanspeak/svelte-headless-table](https://table.svelte.page)                   | Headless data tables for Svelte      |
+| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page)                  | Diff comparison for Svelte           |
+| [@humanspeak/svelte-purify](https://purify.svelte.page)                          | HTML sanitisation for Svelte         |
+| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page)               | Virtual chat viewport for Svelte 5   |
+| [@humanspeak/memory-cache](https://memory.svelte.page)                           | In-memory cache for TypeScript       |
+| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page)                | JSON tree viewer for Svelte 5        |
+| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page)                    | Scoped class props for Svelte        |
 
 ## License
 

--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -72,6 +72,8 @@ function parseStats(s) {
         parseChunkAvgMs: num(grab('parseChunkAvgMs')),
         parseChunkP95Ms: num(grab('parseChunkP95Ms')),
         parseChunkPeakMs: num(grab('parseChunkPeakMs')),
+        headingCount: num(grab('headingCount')),
+        headingIdMismatches: num(grab('headingIdMismatches')),
         // Bursty-stream-only: inter-chunk gap distribution.
         streamGapAvgMs: num(grab('streamGapAvgMs')),
         streamGapP95Ms: num(grab('streamGapP95Ms')),
@@ -134,6 +136,12 @@ async function runStreamingBursty(page) {
     return runDocScenario(page, 'stream-bursty', { timeout: 120_000 })
 }
 
+async function runStreamingLarge(page) {
+    // Tight-loop ~50KB append stream. This catches accidental O(document)
+    // work per flush in the live Svelte render path.
+    return runDocScenario(page, 'stream-large', { timeout: 120_000 })
+}
+
 async function runAll(label, page) {
     console.log(`\n=== ${label} run ===`)
     const out = {}
@@ -170,6 +178,10 @@ async function runAll(label, page) {
     console.log('  → stream-bursty…')
     out.streamBursty = await runStreamingBursty(page)
     console.log('   ', JSON.stringify(out.streamBursty))
+
+    console.log('  → stream-large…')
+    out.streamLarge = await runStreamingLarge(page)
+    console.log('   ', JSON.stringify(out.streamLarge))
 
     return out
 }

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -71,8 +71,10 @@
      *
      */
 
+    import { getContext, hasContext, setContext } from 'svelte'
     import Parser from '$lib/Parser.svelte'
     import Html from '$lib/renderers/html/index.js'
+    import type { AnySnippet } from '$lib/utils/component-props.js'
     import {
         defaultRenderers,
         type Renderers,
@@ -87,9 +89,11 @@
         type SanitizeAttributesFn,
         type SanitizeUrlFn
     } from '$lib/utils/sanitize.js'
-
-    // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
-    type AnySnippet = (..._args: any[]) => any
+    import {
+        createRenderMetadata,
+        RENDER_METADATA_CONTEXT,
+        type RenderMetadata
+    } from '$lib/utils/render-metadata.js'
 
     interface Props<T extends Renderers = Renderers> {
         type?: string
@@ -119,6 +123,15 @@
     }: Props & {
         [key: string]: unknown
     } = $props()
+
+    const hasRenderMetadataContext = hasContext(RENDER_METADATA_CONTEXT)
+    const renderMetadata = hasRenderMetadataContext
+        ? getContext<RenderMetadata>(RENDER_METADATA_CONTEXT)
+        : createRenderMetadata()
+
+    if (!hasRenderMetadataContext) {
+        setContext(RENDER_METADATA_CONTEXT, renderMetadata)
+    }
 
     /**
      * Dev-only Parser-instance counter. Exposed via `window.__svmParserCount`
@@ -221,7 +234,7 @@
         {:else}
             <svelte:element this={htmlTok.tag} {...sanitizedAttrs}>
                 {#if htmlTok.tokens && htmlTok.tokens.length}
-                    {#each htmlTok.tokens as childToken, i (i)}
+                    {#each htmlTok.tokens as childToken, i (renderMetadata.getStableNodeKey(childToken, i))}
                         {@render dispatch(childToken, restProps)}
                     {/each}
                 {/if}
@@ -231,6 +244,7 @@
         <Parser
             {...restProps}
             {...token}
+            id={renderMetadata.getPreparedHeadingId(token) ?? (token as { id?: string }).id}
             {renderers}
             {snippetOverrides}
             {htmlSnippetOverrides}
@@ -243,7 +257,7 @@
 {#if !type}
     {#if tokens}
         {@const { text: _text, raw: _raw, tokens: _tokens, ...parserRest } = rest}
-        {#each tokens as token, index (index)}
+        {#each tokens as token, index (renderMetadata.getStableNodeKey(token, index))}
             {@render dispatch(token, parserRest)}
         {/each}
     {/if}
@@ -260,10 +274,10 @@
                 {#if renderers.tablehead}
                     {#snippet theadContent()}
                         {#snippet headerRowContent()}
-                            {#each header ?? [] as headerItem, i (i)}
+                            {#each header ?? [] as headerItem, i (renderMetadata.getStableNodeKey(headerItem, i))}
                                 {@const { align: _align, ...cellRest } = sanitizedRest}
                                 {#snippet headerCellContent()}
-                                    {#each headerItem.tokens ?? [] as headerCellToken, k (k)}
+                                    {#each headerItem.tokens ?? [] as headerCellToken, k (renderMetadata.getStableNodeKey(headerCellToken, k))}
                                         {@render dispatch(headerCellToken, {})}
                                     {/each}
                                 {/snippet}
@@ -306,12 +320,12 @@
                 {/if}
                 {#if renderers.tablebody}
                     {#snippet tbodyContent()}
-                        {#each rows ?? [] as row, i (i)}
+                        {#each rows ?? [] as row, i (renderMetadata.getStableRowKey(row, i))}
                             {#snippet bodyRowContent()}
-                                {#each row ?? [] as cells, j (j)}
+                                {#each row ?? [] as cells, j (renderMetadata.getStableNodeKey(cells, j))}
                                     {@const { align: _align, ...cellRest } = sanitizedRest}
                                     {#snippet bodyCellContent()}
-                                        {#each cells.tokens ?? [] as cellToken, index (index)}
+                                        {#each cells.tokens ?? [] as cellToken, index (renderMetadata.getStableNodeKey(cellToken, index))}
                                             {@render dispatch(cellToken, cellRest)}
                                         {/each}
                                     {/snippet}
@@ -372,12 +386,12 @@
             {#snippet orderedListContent()}
                 {@const { items: _items, ...parserRest } = sanitizedRest}
                 {@const items = (_items as Props[] | undefined) ?? []}
-                {#each items as item, index (index)}
+                {#each items as item, index (renderMetadata.getStableNodeKey(item, index))}
                     {@const OrderedListComponent = renderers.orderedlistitem || renderers.listitem}
                     {@const orderedItemSnippet =
                         snippetOverrides['orderedlistitem'] || snippetOverrides['listitem']}
                     {#snippet orderedItemContent()}
-                        {#each item.tokens ?? [] as itemToken, k (k)}
+                        {#each item.tokens ?? [] as itemToken, k (renderMetadata.getStableNodeKey(itemToken, k))}
                             {@render dispatch(itemToken, parserRest)}
                         {/each}
                     {/snippet}
@@ -401,13 +415,13 @@
             {#snippet unorderedListContent()}
                 {@const { items: _items, ...parserRest } = sanitizedRest}
                 {@const items = (_items as Props[] | undefined) ?? []}
-                {#each items as item, index (index)}
+                {#each items as item, index (renderMetadata.getStableNodeKey(item, index))}
                     {@const UnorderedListComponent =
                         renderers.unorderedlistitem || renderers.listitem}
                     {@const unorderedItemSnippet =
                         snippetOverrides['unorderedlistitem'] || snippetOverrides['listitem']}
                     {#snippet unorderedItemContent()}
-                        {#each item.tokens ?? [] as itemToken, k (k)}
+                        {#each item.tokens ?? [] as itemToken, k (renderMetadata.getStableNodeKey(itemToken, k))}
                             {@render dispatch(itemToken, parserRest)}
                         {/each}
                     {/snippet}
@@ -438,7 +452,7 @@
         {#if htmlSnippet}
             {#snippet htmlSnippetChildren()}
                 {#if tokens && (tokens as Token[]).length}
-                    {#each tokens as childToken, index (index)}
+                    {#each tokens as childToken, index (renderMetadata.getStableNodeKey(childToken, index))}
                         {@render dispatch(childToken, localRestForChildren)}
                     {/each}
                 {:else}
@@ -454,7 +468,7 @@
             {#if HtmlComponent}
                 <HtmlComponent {...sanitizedRest}>
                     {#if tokens && (tokens as Token[]).length}
-                        {#each tokens as childToken, index (index)}
+                        {#each tokens as childToken, index (renderMetadata.getStableNodeKey(childToken, index))}
                             {@render dispatch(childToken, localRestForChildren)}
                         {/each}
                     {:else}
@@ -467,7 +481,7 @@
                 Object.entries(localRest).filter(([key]) => key !== 'tokens')
             )}
             {@const fallbackTokens = (tokens as Token[]) ?? ([] as Token[])}
-            {#each fallbackTokens as fallbackToken, index (index)}
+            {#each fallbackTokens as fallbackToken, index (renderMetadata.getStableNodeKey(fallbackToken, index))}
                 {@render dispatch(fallbackToken, fallbackRest)}
             {/each}
         {/if}
@@ -478,7 +492,7 @@
         {#snippet renderChildren()}
             {#if tokens}
                 {@const { text: _text, raw: _raw, ...parserRest } = sanitizedRest}
-                {#each tokens as childToken, index (index)}
+                {#each tokens as childToken, index (renderMetadata.getStableNodeKey(childToken, index))}
                     {@render dispatch(childToken, parserRest)}
                 {/each}
             {:else}

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -21,6 +21,13 @@
         'track',
         'wbr'
     ])
+
+    /**
+     * Shared empty prop bag spread into non-heading dispatch. Hoisted so the
+     * common (non-heading) branch reuses one frozen object instead of
+     * allocating a fresh `{}` per dispatched token.
+     */
+    const NO_EXTRA_PROPS = Object.freeze({})
 </script>
 
 <script lang="ts">
@@ -248,7 +255,7 @@
                           renderMetadata.getPreparedHeadingId(token) ??
                           (token as { id?: string }).id
                   }
-                : {}}
+                : NO_EXTRA_PROPS}
         <Parser
             {...restProps}
             {...token}

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -241,10 +241,18 @@
             </svelte:element>
         {/if}
     {:else}
+        {@const headingIdProps =
+            token.type === 'heading'
+                ? {
+                      id:
+                          renderMetadata.getPreparedHeadingId(token) ??
+                          (token as { id?: string }).id
+                  }
+                : {}}
         <Parser
             {...restProps}
             {...token}
-            id={renderMetadata.getPreparedHeadingId(token) ?? (token as { id?: string }).id}
+            {...headingIdProps}
             {renderers}
             {snippetOverrides}
             {htmlSnippetOverrides}

--- a/src/lib/SvelteMarkdown.issue-328.test.ts
+++ b/src/lib/SvelteMarkdown.issue-328.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Regression coverage for issue #328.
+ *
+ * Streaming reparses should not let generated heading ids drift, and token
+ * splits should not remount downstream DOM nodes whose source position stayed
+ * stable.
+ *
+ * https://github.com/humanspeak/svelte-markdown/issues/328
+ */
+
+import '@testing-library/jest-dom'
+import { act, render } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import SvelteMarkdown from './SvelteMarkdown.svelte'
+import TrackedListItem from './test/issues/issue-328/TrackedListItem.svelte'
+import TrackedParagraph from './test/issues/issue-328/TrackedParagraph.svelte'
+import type { SvelteMarkdownProps } from './types.js'
+import type { Renderers, Token } from './utils/markdown-parser.js'
+import { tokenCache } from './utils/token-cache.js'
+
+beforeEach(() => {
+    tokenCache.clearAllTokens()
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        return setTimeout(() => callback(performance.now()), 16) as unknown as number
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+})
+
+const flushStreamingBatch = async () => {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(50)
+    })
+}
+
+const headingIds = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('h1,h2,h3,h4,h5,h6'), (heading) => heading.id)
+
+const renderStaticHeadingIds = async (source: string) => {
+    const { container } = render(SvelteMarkdown, {
+        props: { source }
+    })
+    await flushStreamingBatch()
+
+    return headingIds(container)
+}
+
+const renderChunkedHeadingIds = async (chunks: string[]) => {
+    const { component, container } = render(SvelteMarkdown, {
+        props: { source: '', streaming: true }
+    })
+
+    for (const chunk of chunks) {
+        await act(() => component.writeChunk(chunk))
+        await flushStreamingBatch()
+    }
+
+    return headingIds(container)
+}
+
+const textToken = (text: string): Token =>
+    ({
+        type: 'text',
+        raw: text,
+        text
+    }) as Token
+
+const listItemToken = (text: string): Token =>
+    ({
+        type: 'list_item',
+        raw: `- ${text}`,
+        text,
+        tokens: [textToken(text)]
+    }) as Token
+
+const listToken = (items: Token[]): Token =>
+    ({
+        type: 'list',
+        raw: items.map((item) => item.raw).join('\n'),
+        ordered: false,
+        start: 1,
+        loose: false,
+        items
+    }) as unknown as Token
+
+const tableCell = (text: string) => ({
+    text,
+    tokens: [textToken(text)]
+})
+
+const tableToken = (rows: Array<Array<ReturnType<typeof tableCell>>>): Token =>
+    ({
+        type: 'table',
+        raw: '',
+        align: [null, null],
+        header: [tableCell('Label'), tableCell('Value')],
+        rows
+    }) as unknown as Token
+
+const findBodyRow = (container: HTMLElement, text: string) =>
+    Array.from(container.querySelectorAll('tbody tr')).find((row) => row.textContent === text)
+
+describe('SvelteMarkdown streaming stability (issue #328)', () => {
+    test('keeps generated heading ids stable after a full streaming reparse', async () => {
+        const initialSource = '# Intro\n\nSee [docs][ref]'
+        const nextSource = `${initialSource}\n\n[ref]: https://example.com`
+
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: {
+                source: initialSource,
+                streaming: true
+            }
+        })
+        await flushStreamingBatch()
+
+        expect(container.querySelector('h1')).toHaveAttribute('id', 'intro')
+
+        await rerender({
+            source: nextSource,
+            streaming: true
+        })
+        await flushStreamingBatch()
+
+        expect(container.querySelector('h1')).toHaveAttribute('id', 'intro')
+    })
+
+    test('generates the same final heading ids regardless of streaming chunk boundaries', async () => {
+        const finalSource = '# Intro\n\nSee [docs][ref]\n\n[ref]: https://example.com'
+        const initialChunk = '# Intro\n\nSee [docs][ref]'
+        const referenceChunk = '\n\n[ref]: https://example.com'
+
+        const staticIds = await renderStaticHeadingIds(finalSource)
+        const singleFlushIds = await renderChunkedHeadingIds([finalSource])
+        const splitFlushIds = await renderChunkedHeadingIds([initialChunk, referenceChunk])
+
+        expect(staticIds).toEqual(['intro'])
+        expect(singleFlushIds).toEqual(staticIds)
+        expect(splitFlushIds).toEqual(staticIds)
+    })
+
+    test('keeps duplicate heading dedupe stable after a streaming reparse', async () => {
+        const initialSource = '# Intro\n\n# Intro\n\nSee [docs][ref]'
+        const nextSource = `${initialSource}\n\n[ref]: https://example.com`
+
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: {
+                source: initialSource,
+                streaming: true
+            }
+        })
+        await flushStreamingBatch()
+
+        expect(headingIds(container)).toEqual(['intro', 'intro-1'])
+
+        await rerender({
+            source: nextSource,
+            streaming: true
+        })
+        await flushStreamingBatch()
+
+        expect(headingIds(container)).toEqual(['intro', 'intro-1'])
+    })
+
+    test('keeps a downstream paragraph mounted when an earlier token split preserves its source offset', async () => {
+        const initialSource = 'Intro\n-  \n\nMore'
+        const nextSource = 'Intro\n- T\n\nMore'
+        const editOffset = 'Intro\n- '.length
+        const mounted: Array<{ text: string | undefined; element: HTMLParagraphElement }> = []
+        const destroyed: Array<{ text: string | undefined; element: HTMLParagraphElement }> = []
+
+        expect(initialSource.indexOf('More')).toBe(nextSource.indexOf('More'))
+
+        const props = {
+            source: '',
+            streaming: true,
+            renderers: {
+                paragraph: TrackedParagraph
+            } satisfies Partial<Renderers>,
+            onParagraphMount: (text: string | undefined, element: HTMLParagraphElement) => {
+                mounted.push({ text, element })
+            },
+            onParagraphDestroy: (text: string | undefined, element: HTMLParagraphElement) => {
+                destroyed.push({ text, element })
+            }
+        } satisfies SvelteMarkdownProps & {
+            onParagraphMount: (text: string | undefined, element: HTMLParagraphElement) => void
+            onParagraphDestroy: (text: string | undefined, element: HTMLParagraphElement) => void
+        }
+
+        const { component, container } = render(SvelteMarkdown, { props })
+
+        await act(() => component.resetStream(initialSource))
+        expect(container.querySelector('h2')?.textContent).toBe('Intro')
+
+        const tailBefore = container.querySelector('[data-tracked-paragraph="More"]')
+        expect(tailBefore).toBeInstanceOf(HTMLParagraphElement)
+        expect(mounted.filter((entry) => entry.text === 'More')).toHaveLength(1)
+
+        await act(() => component.writeChunk({ value: 'T', offset: editOffset }))
+
+        const tailAfter = container.querySelector('[data-tracked-paragraph="More"]')
+        expect(container.querySelector('ul li')?.textContent).toBe('T')
+        expect(tailAfter).toBe(tailBefore)
+        expect(destroyed.some((entry) => entry.text === 'More')).toBe(false)
+        expect(mounted.filter((entry) => entry.text === 'More')).toHaveLength(1)
+    })
+
+    test('keeps a stable list item mounted when a sibling is inserted before it', async () => {
+        const stableItem = listItemToken('More')
+        const insertedItem = listItemToken('Inserted')
+
+        const props = {
+            source: [listToken([stableItem])],
+            renderers: {
+                listitem: TrackedListItem
+            } satisfies Partial<Renderers>
+        } satisfies SvelteMarkdownProps
+
+        const { container, rerender } = render(SvelteMarkdown, { props })
+        const itemBefore = container.querySelector('[data-tracked-list-item="More"]')
+
+        expect(itemBefore).toBeInstanceOf(HTMLLIElement)
+
+        await rerender({
+            ...props,
+            source: [listToken([insertedItem, stableItem])]
+        })
+
+        const itemAfter = container.querySelector('[data-tracked-list-item="More"]')
+        expect(container.querySelector('li')?.textContent).toBe('Inserted')
+        expect(itemAfter).toBe(itemBefore)
+    })
+
+    test('keeps a stable table body row mounted when a sibling row is inserted before it', async () => {
+        const stableRow = [tableCell('More'), tableCell('Tail')]
+        const insertedRow = [tableCell('Inserted'), tableCell('Row')]
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: {
+                source: [tableToken([stableRow])]
+            }
+        })
+
+        const rowBefore = findBodyRow(container, 'MoreTail')
+        expect(rowBefore).toBeInstanceOf(HTMLTableRowElement)
+
+        await rerender({
+            source: [tableToken([insertedRow, stableRow])]
+        })
+
+        const rowAfter = findBodyRow(container, 'MoreTail')
+        expect(findBodyRow(container, 'InsertedRow')).toBeInstanceOf(HTMLTableRowElement)
+        expect(rowAfter).toBe(rowBefore)
+    })
+})

--- a/src/lib/SvelteMarkdown.issue-328.test.ts
+++ b/src/lib/SvelteMarkdown.issue-328.test.ts
@@ -18,6 +18,8 @@ import type { SvelteMarkdownProps } from './types.js'
 import type { Renderers, Token } from './utils/markdown-parser.js'
 import { tokenCache } from './utils/token-cache.js'
 
+type TestListItemToken = Token & { text?: string }
+
 beforeEach(() => {
     tokenCache.clearAllTokens()
     vi.useFakeTimers()
@@ -124,7 +126,8 @@ const lastParsedTokens = (parsed: ReturnType<typeof vi.fn>) =>
     parsed.mock.calls.at(-1)?.[0] as Token[] | undefined
 
 const firstListToken = (tokens: Token[] | undefined) =>
-    tokens?.find((token) => token.type === 'list') as (Token & { items: Token[] }) | undefined
+    tokens?.find((token) => token.type === 'list') as
+        (Token & { items: TestListItemToken[] }) | undefined
 
 const firstTableToken = (tokens: Token[] | undefined) =>
     tokens?.find((token) => token.type === 'table') as

--- a/src/lib/SvelteMarkdown.issue-328.test.ts
+++ b/src/lib/SvelteMarkdown.issue-328.test.ts
@@ -41,6 +41,13 @@ const flushStreamingBatch = async () => {
 const headingIds = (container: HTMLElement) =>
     Array.from(container.querySelectorAll('h1,h2,h3,h4,h5,h6'), (heading) => heading.id)
 
+const headingTextsAndIds = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('h1,h2,h3,h4,h5,h6'), (heading) => ({
+        text: heading.textContent,
+        id: heading.id,
+        inBlockquote: heading.closest('blockquote') !== null
+    }))
+
 const renderStaticHeadingIds = async (source: string) => {
     const { container } = render(SvelteMarkdown, {
         props: { source }
@@ -68,6 +75,14 @@ const textToken = (text: string): Token =>
         type: 'text',
         raw: text,
         text
+    }) as Token
+
+const paragraphToken = (text: string, raw = text): Token =>
+    ({
+        type: 'paragraph',
+        raw,
+        text,
+        tokens: [textToken(text)]
     }) as Token
 
 const listItemToken = (text: string): Token =>
@@ -105,7 +120,43 @@ const tableToken = (rows: Array<Array<ReturnType<typeof tableCell>>>): Token =>
 const findBodyRow = (container: HTMLElement, text: string) =>
     Array.from(container.querySelectorAll('tbody tr')).find((row) => row.textContent === text)
 
+const lastParsedTokens = (parsed: ReturnType<typeof vi.fn>) =>
+    parsed.mock.calls.at(-1)?.[0] as Token[] | undefined
+
+const firstListToken = (tokens: Token[] | undefined) =>
+    tokens?.find((token) => token.type === 'list') as (Token & { items: Token[] }) | undefined
+
+const firstTableToken = (tokens: Token[] | undefined) =>
+    tokens?.find((token) => token.type === 'table') as
+        (Token & { rows: Array<Array<ReturnType<typeof tableCell>>> }) | undefined
+
 describe('SvelteMarkdown streaming stability (issue #328)', () => {
+    test('renders adjacent top-level tokens with repeated zero-length spans without duplicate-key crashes', async () => {
+        const tokens = [
+            paragraphToken('Alpha'),
+            { type: 'space', raw: '' } as Token,
+            { type: 'space', raw: '' } as Token,
+            paragraphToken('Beta'),
+            { type: 'space', raw: '' } as Token,
+            paragraphToken('Gamma')
+        ]
+
+        let container: HTMLElement | undefined
+
+        expect(() => {
+            ;({ container } = render(SvelteMarkdown, {
+                props: {
+                    source: tokens,
+                    streaming: true
+                }
+            }))
+        }).not.toThrow()
+
+        expect(container?.textContent).toContain('Alpha')
+        expect(container?.textContent).toContain('Beta')
+        expect(container?.textContent).toContain('Gamma')
+    })
+
     test('keeps generated heading ids stable after a full streaming reparse', async () => {
         const initialSource = '# Intro\n\nSee [docs][ref]'
         const nextSource = `${initialSource}\n\n[ref]: https://example.com`
@@ -129,6 +180,64 @@ describe('SvelteMarkdown streaming stability (issue #328)', () => {
         expect(container.querySelector('h1')).toHaveAttribute('id', 'intro')
     })
 
+    test('keeps headerPrefix on precomputed heading ids across a streaming reparse', async () => {
+        const initialSource = '# Intro\n\nSee [docs][ref]'
+        const nextSource = `${initialSource}\n\n[ref]: https://example.com`
+
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: {
+                source: initialSource,
+                streaming: true,
+                options: {
+                    headerPrefix: 'user-content-'
+                }
+            }
+        })
+        await flushStreamingBatch()
+
+        expect(container.querySelector('h1')).toHaveAttribute('id', 'user-content-intro')
+
+        await rerender({
+            source: nextSource,
+            streaming: true,
+            options: {
+                headerPrefix: 'user-content-'
+            }
+        })
+        await flushStreamingBatch()
+
+        expect(container.querySelector('h1')).toHaveAttribute('id', 'user-content-intro')
+    })
+
+    test('does not emit ids when headerIds is false during streaming reparses', async () => {
+        const initialSource = '# Intro\n\nSee [docs][ref]'
+        const nextSource = `${initialSource}\n\n[ref]: https://example.com`
+
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: {
+                source: initialSource,
+                streaming: true,
+                options: {
+                    headerIds: false
+                }
+            }
+        })
+        await flushStreamingBatch()
+
+        expect(container.querySelector('h1')).not.toHaveAttribute('id')
+
+        await rerender({
+            source: nextSource,
+            streaming: true,
+            options: {
+                headerIds: false
+            }
+        })
+        await flushStreamingBatch()
+
+        expect(container.querySelector('h1')).not.toHaveAttribute('id')
+    })
+
     test('generates the same final heading ids regardless of streaming chunk boundaries', async () => {
         const finalSource = '# Intro\n\nSee [docs][ref]\n\n[ref]: https://example.com'
         const initialChunk = '# Intro\n\nSee [docs][ref]'
@@ -141,6 +250,35 @@ describe('SvelteMarkdown streaming stability (issue #328)', () => {
         expect(staticIds).toEqual(['intro'])
         expect(singleFlushIds).toEqual(staticIds)
         expect(splitFlushIds).toEqual(staticIds)
+    })
+
+    test('dedupes nested and top-level headings in document order after a streaming reparse', async () => {
+        const initialSource = '> # Intro\n\n# Intro\n\nSee [docs][ref]'
+        const nextSource = `${initialSource}\n\n[ref]: https://example.com`
+
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: {
+                source: initialSource,
+                streaming: true
+            }
+        })
+        await flushStreamingBatch()
+
+        expect(headingTextsAndIds(container)).toEqual([
+            { text: 'Intro', id: 'intro', inBlockquote: true },
+            { text: 'Intro', id: 'intro-1', inBlockquote: false }
+        ])
+
+        await rerender({
+            source: nextSource,
+            streaming: true
+        })
+        await flushStreamingBatch()
+
+        expect(headingTextsAndIds(container)).toEqual([
+            { text: 'Intro', id: 'intro', inBlockquote: true },
+            { text: 'Intro', id: 'intro-1', inBlockquote: false }
+        ])
     })
 
     test('keeps duplicate heading dedupe stable after a streaming reparse', async () => {
@@ -164,6 +302,59 @@ describe('SvelteMarkdown streaming stability (issue #328)', () => {
         await flushStreamingBatch()
 
         expect(headingIds(container)).toEqual(['intro', 'intro-1'])
+    })
+
+    test('keeps already-rendered top-level nodes mounted during append-only streaming', async () => {
+        const mounted: Array<{ text: string | undefined; element: HTMLParagraphElement }> = []
+        const destroyed: Array<{ text: string | undefined; element: HTMLParagraphElement }> = []
+        const { component, container } = render(SvelteMarkdown, {
+            props: {
+                source: '',
+                streaming: true,
+                renderers: {
+                    paragraph: TrackedParagraph
+                },
+                onParagraphMount: (text: string | undefined, element: HTMLParagraphElement) => {
+                    mounted.push({ text, element })
+                },
+                onParagraphDestroy: (text: string | undefined, element: HTMLParagraphElement) => {
+                    destroyed.push({ text, element })
+                }
+            } satisfies SvelteMarkdownProps & {
+                onParagraphMount: (text: string | undefined, element: HTMLParagraphElement) => void
+                onParagraphDestroy: (
+                    text: string | undefined,
+                    element: HTMLParagraphElement
+                ) => void
+            }
+        })
+
+        const chunks = [
+            'Intro paragraph',
+            '\n\nSecond paragraph',
+            '\n\n- Streamed list item',
+            '\n\nFinal paragraph'
+        ]
+        let introParagraph: Element | null = null
+
+        for (const chunk of chunks) {
+            await act(() => component.writeChunk(chunk))
+            await flushStreamingBatch()
+
+            const currentIntro = container.querySelector(
+                '[data-tracked-paragraph="Intro paragraph"]'
+            )
+            expect(currentIntro).toBeInstanceOf(HTMLParagraphElement)
+
+            if (introParagraph === null) {
+                introParagraph = currentIntro
+            } else {
+                expect(currentIntro).toBe(introParagraph)
+            }
+        }
+
+        expect(destroyed.some((entry) => entry.text === 'Intro paragraph')).toBe(false)
+        expect(mounted.filter((entry) => entry.text === 'Intro paragraph')).toHaveLength(1)
     })
 
     test('keeps a downstream paragraph mounted when an earlier token split preserves its source offset', async () => {
@@ -236,6 +427,39 @@ describe('SvelteMarkdown streaming stability (issue #328)', () => {
         expect(itemAfter).toBe(itemBefore)
     })
 
+    test('keeps existing list item identity while streaming appends list siblings', async () => {
+        const parsed = vi.fn()
+        const { component, container } = render(SvelteMarkdown, {
+            props: {
+                source: '',
+                streaming: true,
+                parsed,
+                renderers: {
+                    listitem: TrackedListItem
+                }
+            }
+        })
+
+        await act(() => component.writeChunk('- One\n- More\n- Stable'))
+        await flushStreamingBatch()
+
+        const itemBefore = container.querySelector('[data-tracked-list-item="More"]')
+        const firstMoreToken = firstListToken(lastParsedTokens(parsed))?.items[1]
+
+        expect(itemBefore).toBeInstanceOf(HTMLLIElement)
+        expect(firstMoreToken?.text).toBe('More')
+
+        await act(() => component.writeChunk('\n- Tail'))
+        await flushStreamingBatch()
+
+        const itemAfter = container.querySelector('[data-tracked-list-item="More"]')
+        const nextMoreToken = firstListToken(lastParsedTokens(parsed))?.items[1]
+
+        expect(container.querySelectorAll('li')).toHaveLength(4)
+        expect(itemAfter).toBe(itemBefore)
+        expect(nextMoreToken).toBe(firstMoreToken)
+    })
+
     test('keeps a stable table body row mounted when a sibling row is inserted before it', async () => {
         const stableRow = [tableCell('More'), tableCell('Tail')]
         const insertedRow = [tableCell('Inserted'), tableCell('Row')]
@@ -255,5 +479,36 @@ describe('SvelteMarkdown streaming stability (issue #328)', () => {
         const rowAfter = findBodyRow(container, 'MoreTail')
         expect(findBodyRow(container, 'InsertedRow')).toBeInstanceOf(HTMLTableRowElement)
         expect(rowAfter).toBe(rowBefore)
+    })
+
+    test('keeps existing table row identity while streaming appends table rows', async () => {
+        const parsed = vi.fn()
+        const { component, container } = render(SvelteMarkdown, {
+            props: {
+                source: '',
+                streaming: true,
+                parsed
+            }
+        })
+
+        await act(() => component.writeChunk('| Label | Value |\n|---|---|\n| More | Tail |'))
+        await flushStreamingBatch()
+
+        const rowBefore = findBodyRow(container, 'MoreTail')
+        const firstRowToken = firstTableToken(lastParsedTokens(parsed))?.rows[0]
+
+        expect(rowBefore).toBeInstanceOf(HTMLTableRowElement)
+        expect(firstRowToken?.map((cell) => cell.text)).toEqual(['More', 'Tail'])
+
+        await act(() => component.writeChunk('\n| Last | Row |'))
+        await flushStreamingBatch()
+
+        const rowAfter = findBodyRow(container, 'MoreTail')
+        const nextRowToken = firstTableToken(lastParsedTokens(parsed))?.rows[0]
+
+        expect(findBodyRow(container, 'LastRow')).toBeInstanceOf(HTMLTableRowElement)
+        expect(rowAfter).toBe(rowBefore)
+        expect(nextRowToken?.[0]).toBe(firstRowToken?.[0])
+        expect(nextRowToken?.[1]).toBe(firstRowToken?.[1])
     })
 })

--- a/src/lib/SvelteMarkdown.issue-328.test.ts
+++ b/src/lib/SvelteMarkdown.issue-328.test.ts
@@ -12,6 +12,7 @@ import '@testing-library/jest-dom'
 import { act, render } from '@testing-library/svelte'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import SvelteMarkdown from './SvelteMarkdown.svelte'
+import StableHeading from './test/issues/issue-328/StableHeading.svelte'
 import TrackedListItem from './test/issues/issue-328/TrackedListItem.svelte'
 import TrackedParagraph from './test/issues/issue-328/TrackedParagraph.svelte'
 import type { SvelteMarkdownProps } from './types.js'
@@ -70,6 +71,33 @@ const renderChunkedHeadingIds = async (chunks: string[]) => {
     }
 
     return headingIds(container)
+}
+
+const chunkSource = (source: string, chunkSize: number) => {
+    const chunks: string[] = []
+
+    for (let index = 0; index < source.length; index += chunkSize) {
+        chunks.push(source.slice(index, index + chunkSize))
+    }
+
+    return chunks
+}
+
+const buildLargeHeadingSource = (sections: number) => {
+    const out = ['# Intro\n\n']
+
+    for (let index = 0; index < sections; index++) {
+        out.push(`> # Intro\n\n`)
+        out.push(`## Details\n\n`)
+        out.push(`### Section ${index}\n\n`)
+        out.push(`Paragraph ${index} with [link ${index}](https://example.com/${index}).\n\n`)
+
+        if (index % 5 === 0) {
+            out.push(`#### Details\n\n`)
+        }
+    }
+
+    return out.join('')
 }
 
 const textToken = (text: string): Token =>
@@ -212,6 +240,47 @@ describe('SvelteMarkdown streaming stability (issue #328)', () => {
         expect(container.querySelector('h1')).toHaveAttribute('id', 'user-content-intro')
     })
 
+    test('passes stable precomputed ids to custom heading renderers during streaming reparses', async () => {
+        const initialSource = '# Intro\n\nSee [docs][ref]'
+        const nextSource = `${initialSource}\n\n[ref]: https://example.com`
+
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: {
+                source: initialSource,
+                streaming: true,
+                options: {
+                    headerPrefix: 'user-content-'
+                },
+                renderers: {
+                    heading: StableHeading
+                } satisfies Partial<Renderers>
+            }
+        })
+        await flushStreamingBatch()
+
+        expect(container.querySelector('[data-stable-heading-id]')).toHaveAttribute(
+            'data-stable-heading-id',
+            'user-content-intro'
+        )
+
+        await rerender({
+            source: nextSource,
+            streaming: true,
+            options: {
+                headerPrefix: 'user-content-'
+            },
+            renderers: {
+                heading: StableHeading
+            } satisfies Partial<Renderers>
+        })
+        await flushStreamingBatch()
+
+        expect(container.querySelector('[data-stable-heading-id]')).toHaveAttribute(
+            'data-stable-heading-id',
+            'user-content-intro'
+        )
+    })
+
     test('does not emit ids when headerIds is false during streaming reparses', async () => {
         const initialSource = '# Intro\n\nSee [docs][ref]'
         const nextSource = `${initialSource}\n\n[ref]: https://example.com`
@@ -254,6 +323,23 @@ describe('SvelteMarkdown streaming stability (issue #328)', () => {
         expect(singleFlushIds).toEqual(staticIds)
         expect(splitFlushIds).toEqual(staticIds)
     })
+
+    test('matches static heading ids for a large streamed document', async () => {
+        const source = buildLargeHeadingSource(64)
+        const staticIds = await renderStaticHeadingIds(source)
+        const streamedIds = await renderChunkedHeadingIds(chunkSource(source, 137))
+
+        expect(staticIds.length).toBeGreaterThan(200)
+        expect(staticIds.slice(0, 5)).toEqual([
+            'intro',
+            'intro-1',
+            'details',
+            'section-0',
+            'details-1'
+        ])
+        expect(new Set(streamedIds).size).toBe(streamedIds.length)
+        expect(streamedIds).toEqual(staticIds)
+    }, 15_000)
 
     test('dedupes nested and top-level headings in document order after a streaming reparse', async () => {
         const initialSource = '> # Intro\n\n# Intro\n\nSee [docs][ref]'

--- a/src/lib/SvelteMarkdown.issue-328.test.ts
+++ b/src/lib/SvelteMarkdown.issue-328.test.ts
@@ -446,6 +446,45 @@ describe('SvelteMarkdown streaming stability (issue #328)', () => {
         expect(mounted.filter((entry) => entry.text === 'Intro paragraph')).toHaveLength(1)
     })
 
+    test('keeps a stable root token mounted when a sibling is inserted before it', async () => {
+        const stableParagraph = paragraphToken('More')
+        const insertedParagraph = paragraphToken('Inserted')
+        const mounted: Array<{ text: string | undefined; element: HTMLParagraphElement }> = []
+        const destroyed: Array<{ text: string | undefined; element: HTMLParagraphElement }> = []
+
+        const props = {
+            source: [stableParagraph],
+            renderers: {
+                paragraph: TrackedParagraph
+            } satisfies Partial<Renderers>,
+            onParagraphMount: (text: string | undefined, element: HTMLParagraphElement) => {
+                mounted.push({ text, element })
+            },
+            onParagraphDestroy: (text: string | undefined, element: HTMLParagraphElement) => {
+                destroyed.push({ text, element })
+            }
+        } satisfies SvelteMarkdownProps & {
+            onParagraphMount: (text: string | undefined, element: HTMLParagraphElement) => void
+            onParagraphDestroy: (text: string | undefined, element: HTMLParagraphElement) => void
+        }
+
+        const { container, rerender } = render(SvelteMarkdown, { props })
+        const paragraphBefore = container.querySelector('[data-tracked-paragraph="More"]')
+
+        expect(paragraphBefore).toBeInstanceOf(HTMLParagraphElement)
+
+        await rerender({
+            ...props,
+            source: [insertedParagraph, stableParagraph]
+        })
+
+        const paragraphAfter = container.querySelector('[data-tracked-paragraph="More"]')
+        expect(container.querySelector('p')?.textContent).toBe('Inserted')
+        expect(paragraphAfter).toBe(paragraphBefore)
+        expect(destroyed.some((entry) => entry.text === 'More')).toBe(false)
+        expect(mounted.filter((entry) => entry.text === 'More')).toHaveLength(1)
+    })
+
     test('keeps a downstream paragraph mounted when an earlier token split preserves its source offset', async () => {
         const initialSource = 'Intro\n-  \n\nMore'
         const nextSource = 'Intro\n- T\n\nMore'

--- a/src/lib/SvelteMarkdown.svelte
+++ b/src/lib/SvelteMarkdown.svelte
@@ -118,6 +118,8 @@
     let streamFlushHandle: StreamFlushHandle = null
     let streamInputMode: 'append' | 'offset' | null = null
     let streamTokens = $state<Token[]>([])
+    let streamRenderMetadataStartIndex = 0
+    let streamRenderMetadataStartOffset = 0
 
     const warnStreaming = (message: string) => {
         console.warn(`[svelte-markdown] ${message}`)
@@ -154,7 +156,7 @@
         const parser = incrementalParser
         if (!parser) return
 
-        const { tokens: newTokens, divergeAt, canReuse } = parser.update(nextSource)
+        const { tokens: newTokens, divergeAt, divergeOffset, canReuse } = parser.update(nextSource)
 
         // Replace the array reference rather than mutating per-index +
         // length. Under Svelte 5's reactive proxy, shrinking the array
@@ -169,6 +171,9 @@
         streamTokens = canReuse
             ? reuseStableStreamingTokens(streamTokens, newTokens, divergeAt)
             : newTokens
+        const canSkipRenderMetadataPrefix = canReuse && divergeOffset !== undefined
+        streamRenderMetadataStartIndex = canSkipRenderMetadataPrefix ? divergeAt : 0
+        streamRenderMetadataStartOffset = canSkipRenderMetadataPrefix ? divergeOffset : 0
     }
 
     const commitPendingAppendBuffer = () => {
@@ -212,6 +217,8 @@
         pendingStreamAppendBuffer = ''
         streamInputMode = null
         streamSourceBuffer = ''
+        streamRenderMetadataStartIndex = 0
+        streamRenderMetadataStartOffset = 0
     }
 
     const resetStreamingState = (nextSource = '') => {
@@ -475,14 +482,31 @@
     const tokens = $derived.by(() => {
         if (!rawTokens) return rawTokens
 
-        const sourceForMetadata =
-            streaming && !hasAsyncExtension
-                ? streamSourceBuffer
-                : Array.isArray(source)
-                  ? undefined
-                  : (source as string)
+        // This derived intentionally prepares WeakMap metadata before Parser
+        // renders. An $effect would run too late: keyed each blocks and
+        // heading props need the metadata during this render pass.
+        const sourceForMetadata = Array.isArray(source)
+            ? undefined
+            : streaming && !hasAsyncExtension
+              ? streamSourceBuffer
+              : (source as string)
 
-        return renderMetadata.prepareTokensForRender(rawTokens, combinedOptions, sourceForMetadata)
+        // In streaming mode, streamSourceBuffer is a plain let that changes
+        // in lockstep with streamTokens inside applyStreamingSource(). This
+        // derived is invalidated by rawTokens; the buffer read relies on that
+        // coupling so metadata sees the same source that produced the tokens.
+        const streamingStart =
+            streaming && !hasAsyncExtension
+                ? {
+                      startIndex: streamRenderMetadataStartIndex,
+                      startOffset: streamRenderMetadataStartOffset
+                  }
+                : {}
+
+        return renderMetadata.prepareTokensForRender(rawTokens, combinedOptions, {
+            source: sourceForMetadata,
+            ...streamingStart
+        })
     })
 
     $effect(() => {

--- a/src/lib/SvelteMarkdown.svelte
+++ b/src/lib/SvelteMarkdown.svelte
@@ -23,6 +23,7 @@
  @property {function} [parsed] - Callback function called with the parsed tokens
 -->
 <script lang="ts">
+    import { setContext } from 'svelte'
     /**
      * Component Evolution & Design Notes:
      *
@@ -70,6 +71,7 @@
     import { IncrementalParser } from '$lib/utils/incremental-parser.js'
     import { Slugger, type Token, type TokensList } from '$lib/utils/markdown-parser.js'
     import { parseAndCacheTokens, parseAndCacheTokensAsync } from '$lib/utils/parse-and-cache.js'
+    import { createRenderMetadata, RENDER_METADATA_CONTEXT } from '$lib/utils/render-metadata.js'
     import { defaultSanitizeAttributes, defaultSanitizeUrl } from '$lib/utils/sanitize.js'
     import { isStreamingOffsetChunk } from '$lib/utils/streaming.js'
     import { reuseStableStreamingTokens } from '$lib/utils/streaming-token-reuse.js'
@@ -99,6 +101,9 @@
     const extensionTokenNames = $derived(getExtensionTokenNames(extensions))
     const combinedOptions = $derived(buildParserOptions(options, extensions))
     const slugger = new Slugger()
+    const renderMetadata = createRenderMetadata()
+
+    setContext(RENDER_METADATA_CONTEXT, renderMetadata)
 
     // Detect if any extension requires async processing
     const hasAsyncExtension = $derived(getHasAsyncExtension(extensions))
@@ -459,13 +464,26 @@
     })
 
     // Unified tokens: streaming > sync > async
-    const tokens = $derived(
+    const rawTokens = $derived(
         streaming && !hasAsyncExtension
             ? streamTokens
             : hasAsyncExtension
               ? asyncTokens
               : syncTokens
     )
+
+    const tokens = $derived.by(() => {
+        if (!rawTokens) return rawTokens
+
+        const sourceForMetadata =
+            streaming && !hasAsyncExtension
+                ? streamSourceBuffer
+                : Array.isArray(source)
+                  ? undefined
+                  : (source as string)
+
+        return renderMetadata.prepareTokensForRender(rawTokens, combinedOptions, sourceForMetadata)
+    })
 
     $effect(() => {
         if (!tokens) return

--- a/src/lib/renderers/Heading.svelte
+++ b/src/lib/renderers/Heading.svelte
@@ -8,6 +8,7 @@ heading text via `github-slugger`, optionally prefixed by `options.headerPrefix`
 @prop {number} depth - Heading level (1–6).
 @prop {string} raw - Original markdown source of the heading line.
 @prop {string} text - Plain-text content used for slug generation.
+@prop {string} [id] - Precomputed heading id for the current render pass.
 @prop {SvelteMarkdownOptions} options - Parser options (controls ID generation).
 @prop {(val: string) => string} slug - Slugger function for generating heading IDs.
 @prop {Snippet} [children] - Rendered inline content of the heading.
@@ -20,14 +21,25 @@ heading text via `github-slugger`, optionally prefixed by `options.headerPrefix`
         depth: number
         raw: string
         text: string
+        id?: string
         options: SvelteMarkdownOptions
-        slug: (val: string) => string // trunk-ignore(eslint/no-unused-vars)
+        slug: (_val: string) => string
         children?: Snippet
     }
 
-    const { depth, raw, text, options, slug, children }: Props = $props()
+    const {
+        depth,
+        raw,
+        text,
+        id: precomputedId = undefined,
+        options,
+        slug,
+        children
+    }: Props = $props()
 
-    const id = $derived(options.headerIds ? options.headerPrefix + slug(text) : undefined)
+    const id = $derived(
+        options.headerIds ? (precomputedId ?? `${options.headerPrefix}${slug(text)}`) : undefined
+    )
 </script>
 
 {#if depth === 1}

--- a/src/lib/test/issues/issue-328/StableHeading.svelte
+++ b/src/lib/test/issues/issue-328/StableHeading.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte'
+
+    interface Props {
+        id?: string
+        children?: Snippet
+    }
+
+    const { id = undefined, children }: Props = $props()
+</script>
+
+<h1 {id} data-stable-heading-id={id}>{@render children?.()}</h1>

--- a/src/lib/test/issues/issue-328/TrackedListItem.svelte
+++ b/src/lib/test/issues/issue-328/TrackedListItem.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte'
+
+    interface Props {
+        text?: string
+        children?: Snippet
+    }
+
+    const { text = undefined, children }: Props = $props()
+</script>
+
+<li data-tracked-list-item={text}>{@render children?.()}</li>

--- a/src/lib/test/issues/issue-328/TrackedParagraph.svelte
+++ b/src/lib/test/issues/issue-328/TrackedParagraph.svelte
@@ -22,10 +22,11 @@
     onMount(() => {
         if (!element) return
 
-        onParagraphMount?.(text, element)
+        const mountedElement = element
+        onParagraphMount?.(text, mountedElement)
 
         return () => {
-            onParagraphDestroy?.(text, element)
+            onParagraphDestroy?.(text, mountedElement)
         }
     })
 </script>

--- a/src/lib/test/issues/issue-328/TrackedParagraph.svelte
+++ b/src/lib/test/issues/issue-328/TrackedParagraph.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+    import { onMount, type Snippet } from 'svelte'
+
+    type ParagraphLifecycleCallback = (..._args: [string | undefined, HTMLParagraphElement]) => void
+
+    interface Props {
+        text?: string
+        children?: Snippet
+        onParagraphMount?: ParagraphLifecycleCallback
+        onParagraphDestroy?: ParagraphLifecycleCallback
+    }
+
+    const {
+        text = undefined,
+        children,
+        onParagraphMount = undefined,
+        onParagraphDestroy = undefined
+    }: Props = $props()
+
+    let element = $state<HTMLParagraphElement>()
+
+    onMount(() => {
+        if (!element) return
+
+        onParagraphMount?.(text, element)
+
+        return () => {
+            onParagraphDestroy?.(text, element)
+        }
+    })
+</script>
+
+<p bind:this={element} data-tracked-paragraph={text}>{@render children?.()}</p>

--- a/src/lib/utils/component-props.ts
+++ b/src/lib/utils/component-props.ts
@@ -1,7 +1,8 @@
 import { defaultRenderers } from '$lib/utils/markdown-parser.js'
 import { rendererKeysInternal } from '$lib/utils/rendererKeys.js'
+import type { Snippet } from 'svelte'
 
-type AnySnippet = (..._args: unknown[]) => unknown
+export type AnySnippet = Snippet<[Record<string, unknown>]>
 
 type RestProps = Record<string, unknown>
 

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -48,6 +48,8 @@ export interface IncrementalUpdateResult {
     tokens: Token[]
     /** Index of the first token that differs from the previous parse */
     divergeAt: number
+    /** Source offset where the divergent token begins, when known without scanning the stable prefix */
+    divergeOffset?: number
     /** Whether consumers can safely reuse stable token objects from the previous parse */
     canReuse: boolean
 }
@@ -529,6 +531,7 @@ export class IncrementalParser {
         // this check the streaming consumer would never see the partial-
         // to-closed transition. See #291.
         let divergeAt = 0
+        let divergeOffset = parseResult.usedTailWindow ? boundary.reparseOffset : undefined
         if (!referenceSensitive) {
             const minLen = Math.min(this.prevTokens.length, newTokens.length)
             while (divergeAt < minLen) {
@@ -541,11 +544,18 @@ export class IncrementalParser {
                     if ((prevKids === undefined) !== (nextKids === undefined)) break
                     if (prevKids && nextKids && prevKids.length !== nextKids.length) break
                 }
+                if (
+                    parseResult.usedTailWindow &&
+                    divergeOffset !== undefined &&
+                    divergeAt >= boundary.prefixCount
+                ) {
+                    divergeOffset += this.getTokenSourceLength(next)
+                }
                 divergeAt++
             }
         }
 
         this.updateCachedState(source, parseResult, isAppendOnly, appendAddsDefinition)
-        return { tokens: newTokens, divergeAt, canReuse }
+        return { tokens: newTokens, divergeAt, divergeOffset, canReuse }
     }
 }

--- a/src/lib/utils/render-metadata.ts
+++ b/src/lib/utils/render-metadata.ts
@@ -14,8 +14,11 @@ import Slugger from 'github-slugger'
  * Source-backed renders use source offsets for keys. Append-only streaming can
  * skip the stable top-level prefix by passing the parser's `divergeAt` and
  * `divergeOffset`; reused-prefix tokens already have WeakMap keys from the
- * previous render pass. Pre-parsed token arrays have no source, so root tokens
- * use a root-slot fallback while nested tokens fall through to object identity.
+ * previous render pass. Pre-parsed token arrays have no source offsets, so
+ * root tokens use object-based fallback keys. If a caller recreates a root
+ * wrapper while reusing nested token objects, the wrapper inherits its prior
+ * key from that nested identity; otherwise root and nested tokens both fall
+ * through to object identity.
  *
  * Heading ids are recomputed in document order every pass because duplicate
  * heading slugs are global across nesting boundaries. That walk is intentional:
@@ -31,6 +34,12 @@ type RenderMetadataNode = Record<string, unknown> & {
     items?: unknown
     header?: unknown
     rows?: unknown
+}
+
+interface SourceLessRootRecord {
+    key: unknown
+    identities: Set<object>
+    type?: string
 }
 
 export interface RenderPreparation {
@@ -70,6 +79,7 @@ export const createRenderMetadata = (): RenderMetadata => {
     const renderKeys = new WeakMap<object, unknown>()
     const headingIds = new WeakMap<object, string | undefined>()
     let preparedHeadingNodes: RenderMetadataNode[] = []
+    let previousSourceLessRoots: SourceLessRootRecord[] = []
 
     const setRenderKey = (node: object, value: unknown) => {
         renderKeys.set(node, value)
@@ -121,15 +131,93 @@ export const createRenderMetadata = (): RenderMetadata => {
         }
     }
 
-    const assignRootFallbackKeys = (nodes: RenderMetadataNode[] | undefined) => {
-        if (!nodes) return
+    const collectSourceLessIdentities = (value: unknown, identities = new Set<object>()) => {
+        if (typeof value !== 'object' || value === null) return identities
 
-        for (let index = 0; index < nodes.length; index++) {
-            const node = nodes[index]
-            if (getRenderKey(node) === undefined) {
-                setRenderKey(node, `root:${index}:${node.type ?? 'token'}`)
+        identities.add(value)
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                collectSourceLessIdentities(item, identities)
+            }
+            return identities
+        }
+
+        const node = value as RenderMetadataNode
+        collectSourceLessIdentities(node.tokens, identities)
+        collectSourceLessIdentities(node.items, identities)
+        collectSourceLessIdentities(node.header, identities)
+        collectSourceLessIdentities(node.rows, identities)
+
+        return identities
+    }
+
+    const countIdentityOverlap = (a: Set<object>, b: Set<object>) => {
+        let count = 0
+        const [smaller, larger] = a.size <= b.size ? [a, b] : [b, a]
+
+        for (const identity of smaller) {
+            if (larger.has(identity)) count++
+        }
+
+        return count
+    }
+
+    const findPreviousSourceLessRoot = (
+        node: RenderMetadataNode,
+        identities: Set<object>,
+        usedPreviousRoots: Set<number>
+    ) => {
+        let bestIndex = -1
+        let bestScore = 0
+
+        for (let index = 0; index < previousSourceLessRoots.length; index++) {
+            if (usedPreviousRoots.has(index)) continue
+
+            const previous = previousSourceLessRoots[index]
+            if (previous.type !== node.type) continue
+
+            const score = countIdentityOverlap(identities, previous.identities)
+            if (score > bestScore) {
+                bestIndex = index
+                bestScore = score
             }
         }
+
+        return bestIndex === -1
+            ? undefined
+            : { index: bestIndex, record: previousSourceLessRoots[bestIndex] }
+    }
+
+    const assignSourceLessRootKeys = (nodes: RenderMetadataNode[] | undefined) => {
+        if (!nodes) {
+            previousSourceLessRoots = []
+            return
+        }
+
+        const nextRoots: SourceLessRootRecord[] = []
+        const usedPreviousRoots = new Set<number>()
+
+        for (const node of nodes) {
+            const identities = collectSourceLessIdentities(node)
+            const existingKey = getRenderKey(node)
+            const previous =
+                existingKey === undefined
+                    ? findPreviousSourceLessRoot(node, identities, usedPreviousRoots)
+                    : undefined
+            const key = existingKey ?? previous?.record.key ?? node
+
+            if (previous) usedPreviousRoots.add(previous.index)
+            if (existingKey === undefined) setRenderKey(node, key)
+
+            nextRoots.push({
+                key,
+                identities,
+                type: node.type
+            })
+        }
+
+        previousSourceLessRoots = nextRoots
     }
 
     const assignSourceKeysToChildren = (node: RenderMetadataNode, absoluteOffset: number) => {
@@ -216,6 +304,7 @@ export const createRenderMetadata = (): RenderMetadata => {
             const renderNodes = tokens as RenderMetadataNode[]
 
             if (preparation?.source !== undefined) {
+                previousSourceLessRoots = []
                 assignSequentialSourceKeys(
                     renderNodes,
                     0,
@@ -223,7 +312,7 @@ export const createRenderMetadata = (): RenderMetadata => {
                     preparation.startOffset ?? 0
                 )
             } else {
-                assignRootFallbackKeys(renderNodes)
+                assignSourceLessRootKeys(renderNodes)
             }
 
             assignPreparedHeadingIds(renderNodes, options, preparation)

--- a/src/lib/utils/render-metadata.ts
+++ b/src/lib/utils/render-metadata.ts
@@ -78,6 +78,7 @@ const getNodeSourceLength = (node: RenderMetadataNode) => {
 export const createRenderMetadata = (): RenderMetadata => {
     const renderKeys = new WeakMap<object, unknown>()
     const headingIds = new WeakMap<object, string | undefined>()
+    const sourceOffsets = new WeakMap<object, number>()
     let preparedHeadingNodes: RenderMetadataNode[] = []
     let previousSourceLessRoots: SourceLessRootRecord[] = []
 
@@ -97,13 +98,11 @@ export const createRenderMetadata = (): RenderMetadata => {
         return `${index}:${String(node)}`
     }
 
-    const getSourceOffset = (node: RenderMetadataNode): number | undefined => {
-        const renderKey = getRenderKey(node)
-        if (typeof renderKey !== 'string' || !renderKey.startsWith('src:')) return undefined
-
-        const offset = Number(renderKey.split(':')[1])
-        return Number.isFinite(offset) ? offset : undefined
-    }
+    // Source offsets are recorded as numbers when keys are assigned, so the
+    // streaming heading-seed loop can read them without re-parsing the `src:`
+    // key string on every prior heading each flush.
+    const getSourceOffset = (node: RenderMetadataNode): number | undefined =>
+        sourceOffsets.get(node)
 
     const assignSequentialSourceKeys = (
         nodes: RenderMetadataNode[] | undefined,
@@ -119,6 +118,7 @@ export const createRenderMetadata = (): RenderMetadata => {
             const node = nodes[index]
             const spanLength = getNodeSourceLength(node)
             const nodeOffset = absoluteOffset + cursor
+            sourceOffsets.set(node, nodeOffset)
 
             if (spanLength === 0) {
                 setRenderKey(node, `src:${nodeOffset}:zero:${index}`)
@@ -238,20 +238,18 @@ export const createRenderMetadata = (): RenderMetadata => {
         for (let index = startIndex; index < nodes.length; index++) {
             const node = nodes[index]
             if (node.type === 'heading') {
-                headingIds.set(
-                    node,
-                    options.headerIds && typeof node.text === 'string'
-                        ? `${options.headerPrefix}${slugger.slug(node.text)}`
-                        : undefined
-                )
+                seedHeadingSlugger(node, options, slugger)
                 nextHeadingNodes.push(node)
             }
 
             assignHeadingIds(asNodeArray(node.tokens), options, slugger, nextHeadingNodes)
             assignHeadingIds(asNodeArray(node.items), options, slugger, nextHeadingNodes)
             assignHeadingIds(asNodeArray(node.header), options, slugger, nextHeadingNodes)
-            for (const row of asNodeArray(node.rows) ?? []) {
-                assignHeadingIds(asNodeArray(row), options, slugger, nextHeadingNodes)
+            const rows = asNodeArray(node.rows)
+            if (rows) {
+                for (const row of rows) {
+                    assignHeadingIds(asNodeArray(row), options, slugger, nextHeadingNodes)
+                }
             }
         }
     }

--- a/src/lib/utils/render-metadata.ts
+++ b/src/lib/utils/render-metadata.ts
@@ -75,6 +75,30 @@ const getNodeSourceLength = (node: RenderMetadataNode) => {
     return getNodeSpanText(node).length
 }
 
+/**
+ * Creates a per-`SvelteMarkdown`-instance render metadata helper. State
+ * (render keys, precomputed heading ids, source offsets, and cross-pass
+ * bookkeeping) is captured in the returned closure via WeakMaps keyed by token
+ * objects, so each component instance gets isolated metadata and caller token
+ * arrays are never mutated. See the module overview above for the keying and
+ * heading-id strategy.
+ *
+ * @returns A {@link RenderMetadata} whose methods precompute per-pass metadata
+ *   (`prepareTokensForRender`) and read it back during render
+ *   (`getPreparedHeadingId`, `getStableNodeKey`, `getStableRowKey`).
+ * @example
+ * ```ts
+ * const metadata = createRenderMetadata()
+ * // Streaming append: skip the stable prefix via the parser's diverge point.
+ * const tokens = metadata.prepareTokensForRender(rawTokens, options, {
+ *     source,
+ *     startIndex,
+ *     startOffset
+ * })
+ * const key = metadata.getStableNodeKey(tokens?.[0], 0)
+ * const id = metadata.getPreparedHeadingId(tokens?.[0])
+ * ```
+ */
 export const createRenderMetadata = (): RenderMetadata => {
     const renderKeys = new WeakMap<object, unknown>()
     const headingIds = new WeakMap<object, string | undefined>()

--- a/src/lib/utils/render-metadata.ts
+++ b/src/lib/utils/render-metadata.ts
@@ -2,8 +2,29 @@ import type { SvelteMarkdownOptions } from '$lib/types.js'
 import type { Token, TokensList } from '$lib/utils/markdown-parser.js'
 import Slugger from 'github-slugger'
 
+/**
+ * Per-SvelteMarkdown-instance render metadata.
+ *
+ * Stable render keys and precomputed heading ids are renderer concerns, not
+ * markdown-token data, so they live in WeakMaps keyed by token objects. This
+ * keeps caller-provided token arrays unmodified, avoids public property
+ * collisions, and lets multiple SvelteMarkdown instances render concurrently
+ * without sharing slug or key state.
+ *
+ * Source-backed renders use source offsets for keys. Append-only streaming can
+ * skip the stable top-level prefix by passing the parser's `divergeAt` and
+ * `divergeOffset`; reused-prefix tokens already have WeakMap keys from the
+ * previous render pass. Pre-parsed token arrays have no source, so root tokens
+ * use a root-slot fallback while nested tokens fall through to object identity.
+ *
+ * Heading ids are recomputed in document order every pass because duplicate
+ * heading slugs are global across nesting boundaries. That walk is intentional:
+ * it resets slugger state for the render pass before any Heading component
+ * renders.
+ */
 type RenderMetadataNode = Record<string, unknown> & {
     raw?: string
+    sourceLength?: number
     text?: string
     type?: string
     tokens?: unknown
@@ -12,11 +33,17 @@ type RenderMetadataNode = Record<string, unknown> & {
     rows?: unknown
 }
 
+export interface RenderPreparation {
+    source?: string
+    startIndex?: number
+    startOffset?: number
+}
+
 export interface RenderMetadata {
     prepareTokensForRender: (
         _tokens: Token[] | TokensList | undefined,
         _options: SvelteMarkdownOptions,
-        _source?: string
+        _preparation?: RenderPreparation
     ) => Token[] | TokensList | undefined
     getPreparedHeadingId: (_node: unknown) => string | undefined
     getStableNodeKey: (_node: unknown, _index: number) => unknown
@@ -34,9 +61,15 @@ const getNodeSpanText = (node: RenderMetadataNode) => {
     return ''
 }
 
+const getNodeSourceLength = (node: RenderMetadataNode) => {
+    if (typeof node.sourceLength === 'number') return node.sourceLength
+    return getNodeSpanText(node).length
+}
+
 export const createRenderMetadata = (): RenderMetadata => {
     const renderKeys = new WeakMap<object, unknown>()
     const headingIds = new WeakMap<object, string | undefined>()
+    let preparedHeadingNodes: RenderMetadataNode[] = []
 
     const setRenderKey = (node: object, value: unknown) => {
         renderKeys.set(node, value)
@@ -54,35 +87,37 @@ export const createRenderMetadata = (): RenderMetadata => {
         return `${index}:${String(node)}`
     }
 
+    const getSourceOffset = (node: RenderMetadataNode): number | undefined => {
+        const renderKey = getRenderKey(node)
+        if (typeof renderKey !== 'string' || !renderKey.startsWith('src:')) return undefined
+
+        const offset = Number(renderKey.split(':')[1])
+        return Number.isFinite(offset) ? offset : undefined
+    }
+
     const assignSequentialSourceKeys = (
         nodes: RenderMetadataNode[] | undefined,
-        source: string,
-        absoluteOffset = 0
+        absoluteOffset = 0,
+        startIndex = 0,
+        startOffset = 0
     ) => {
         if (!nodes) return
 
-        let searchOffset = 0
-        const zeroLengthCounts = new Map<number, number>()
+        let cursor = startOffset
 
-        for (const node of nodes) {
-            const spanText = getNodeSpanText(node)
-            const relativeStart =
-                spanText === ''
-                    ? searchOffset
-                    : source.indexOf(spanText, Math.min(searchOffset, source.length))
-            const start = relativeStart >= 0 ? relativeStart : searchOffset
-            const absoluteStart = absoluteOffset + start
+        for (let index = startIndex; index < nodes.length; index++) {
+            const node = nodes[index]
+            const spanLength = getNodeSourceLength(node)
+            const nodeOffset = absoluteOffset + cursor
 
-            if (spanText === '') {
-                const count = zeroLengthCounts.get(absoluteStart) ?? 0
-                zeroLengthCounts.set(absoluteStart, count + 1)
-                setRenderKey(node, `src:${absoluteStart}:zero:${count}`)
+            if (spanLength === 0) {
+                setRenderKey(node, `src:${nodeOffset}:zero:${index}`)
             } else {
-                setRenderKey(node, `src:${absoluteStart}`)
-                searchOffset = start + spanText.length
+                setRenderKey(node, `src:${nodeOffset}`)
             }
 
-            assignSourceKeysToChildren(node, spanText, absoluteStart)
+            assignSourceKeysToChildren(node, nodeOffset)
+            cursor += spanLength
         }
     }
 
@@ -97,68 +132,23 @@ export const createRenderMetadata = (): RenderMetadata => {
         }
     }
 
-    const assignSourceKeysToRows = (
-        rows: RenderMetadataNode[][] | undefined,
-        source: string,
-        absoluteOffset: number
-    ) => {
-        if (!rows) return
-
-        let searchOffset = 0
-
-        for (const row of rows) {
-            if (row.length === 0) {
-                setRenderKey(row, row)
-                continue
-            }
-
-            const firstCellSpan = getNodeSpanText(row[0])
-            const relativeStart =
-                firstCellSpan === ''
-                    ? searchOffset
-                    : source.indexOf(firstCellSpan, Math.min(searchOffset, source.length))
-            const rowStart = relativeStart >= 0 ? relativeStart : searchOffset
-
-            assignSequentialSourceKeys(row, source.slice(rowStart), absoluteOffset + rowStart)
-            setRenderKey(row, getStableNodeKey(row[0], 0))
-
-            const lastCell = row[row.length - 1]
-            const lastCellSpan = getNodeSpanText(lastCell)
-            const lastCellKey = getStableNodeKey(lastCell, row.length - 1)
-            const lastCellStart =
-                typeof lastCellKey === 'string' && lastCellKey.startsWith('src:')
-                    ? Number(lastCellKey.split(':')[1])
-                    : absoluteOffset + rowStart
-            searchOffset = Math.max(
-                rowStart + 1,
-                lastCellStart - absoluteOffset + lastCellSpan.length
-            )
-        }
-    }
-
-    const assignSourceKeysToChildren = (
-        node: RenderMetadataNode,
-        spanText: string,
-        absoluteOffset: number
-    ) => {
-        assignSequentialSourceKeys(asNodeArray(node.tokens), spanText, absoluteOffset)
-        assignSequentialSourceKeys(asNodeArray(node.items), spanText, absoluteOffset)
-        assignSequentialSourceKeys(asNodeArray(node.header), spanText, absoluteOffset)
-        assignSourceKeysToRows(
-            asNodeArray(node.rows) as RenderMetadataNode[][] | undefined,
-            spanText,
-            absoluteOffset
-        )
+    const assignSourceKeysToChildren = (node: RenderMetadataNode, absoluteOffset: number) => {
+        assignSequentialSourceKeys(asNodeArray(node.tokens), absoluteOffset)
+        assignSequentialSourceKeys(asNodeArray(node.items), absoluteOffset)
+        assignSequentialSourceKeys(asNodeArray(node.header), absoluteOffset)
     }
 
     const assignHeadingIds = (
         nodes: RenderMetadataNode[] | undefined,
         options: SvelteMarkdownOptions,
-        slugger: Slugger
+        slugger: Slugger,
+        nextHeadingNodes: RenderMetadataNode[],
+        startIndex = 0
     ) => {
         if (!nodes) return
 
-        for (const node of nodes) {
+        for (let index = startIndex; index < nodes.length; index++) {
+            const node = nodes[index]
             if (node.type === 'heading') {
                 headingIds.set(
                     node,
@@ -166,34 +156,77 @@ export const createRenderMetadata = (): RenderMetadata => {
                         ? `${options.headerPrefix}${slugger.slug(node.text)}`
                         : undefined
                 )
+                nextHeadingNodes.push(node)
             }
 
-            assignHeadingIds(asNodeArray(node.tokens), options, slugger)
-            assignHeadingIds(asNodeArray(node.items), options, slugger)
-            assignHeadingIds(asNodeArray(node.header), options, slugger)
+            assignHeadingIds(asNodeArray(node.tokens), options, slugger, nextHeadingNodes)
+            assignHeadingIds(asNodeArray(node.items), options, slugger, nextHeadingNodes)
+            assignHeadingIds(asNodeArray(node.header), options, slugger, nextHeadingNodes)
             for (const row of asNodeArray(node.rows) ?? []) {
-                assignHeadingIds(asNodeArray(row), options, slugger)
+                assignHeadingIds(asNodeArray(row), options, slugger, nextHeadingNodes)
             }
         }
+    }
+
+    const seedHeadingSlugger = (
+        node: RenderMetadataNode,
+        options: SvelteMarkdownOptions,
+        slugger: Slugger
+    ) => {
+        headingIds.set(
+            node,
+            options.headerIds && typeof node.text === 'string'
+                ? `${options.headerPrefix}${slugger.slug(node.text)}`
+                : undefined
+        )
+    }
+
+    const assignPreparedHeadingIds = (
+        nodes: RenderMetadataNode[],
+        options: SvelteMarkdownOptions,
+        preparation?: RenderPreparation
+    ) => {
+        const slugger = new Slugger()
+        const nextHeadingNodes: RenderMetadataNode[] = []
+
+        if (preparation?.source !== undefined && preparation.startOffset !== undefined) {
+            for (const heading of preparedHeadingNodes) {
+                const headingOffset = getSourceOffset(heading)
+                if (headingOffset === undefined || headingOffset >= preparation.startOffset) {
+                    continue
+                }
+
+                seedHeadingSlugger(heading, options, slugger)
+                nextHeadingNodes.push(heading)
+            }
+        }
+
+        assignHeadingIds(nodes, options, slugger, nextHeadingNodes, preparation?.startIndex ?? 0)
+        preparedHeadingNodes = nextHeadingNodes
     }
 
     return {
         prepareTokensForRender: (
             tokens: Token[] | TokensList | undefined,
             options: SvelteMarkdownOptions,
-            source?: string
+            preparation?: RenderPreparation
         ): Token[] | TokensList | undefined => {
             if (!tokens) return tokens
 
             const renderNodes = tokens as RenderMetadataNode[]
 
-            if (source !== undefined) {
-                assignSequentialSourceKeys(renderNodes, source)
+            if (preparation?.source !== undefined) {
+                assignSequentialSourceKeys(
+                    renderNodes,
+                    0,
+                    preparation.startIndex ?? 0,
+                    preparation.startOffset ?? 0
+                )
             } else {
                 assignRootFallbackKeys(renderNodes)
             }
 
-            assignHeadingIds(renderNodes, options, new Slugger())
+            assignPreparedHeadingIds(renderNodes, options, preparation)
 
             return tokens
         },

--- a/src/lib/utils/render-metadata.ts
+++ b/src/lib/utils/render-metadata.ts
@@ -1,0 +1,213 @@
+import type { SvelteMarkdownOptions } from '$lib/types.js'
+import type { Token, TokensList } from '$lib/utils/markdown-parser.js'
+import Slugger from 'github-slugger'
+
+type RenderMetadataNode = Record<string, unknown> & {
+    raw?: string
+    text?: string
+    type?: string
+    tokens?: unknown
+    items?: unknown
+    header?: unknown
+    rows?: unknown
+}
+
+export interface RenderMetadata {
+    prepareTokensForRender: (
+        _tokens: Token[] | TokensList | undefined,
+        _options: SvelteMarkdownOptions,
+        _source?: string
+    ) => Token[] | TokensList | undefined
+    getPreparedHeadingId: (_node: unknown) => string | undefined
+    getStableNodeKey: (_node: unknown, _index: number) => unknown
+    getStableRowKey: (_row: unknown[] | undefined, _index: number) => unknown
+}
+
+export const RENDER_METADATA_CONTEXT = Symbol('svelte-markdown.renderMetadata')
+
+const asNodeArray = (value: unknown): RenderMetadataNode[] | undefined =>
+    Array.isArray(value) ? (value as RenderMetadataNode[]) : undefined
+
+const getNodeSpanText = (node: RenderMetadataNode) => {
+    if (typeof node.raw === 'string') return node.raw
+    if (typeof node.text === 'string') return node.text
+    return ''
+}
+
+export const createRenderMetadata = (): RenderMetadata => {
+    const renderKeys = new WeakMap<object, unknown>()
+    const headingIds = new WeakMap<object, string | undefined>()
+
+    const setRenderKey = (node: object, value: unknown) => {
+        renderKeys.set(node, value)
+    }
+
+    const getRenderKey = (node: unknown) =>
+        typeof node === 'object' && node !== null ? renderKeys.get(node) : undefined
+
+    const getStableNodeKey = (node: unknown, index: number): unknown => {
+        const renderKey = getRenderKey(node)
+        if (renderKey !== undefined) return renderKey
+
+        if (typeof node === 'object' && node !== null) return node
+
+        return `${index}:${String(node)}`
+    }
+
+    const assignSequentialSourceKeys = (
+        nodes: RenderMetadataNode[] | undefined,
+        source: string,
+        absoluteOffset = 0
+    ) => {
+        if (!nodes) return
+
+        let searchOffset = 0
+        const zeroLengthCounts = new Map<number, number>()
+
+        for (const node of nodes) {
+            const spanText = getNodeSpanText(node)
+            const relativeStart =
+                spanText === ''
+                    ? searchOffset
+                    : source.indexOf(spanText, Math.min(searchOffset, source.length))
+            const start = relativeStart >= 0 ? relativeStart : searchOffset
+            const absoluteStart = absoluteOffset + start
+
+            if (spanText === '') {
+                const count = zeroLengthCounts.get(absoluteStart) ?? 0
+                zeroLengthCounts.set(absoluteStart, count + 1)
+                setRenderKey(node, `src:${absoluteStart}:zero:${count}`)
+            } else {
+                setRenderKey(node, `src:${absoluteStart}`)
+                searchOffset = start + spanText.length
+            }
+
+            assignSourceKeysToChildren(node, spanText, absoluteStart)
+        }
+    }
+
+    const assignRootFallbackKeys = (nodes: RenderMetadataNode[] | undefined) => {
+        if (!nodes) return
+
+        for (let index = 0; index < nodes.length; index++) {
+            const node = nodes[index]
+            if (getRenderKey(node) === undefined) {
+                setRenderKey(node, `root:${index}:${node.type ?? 'token'}`)
+            }
+        }
+    }
+
+    const assignSourceKeysToRows = (
+        rows: RenderMetadataNode[][] | undefined,
+        source: string,
+        absoluteOffset: number
+    ) => {
+        if (!rows) return
+
+        let searchOffset = 0
+
+        for (const row of rows) {
+            if (row.length === 0) {
+                setRenderKey(row, row)
+                continue
+            }
+
+            const firstCellSpan = getNodeSpanText(row[0])
+            const relativeStart =
+                firstCellSpan === ''
+                    ? searchOffset
+                    : source.indexOf(firstCellSpan, Math.min(searchOffset, source.length))
+            const rowStart = relativeStart >= 0 ? relativeStart : searchOffset
+
+            assignSequentialSourceKeys(row, source.slice(rowStart), absoluteOffset + rowStart)
+            setRenderKey(row, getStableNodeKey(row[0], 0))
+
+            const lastCell = row[row.length - 1]
+            const lastCellSpan = getNodeSpanText(lastCell)
+            const lastCellKey = getStableNodeKey(lastCell, row.length - 1)
+            const lastCellStart =
+                typeof lastCellKey === 'string' && lastCellKey.startsWith('src:')
+                    ? Number(lastCellKey.split(':')[1])
+                    : absoluteOffset + rowStart
+            searchOffset = Math.max(
+                rowStart + 1,
+                lastCellStart - absoluteOffset + lastCellSpan.length
+            )
+        }
+    }
+
+    const assignSourceKeysToChildren = (
+        node: RenderMetadataNode,
+        spanText: string,
+        absoluteOffset: number
+    ) => {
+        assignSequentialSourceKeys(asNodeArray(node.tokens), spanText, absoluteOffset)
+        assignSequentialSourceKeys(asNodeArray(node.items), spanText, absoluteOffset)
+        assignSequentialSourceKeys(asNodeArray(node.header), spanText, absoluteOffset)
+        assignSourceKeysToRows(
+            asNodeArray(node.rows) as RenderMetadataNode[][] | undefined,
+            spanText,
+            absoluteOffset
+        )
+    }
+
+    const assignHeadingIds = (
+        nodes: RenderMetadataNode[] | undefined,
+        options: SvelteMarkdownOptions,
+        slugger: Slugger
+    ) => {
+        if (!nodes) return
+
+        for (const node of nodes) {
+            if (node.type === 'heading') {
+                headingIds.set(
+                    node,
+                    options.headerIds && typeof node.text === 'string'
+                        ? `${options.headerPrefix}${slugger.slug(node.text)}`
+                        : undefined
+                )
+            }
+
+            assignHeadingIds(asNodeArray(node.tokens), options, slugger)
+            assignHeadingIds(asNodeArray(node.items), options, slugger)
+            assignHeadingIds(asNodeArray(node.header), options, slugger)
+            for (const row of asNodeArray(node.rows) ?? []) {
+                assignHeadingIds(asNodeArray(row), options, slugger)
+            }
+        }
+    }
+
+    return {
+        prepareTokensForRender: (
+            tokens: Token[] | TokensList | undefined,
+            options: SvelteMarkdownOptions,
+            source?: string
+        ): Token[] | TokensList | undefined => {
+            if (!tokens) return tokens
+
+            const renderNodes = tokens as RenderMetadataNode[]
+
+            if (source !== undefined) {
+                assignSequentialSourceKeys(renderNodes, source)
+            } else {
+                assignRootFallbackKeys(renderNodes)
+            }
+
+            assignHeadingIds(renderNodes, options, new Slugger())
+
+            return tokens
+        },
+        getPreparedHeadingId: (node: unknown): string | undefined =>
+            typeof node === 'object' && node !== null ? headingIds.get(node) : undefined,
+        getStableNodeKey,
+        getStableRowKey: (row: unknown[] | undefined, index: number): unknown => {
+            const renderKey = getRenderKey(row)
+            if (renderKey !== undefined) return renderKey
+
+            if (row && row.length > 0) return getStableNodeKey(row[0], index)
+            if (row) return row
+
+            return index
+        }
+    }
+}

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
     import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
-    import type { HtmlSnippetProps, ParagraphSnippetProps, TextSnippetProps } from '$lib/types.js'
+    import type {
+        HtmlSnippetProps,
+        ParagraphSnippetProps,
+        StreamingChunk,
+        TextSnippetProps
+    } from '$lib/types.js'
+    import { Lexer, Slugger, type Token } from '$lib/utils/markdown-parser.js'
     import { parseAndCacheTokens } from '$lib/utils/parse-and-cache.js'
     import { benchmarkAppendStream } from '$lib/utils/stream-benchmark.js'
     import { hashString, tokenCache } from '$lib/utils/token-cache.js'
     import { shrinkHtmlTokens } from '$lib/utils/token-cleanup.js'
-    import { Lexer } from 'marked'
     import { onMount, tick } from 'svelte'
 
     /**
@@ -26,6 +31,20 @@
         __svmParserCount?: number
         __svmParserByType?: Record<string, number>
     }
+
+    interface ImperativeMarkdownHandle {
+        writeChunk: (_chunk: StreamingChunk) => void
+        resetStream: (_nextSource?: string) => void
+    }
+
+    type HeadingBenchNode = Token & {
+        text?: string
+        tokens?: HeadingBenchNode[]
+        items?: HeadingBenchNode[]
+        header?: HeadingBenchNode[]
+        rows?: HeadingBenchNode[][]
+    }
+
     const svmWindow = (): SVMWindow | undefined =>
         typeof window === 'undefined' ? undefined : (window as SVMWindow)
 
@@ -241,6 +260,7 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
 
     let source = $state('')
     let previewEl: HTMLDivElement | undefined = $state()
+    let markdown: ImperativeMarkdownHandle | undefined = $state()
     let scenario = $state<string>('idle')
 
     let stat = $state({
@@ -287,6 +307,8 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         parseChunkAvgMs: 0,
         parseChunkP95Ms: 0,
         parseChunkPeakMs: 0,
+        headingCount: 0,
+        headingIdMismatches: 0,
         // streaming jitter shape (only populated by the bursty stream
         // scenario): wall-clock distribution of inter-chunk gaps.
         streamGapAvgMs: 0,
@@ -339,6 +361,50 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         return Math.round(n * m) / m
     }
 
+    const asHeadingBenchNodes = (value: unknown): HeadingBenchNode[] =>
+        Array.isArray(value) ? (value as HeadingBenchNode[]) : []
+
+    const collectExpectedHeadingIds = (tokens: Token[], headerPrefix = '') => {
+        const slugger = new Slugger()
+        const ids: string[] = []
+
+        const visit = (nodes: HeadingBenchNode[]) => {
+            for (const node of nodes) {
+                if (node.type === 'heading' && typeof node.text === 'string') {
+                    ids.push(`${headerPrefix}${slugger.slug(node.text)}`)
+                }
+
+                visit(asHeadingBenchNodes(node.tokens))
+                visit(asHeadingBenchNodes(node.items))
+                visit(asHeadingBenchNodes(node.header))
+
+                for (const row of asHeadingBenchNodes(node.rows)) {
+                    visit(asHeadingBenchNodes(row))
+                }
+            }
+        }
+
+        visit(tokens as HeadingBenchNode[])
+        return ids
+    }
+
+    const getRenderedHeadingIds = () =>
+        Array.from(previewEl?.querySelectorAll('h1,h2,h3,h4,h5,h6') ?? [], (heading) => heading.id)
+
+    const countHeadingIdMismatches = (actual: string[], expected: string[]) => {
+        let mismatches = Math.abs(actual.length - expected.length)
+        const sharedLength = Math.min(actual.length, expected.length)
+
+        for (let index = 0; index < sharedLength; index++) {
+            if (actual[index] !== expected[index]) mismatches++
+        }
+
+        return mismatches
+    }
+
+    const waitForAnimationFrame = (): Promise<void> =>
+        new Promise((resolve) => requestAnimationFrame(() => resolve()))
+
     const resetStat = () => {
         stat = {
             srcKb: 0,
@@ -370,6 +436,8 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             parseChunkAvgMs: 0,
             parseChunkP95Ms: 0,
             parseChunkPeakMs: 0,
+            headingCount: 0,
+            headingIdMismatches: 0,
             streamGapAvgMs: 0,
             streamGapP95Ms: 0,
             streamGapPeakMs: 0
@@ -769,6 +837,78 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         scenario = 'stream-bursty-done'
     }
 
+    /**
+     * Large imperative append stream. This exercises the public writeChunk()
+     * path on a realistic document and verifies the final streamed heading IDs
+     * match a static token walk of the same source.
+     */
+    const runStreamingLarge = async () => {
+        if (isStreaming) return
+        scenario = 'stream-large'
+        resetStat()
+        useOverrides = false
+        source = ''
+        tokenCache.clearAllTokens()
+        isStreaming = true
+        await tick()
+        if (!markdown) {
+            throw new Error('stream-large could not bind the SvelteMarkdown instance')
+        }
+        markdown.resetStream()
+
+        const corpus = generateRealistic(120)
+        const chunks: string[] = []
+        const chunkSize = 512
+        for (let index = 0; index < corpus.length; index += chunkSize) {
+            chunks.push(corpus.slice(index, index + chunkSize))
+        }
+
+        const opts = { gfm: true, breaks: false, headerIds: true, headerPrefix: '' }
+        const bench = benchmarkAppendStream(chunks, opts)
+        const expectedHeadingIds = collectExpectedHeadingIds(new Lexer(opts).lex(corpus), '')
+        const renderDurations: number[] = []
+
+        const startWall = performance.now()
+        for (const chunk of chunks) {
+            if (!isStreaming) break
+            const t0 = performance.now()
+            markdown.writeChunk(chunk)
+            await waitForAnimationFrame()
+            await tick()
+            if (!isStreaming) break
+            renderDurations.push(performance.now() - t0)
+        }
+        const wallMs = performance.now() - startWall
+        isStreaming = false
+        const actualHeadingIds = getRenderedHeadingIds()
+        const headingIdMismatches = countHeadingIdMismatches(actualHeadingIds, expectedHeadingIds)
+        if (headingIdMismatches > 0) {
+            console.error('stream-large heading id mismatch', {
+                expected: expectedHeadingIds.slice(0, 10),
+                actual: actualHeadingIds.slice(0, 10),
+                headingIdMismatches
+            })
+        }
+
+        const renderTotal = renderDurations.reduce((sum, duration) => sum + duration, 0)
+        stat = {
+            ...stat,
+            srcKb: round(corpus.length / 1024, 1),
+            streamChunks: chunks.length,
+            streamTotalMs: round(renderTotal),
+            streamAvgMs: round(renderTotal / chunks.length, 3),
+            streamP95Ms: round(percentile(renderDurations, 0.95), 3),
+            streamPeakMs: round(Math.max(...renderDurations), 3),
+            chunksPerSec: round((chunks.length / wallMs) * 1000, 1),
+            parseChunkAvgMs: round(bench.totalParseMs / bench.chunkCount, 3),
+            parseChunkP95Ms: round(bench.p95ParseMs, 3),
+            parseChunkPeakMs: round(bench.peakParseMs, 3),
+            headingCount: expectedHeadingIds.length,
+            headingIdMismatches
+        }
+        scenario = 'stream-large-done'
+    }
+
     const clear = () => {
         if (streamHandle !== null) {
             clearTimeout(streamHandle)
@@ -991,6 +1131,13 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         >
             {isStreaming ? 'Streaming…' : 'Stream bursty'}
         </button>
+        <button
+            data-testid="stream-large"
+            onclick={() => runStreamingLarge()}
+            disabled={isStreaming}
+        >
+            {isStreaming ? 'Streaming…' : 'Stream large'}
+        </button>
         <button data-testid="clear" onclick={clear}>Clear</button>
     </div>
 
@@ -1004,8 +1151,9 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         cachePeakMs={stat.cachePeakMs} · streamChunks={stat.streamChunks} streamTotalMs={stat.streamTotalMs}
         streamAvgMs={stat.streamAvgMs} streamP95Ms={stat.streamP95Ms} streamPeakMs={stat.streamPeakMs}
         chunksPerSec={stat.chunksPerSec} parseChunkAvgMs={stat.parseChunkAvgMs} parseChunkP95Ms={stat.parseChunkP95Ms}
-        parseChunkPeakMs={stat.parseChunkPeakMs} streamGapAvgMs={stat.streamGapAvgMs} streamGapP95Ms={stat.streamGapP95Ms}
-        streamGapPeakMs={stat.streamGapPeakMs} · longestTaskMs={longTaskSupported
+        parseChunkPeakMs={stat.parseChunkPeakMs} headingCount={stat.headingCount}
+        headingIdMismatches={stat.headingIdMismatches} streamGapAvgMs={stat.streamGapAvgMs}
+        streamGapP95Ms={stat.streamGapP95Ms} streamGapPeakMs={stat.streamGapPeakMs} · longestTaskMs={longTaskSupported
             ? displayLongestTaskMs
             : 'n/a'}
         longTasks10s={longTaskSupported ? displayLongTaskCount : 'n/a'} rafP95Ms={displayRafP95Ms}
@@ -1039,6 +1187,7 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
                 fast-path benchmarks would miss.
             -->
             <SvelteMarkdown
+                bind:this={markdown}
                 {source}
                 streaming={isStreaming}
                 paragraph={overrideParagraphSnippet}
@@ -1046,7 +1195,7 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
                 html_div={overrideHtmlDivSnippet}
             />
         {:else}
-            <SvelteMarkdown {source} streaming={isStreaming} />
+            <SvelteMarkdown bind:this={markdown} {source} streaming={isStreaming} />
         {/if}
     </div>
 </div>

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -879,7 +879,7 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             renderDurations.push(performance.now() - t0)
         }
         const wallMs = performance.now() - startWall
-        isStreaming = false
+        const completed = isStreaming && renderDurations.length === chunks.length
         const actualHeadingIds = getRenderedHeadingIds()
         const headingIdMismatches = countHeadingIdMismatches(actualHeadingIds, expectedHeadingIds)
         if (headingIdMismatches > 0) {
@@ -889,6 +889,13 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
                 headingIdMismatches
             })
         }
+
+        // writeChunk() updates the component's internal streaming buffer, not
+        // this page's `source` prop. Keep the final source before leaving
+        // streaming mode so the preview does not fall back to rendering ''.
+        if (completed) source = corpus
+        isStreaming = false
+        await tick()
 
         const renderTotal = renderDurations.reduce((sum, duration) => sum + duration, 0)
         stat = {


### PR DESCRIPTION
## Summary

Fixes the two streaming visual-stability problems in #328: heading ids drift mid-stream (`intro` → `intro-1` → `intro-2` …, breaking anchors and `:target`), and index-keyed `{#each}` blocks amplify token splits into DOM flashes by remounting downstream siblings.

Both are solved by a per-instance `RenderMetadata` (WeakMap-backed, in Svelte context) computed once per render pass: it precomputes deterministic heading ids with a fresh slugger in document order, and assigns stable render keys — source offsets when a source string exists, object identity for pre-parsed arrays. Keys and heading ids are stored off-token so caller token arrays stay untouched and concurrent instances don't share state.

To avoid reintroducing the O(document)-per-flush cost the incremental parser works to avoid, the metadata pass skips the stable streamed prefix using the parser's new `divergeOffset`. Non-heading metadata is now linear per stream; heading-id dedup remains quadratic for heading-dense docs by construction (github-slugger must replay prior headings to dedupe) — tracked as a follow-up in #337, negligible at realistic heading densities.

## Changes

- 🐛 Precompute heading ids per render pass (fresh slugger, document order) so ids stay stable across streaming reparses, chunk boundaries, and `headerPrefix`; `Heading` prefers the precomputed `id` and falls back to the `slug` prop.
- 🐛 Key `{#each}` blocks by stable render key instead of array index: source offset when available, object identity otherwise (incl. reused-root matching by nested-token identity), so token splits and sibling inserts stop remounting stable downstream DOM.
- ⚡ Keep the metadata pass proportional to the streamed chunk via prefix-skip (`divergeOffset` from `IncrementalParser`); drop the fragile `indexOf`/table-row offset math in favor of cumulative `sourceLength` and object identity.
- 🔧 Cleanup pass (`/simplify` + CodeRabbit): de-duplicate the heading-id formula, replace per-flush `src:` key string parsing with a numeric-offset WeakMap, drop per-node/per-token throwaway allocations, and add factory JSDoc — no behavior change.
- 🧪 Full #328 regression suite (16 tests) — drift, dedup order, prefix, custom-renderer id via `StableHeading`, DOM node identity via tracked renderers, zero-length-span key uniqueness — plus a `stream-large` perf-bench scenario that verifies streamed heading ids against a static lex (`headingIdMismatches`).
- 📚 README note on streaming id stability and the custom-renderer `slug`/`id` caveat.

## Verification

- Unit suite green (904 tests); typecheck 0 errors; lint clean.
- `stream-large` perf-bench: `headingIdMismatches` = 0 across runs; in-process microbench confirms non-heading metadata scales linearly with the prefix-skip.

## Follow-ups

- #337 — snapshot the slugger `occurrences` map to make heading-id dedup linear for heading-dense streams.
- #339 — simplify the source-less root-key matching heuristic (cold pre-parsed-array path).

## Commits

- [`45757db`](https://github.com/humanspeak/svelte-markdown/commit/45757db) test(streaming): add failing regression tests for heading id drift and DOM flashes
- [`104f9b1`](https://github.com/humanspeak/svelte-markdown/commit/104f9b1) test(streaming): expand issue #328 coverage with edge cases and regression guards
- [`32a9c21`](https://github.com/humanspeak/svelte-markdown/commit/32a9c21) fix(streaming): stabilize heading ids and keyed each blocks during streaming
- [`7fad836`](https://github.com/humanspeak/svelte-markdown/commit/7fad836) perf(streaming): keep render metadata proportional to the streamed chunk
- [`a3ac9e4`](https://github.com/humanspeak/svelte-markdown/commit/a3ac9e4) test(streaming): verify precomputed heading ids and add stream-large guard
- [`0443369`](https://github.com/humanspeak/svelte-markdown/commit/0443369) docs: note streaming heading id stability and custom-renderer slug caveat
- [`b8fa9ea`](https://github.com/humanspeak/svelte-markdown/commit/b8fa9ea) fix(streaming): keep reused root tokens mounted in source-less renders
- [`c359797`](https://github.com/humanspeak/svelte-markdown/commit/c359797) test(perf-bench): retain streamed source after imperative stream-large run
- [`4fab9bb`](https://github.com/humanspeak/svelte-markdown/commit/4fab9bb) refactor(streaming): trim render-metadata duplication and per-flush allocations
- [`8c25385`](https://github.com/humanspeak/svelte-markdown/commit/8c25385) docs(render-metadata): add JSDoc to createRenderMetadata factory

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
