### PR TITLE
fix(parser): drop unknown HTML tags in inline fast path (XSS)

### DIFF
--- a/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.guard-report.md
+++ b/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.guard-report.md
@@ -2,7 +2,7 @@
 
 **Recommendation: PASS** — the default-config inline-HTML XSS is closed; every done criterion reproduced green against the corrected lint gate.
 **Reviewed at** `ea7a31a` · 2026-07-07 14:42 · **Plan planned at** `939f154`
-**Integrated** — commit `<filled after commit skill>` · PR `<filled after pr skill>` · via the `commit` / `pr` skills
+**Integrated** — executor fix commits `596480c` / `9fae0ae` / `ea7a31a`; guard artifacts + plan amendment commit `aa1d55a` · PR https://github.com/humanspeak/svelte-markdown/pull/342 · via the `commit` / `pr` skills. Merge is the operator's call.
 
 ## Done criteria
 

--- a/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.guard-report.md
+++ b/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.guard-report.md
@@ -2,7 +2,7 @@
 
 **Recommendation: PASS** — the default-config inline-HTML XSS is closed; every done criterion reproduced green against the corrected lint gate.
 **Reviewed at** `ea7a31a` · 2026-07-07 14:42 · **Plan planned at** `939f154`
-**Integrated** — executor fix commits `596480c` / `9fae0ae` / `ea7a31a`; guard artifacts + plan amendment commit `aa1d55a` · PR https://github.com/humanspeak/svelte-markdown/pull/342 · via the `commit` / `pr` skills. Merge is the operator's call.
+**Integrated** — executor fix commits `596480c` / `9fae0ae` / `ea7a31a`; guard artifacts + plan amendment commit `aa1d55a` · PR [#342](https://github.com/humanspeak/svelte-markdown/pull/342) · via the `commit` / `pr` skills. Merge is the operator's call.
 
 ## Done criteria
 

--- a/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.guard-report.md
+++ b/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.guard-report.md
@@ -1,0 +1,36 @@
+# Guard report — 001 xss-inline-html-fastpath
+
+**Recommendation: PASS** — the default-config inline-HTML XSS is closed; every done criterion reproduced green against the corrected lint gate.
+**Reviewed at** `ea7a31a` · 2026-07-07 14:42 · **Plan planned at** `939f154`
+**Integrated** — commit `<filled after commit skill>` · PR `<filled after pr skill>` · via the `commit` / `pr` skills
+
+## Done criteria
+
+| Criterion                                                                  | Result | Evidence                                                                                                                    |
+| -------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm check` exits 0                                                       | met    | `COMPLETED 1005 FILES 0 ERRORS` (4 pre-existing warnings, none on changed lines)                                            |
+| `pnpm test:only` exits 0; script/style/div tests exist & pass              | met    | full suite `911 passed (144 files)`; the 7 new html tests all `✓`                                                           |
+| `grep -n "htmlTok.tag in Html" src/lib/Parser.svelte` returns the line     | met    | `Parser.svelte:225`                                                                                                         |
+| `<script>alert(1)</script>` produces no live `<script>` (asserted by test) | met    | `drops unknown script tags …` `✓`; asserts `querySelector('script')` null + text `alert(1)` preserved                       |
+| No files outside in-scope list modified (executor contribution)            | met    | `git diff origin/main...HEAD` = `Parser.svelte` (+1), `SvelteMarkdown.test.ts` (+72), `README.md` (DONE row, plan-mandated) |
+| Batch README 001 status row updated                                        | met    | row 25 → `DONE` (committed in `ea7a31a`)                                                                                    |
+| Lint gate (amended) `trunk fmt && trunk check` exits 0                     | met    | `trunk check` on both changed files → `✔ No issues`                                                                         |
+
+Note on base: local `main` is stale (lacks the plans). The true fork point is `origin/main` (contains the plans; `e260af6`/#341 is a genuine ancestor — no squash-merge duplication). All scope/diff claims above use `origin/main`.
+
+## Spirit
+
+The fix delivers `Why this matters` directly and minimally. Adding `htmlTok.tag in Html` to `inlineHtmlOk` (`Parser.svelte:225`) makes the inline fast path's eligibility check agree with the already-safe non-inline path: an unknown tag (`script`, `style`, `meta`, `base`, `object`, …) is no longer `undefined === undefined → true`, so it falls through to the general dispatch that drops the tag and renders only children. The regression tests reproduce the exact vulnerability — `<script>`/`<style>`/`<meta http-equiv=refresh>`/`<base href>` each render **no** live element, with `<script>`'s content demonstrably neutralized to text rather than silently dropped — and the `<div>`/`<iframe>` cases prove the legitimate fast path was not over-corrected. The custom-renderer test confirms the intended escape hatch (an explicit `renderers.html.script`) still routes through the non-inline branch. This is the plan's intent, not merely its checkboxes.
+
+## Scope & conduct
+
+- **In-scope only?** Yes for the executor's committed work — `Parser.svelte`, `SvelteMarkdown.test.ts`, plus the plan-required README status row. No touch to `sanitize.ts`, `renderers/html/**`, or the non-inline branch (all listed out-of-scope).
+- **STOP conditions respected?** Yes. The `inlineHtmlOk` `@const` still matches the plan excerpt (drift check clean); no existing supported-tag test regressed; no second live-render path surfaced.
+- **Plan amendments during execution:** one — **2026-07-07 (guard, operator-directed):** lint gate `pnpm lint` → `trunk fmt && trunk check` across all 12 plans + batch README. Rationale: `pnpm lint` = `prettier --check . && eslint .` (`package.json:107`) fails on pre-existing `docs/**` formatting outside every plan's scope; this repo lints via Trunk. `Planned at` SHAs deliberately **not** re-stamped (tooling-only correction; re-stamping would break the plans' `939f154` drift baselines). Dated revision recorded once in the batch README rather than 12 duplicate blockquotes.
+
+## Residual risk / follow-ups
+
+- **This PR carries guard's batch-wide doc amendment** (the `trunk fmt && trunk check` swap across plans 002–012 + README) alongside the 001 fix. It is doc-only and authorized, but if you prefer the 001 PR to contain only the fix, split that commit out before merging.
+- **Executor work is committed as 3 conventional commits** (`596480c`, `9fae0ae`, `ea7a31a`) authored by `jason.h@kummerl.com`; guard's amendments + oversight artifacts are a separate commit.
+- **Maintenance note (from the plan):** if `script`/`style`/etc. are ever added to the `Html` map (e.g. an opt-in trusted-HTML renderer), this `tag in Html` guard would make them inline-eligible again — that must be a deliberate, sanitized decision.
+- **Not a full sanitizer.** This fixes tag identity only; attribute sanitization (`sanitize.ts`) remains the separate layer for `href`/`src`/`on*`/`srcdoc`, and is unchanged.

--- a/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.guard.md
+++ b/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.guard.md
@@ -1,0 +1,41 @@
+# Guard log — 001 xss-inline-html-fastpath
+
+## Checkpoint 1 — 2026-07-07 14:16 — DRIFTING
+
+`45ca5b9` (merge-base) · first checkpoint; executor has added regression tests but **not** the fix. Working tree: `src/lib/SvelteMarkdown.test.ts` staged (+56); `src/lib/Parser.svelte` untouched.
+
+- **Core fix (Step 1) missing.** Done criterion "`grep -n "htmlTok.tag in Html" src/lib/Parser.svelte`" fails — marker ABSENT. `Parser.svelte:221-226` still holds the vulnerable `inlineHtmlOk` (`renderers.html[tag] === Html[tag]` with no `tag in Html` membership guard). `git diff 939f154..HEAD -- src/lib/Parser.svelte` is empty. The XSS the plan exists to close is still open.
+- **Regression tests are legitimate and correctly RED.** `pnpm test:only src/lib/SvelteMarkdown.test.ts` → 2 failed / 70 passed. `<script>` case fails at `SvelteMarkdown.test.ts:827` (live `<script>` rendered); `<style>` case fails at `:836` (received `<style>*{color:red}</style>`). These failures _are_ the vulnerability reproducing — the tests are well-formed, not gamed; they simply have no fix to pass against.
+- **Done criteria unmet:** `pnpm test:only` would exit non-zero; README 001 row still `TODO` (`README.md:17`); "no live `<script>`" test is failing, not passing.
+- **No violations.** All edits in-scope (`SvelteMarkdown.test.ts` only); `Parser.svelte`, `renderers/html/**`, `sanitize.ts`, non-inline branch all untouched; plan file unmodified; no STOP condition skipped (drift check clean — plan still matches live code). One extra test beyond the plan's four cases ("script via explicitly approved custom renderer", `:838-853`) — additive, in-scope, reasonable; not a concern.
+- Action: reported to operator. Blocking gap = apply Step 1 (`htmlTok.tag in Html` guard in `inlineHtmlOk`, `Parser.svelte:221-226`); the two red tests should then go green. Not integrable in this state.
+
+## Checkpoint 2 — 2026-07-07 14:19 — ON TRACK (tests only)
+
+`45ca5b9` · operator clarified the red tests are intentional (TDD red-phase first); Step 1 fix deliberately deferred. Re-scoped this checkpoint to test-shape review only.
+
+- Tests match the plan's Step 2 case list exactly (script, style, div, iframe) plus one additive opt-in case. Security invariant asserted correctly: `querySelector('script'|'style')` null, and content preserved as text (`toContain('alert(1)')` / `'*{color:red}'`) — proves neutralize-to-text, not silent drop.
+- Custom-renderer test (`:838-853`) is valid and green-able post-fix: fixture `ClickRenderer.svelte:7` emits `<button data-testid="custom-tag-component">{children}</button>`; post-fix `script` routes to the non-inline branch (`'script' in renderers.html`) → renders it. Guards against over-blocking the opt-in path.
+- div/iframe cases currently green (in `Html` map, unaffected) — correct over-correction guards.
+- Optional strengthening (not required by plan): add `<meta http-equiv=refresh>` and `<base href>` cases — both named in "Why this matters" as taking effect, cheap to add, highest-value remaining regressions.
+- Action: reported to operator — tests are the right shape. Next: apply Step 1.
+
+## Checkpoint 3 — 2026-07-07 14:36 — ON TRACK (fix landed) + PLAN AMENDED
+
+`e260af6` HEAD; fix in working tree (uncommitted). Re-ran the plan's own done criteria.
+
+- **Step 1 fix present and correct.** `Parser.svelte:225` adds `htmlTok.tag in Html &&` to `inlineHtmlOk` — exactly the plan's load-bearing change, one line, nothing else touched in that file. Done-criterion grep passes.
+- **Done criteria reproduced green (self-run, not trusted):** `pnpm check` → 0 errors (4 pre-existing warnings, none in changed lines); `pnpm test:only src/lib/SvelteMarkdown.test.ts` → 74 passed; `pnpm test:only` (full) → 911 passed / 144 files. The two previously-red script/style tests now pass; div/iframe stayed green.
+- **Tests expanded beyond checkpoint 2** to include the suggested `<meta http-equiv=refresh>` and `<base href>` cases (`SvelteMarkdown.test.ts` +72 vs main). All in-scope, all asserting `querySelector(tag)` null. Good hardening.
+- **Scope clean.** Working-tree source changes limited to in-scope `Parser.svelte` (+1) and `SvelteMarkdown.test.ts` (+72); README 001 row → `DONE`. No out-of-scope files, no plan-file tampering by the executor.
+- **PLAN AMENDED (operator-directed).** Lint gate `pnpm lint` → `trunk fmt && trunk check` across all 12 plans + batch README. Rationale: `pnpm lint` = `prettier --check . && eslint .` (`package.json:107`) fails on pre-existing `docs/**` formatting outside every plan's scope; repo lints via Trunk. `Planned at` SHAs deliberately NOT re-stamped — tooling-only correction, no source-baseline change, and re-stamping would corrupt the plans' `939f154` drift checks. Deviation from single-plan amend protocol: recorded the dated revision once in the batch README (all executors read it first) rather than 12 duplicate blockquotes; flagged to operator.
+- Action: reported to operator. Fix is verified against the corrected gate (`trunk check`) pending — see note. Not yet committed; awaiting operator go-ahead for `guard 01 final` / integration.
+
+## Checkpoint 4 — 2026-07-07 14:42 — PASS (final close-out)
+
+`ea7a31a` HEAD; executor committed the work as 3 conventional commits (`596480c`, `9fae0ae`, `ea7a31a`) since checkpoint 3. Corrected base = `origin/main` (local `main` is stale; `e260af6`/#341 is a genuine ancestor of origin/main — no squash-dup trap).
+
+- All 7 done criteria reproduced green (self-run): `pnpm check` 0 errors; `pnpm test:only` 911 passed; marker at `Parser.svelte:225`; script test asserts no live `<script>`; scope clean vs `origin/main` (Parser +1, test +72, README DONE row); `trunk check` on both files → No issues.
+- Spirit met: inline fast path now agrees with the safe non-inline path; unknown dangerous tags fall through and are dropped. Tests reproduce the vuln and guard against over-correction + confirm the opt-in path.
+- Close-out report written: `001-xss-inline-html-fastpath.guard-report.md` → **PASS**.
+- Action: integrating — commit (guard amendments + oversight artifacts; source already committed by executor) + open PR via the `commit`/`pr` skills. Merge remains the operator's call.

--- a/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.md
+++ b/.agents/.plans/streaming-component-hardening/001-xss-inline-html-fastpath.md
@@ -100,7 +100,7 @@ live in `src/lib/SvelteMarkdown.test.ts`.
 | Typecheck | `pnpm check`                                    | exit 0, 0 errors    |
 | Unit test | `pnpm test:only`                                | all pass            |
 | One file  | `pnpm test:only src/lib/SvelteMarkdown.test.ts` | all pass            |
-| Lint      | `pnpm lint`                                     | exit 0              |
+| Lint      | `trunk fmt && trunk check`                      | exit 0              |
 
 ## Scope
 
@@ -186,7 +186,7 @@ including the new cases.
 **Verify**:
 
 - `pnpm test:only` → all pass.
-- `pnpm lint` → exit 0.
+- `trunk fmt && trunk check` → exit 0.
 
 ## Test plan
 

--- a/.agents/.plans/streaming-component-hardening/002-offset-mode-dos-guard.md
+++ b/.agents/.plans/streaming-component-hardening/002-offset-mode-dos-guard.md
@@ -79,7 +79,7 @@ that file (see the `flushStreamingBatch` helper near line 125).
 | Typecheck | `pnpm check`                                    | exit 0, 0 errors    |
 | One file  | `pnpm test:only src/lib/SvelteMarkdown.test.ts` | all pass            |
 | All unit  | `pnpm test:only`                                | all pass            |
-| Lint      | `pnpm lint`                                     | exit 0              |
+| Lint      | `trunk fmt && trunk check`                      | exit 0              |
 
 ## Scope
 

--- a/.agents/.plans/streaming-component-hardening/003-token-cleanup-preserve-identity.md
+++ b/.agents/.plans/streaming-component-hardening/003-token-cleanup-preserve-identity.md
@@ -133,7 +133,7 @@ keeps all existing `token-cleanup` tests green.
 | Cleanup   | `pnpm test:only src/lib/utils/token-cleanup.test.ts`                                                  | all pass            |
 | Streaming | `pnpm test:only src/lib/utils/streaming-token-reuse.test.ts src/lib/utils/incremental-parser.test.ts` | all pass            |
 | All unit  | `pnpm test:only`                                                                                      | all pass            |
-| Lint      | `pnpm lint`                                                                                           | exit 0              |
+| Lint      | `trunk fmt && trunk check`                                                                            | exit 0              |
 
 ## Scope
 
@@ -192,7 +192,7 @@ expansion still happen on first clean.
 
 - `pnpm check` → exit 0.
 - `pnpm test:only` → all pass.
-- `pnpm lint` → exit 0.
+- `trunk fmt && trunk check` → exit 0.
 
 ## Test plan
 

--- a/.agents/.plans/streaming-component-hardening/004-source-keys-table-rows.md
+++ b/.agents/.plans/streaming-component-hardening/004-source-keys-table-rows.md
@@ -82,7 +82,7 @@ match header cells.
 | Typecheck | `pnpm check`                                              | exit 0, 0 errors    |
 | 328 tests | `pnpm test:only src/lib/SvelteMarkdown.issue-328.test.ts` | all pass            |
 | All unit  | `pnpm test:only`                                          | all pass            |
-| Lint      | `pnpm lint`                                               | exit 0              |
+| Lint      | `trunk fmt && trunk check`                                | exit 0              |
 
 ## Scope
 
@@ -152,7 +152,7 @@ const assignSourceKeysToChildren = (node: RenderMetadataNode, absoluteOffset: nu
 
 ### Step 3: Typecheck + lint
 
-**Verify**: `pnpm check` → exit 0; `pnpm lint` → exit 0.
+**Verify**: `pnpm check` → exit 0; `trunk fmt && trunk check` → exit 0.
 
 ## Test plan
 

--- a/.agents/.plans/streaming-component-hardening/005-prop-path-raf-batching.md
+++ b/.agents/.plans/streaming-component-hardening/005-prop-path-raf-batching.md
@@ -81,7 +81,7 @@ source_, not accumulate deltas. Design accordingly (see Step 2).
 | Typecheck | `pnpm check`                                    | exit 0, 0 errors    |
 | Stream    | `pnpm test:only src/lib/SvelteMarkdown.test.ts` | all pass            |
 | All unit  | `pnpm test:only`                                | all pass            |
-| Lint      | `pnpm lint`                                     | exit 0              |
+| Lint      | `trunk fmt && trunk check`                      | exit 0              |
 
 ## Scope
 
@@ -178,7 +178,7 @@ same frame ends with the shorter source rendered (reset wins, no stale flush);
 renders the array. Confirm the `$effect` cleanup (`cancelScheduledAppendFlush`
 at lines 371-375) still cancels everything on unmount.
 
-**Verify**: `pnpm test:only` → all pass; `pnpm check` → exit 0; `pnpm lint` → 0.
+**Verify**: `pnpm test:only` → all pass; `pnpm check` → exit 0; `trunk fmt && trunk check` → 0.
 
 ## Test plan
 

--- a/.agents/.plans/streaming-component-hardening/006-heading-id-slugger-snapshot.md
+++ b/.agents/.plans/streaming-component-hardening/006-heading-id-slugger-snapshot.md
@@ -105,7 +105,7 @@ wrong id to save time.
 | Typecheck | `pnpm check`                                              | exit 0, 0 errors    |
 | 328 tests | `pnpm test:only src/lib/SvelteMarkdown.issue-328.test.ts` | all pass            |
 | All unit  | `pnpm test:only`                                          | all pass            |
-| Lint      | `pnpm lint`                                               | exit 0              |
+| Lint      | `trunk fmt && trunk check`                                | exit 0              |
 
 ## Scope
 
@@ -170,7 +170,7 @@ that the number of `slug()` calls per flush is proportional to the tail, not the
 full heading count. If no such harness exists, skip this step — do not build a
 timing-based test (flaky).
 
-**Verify**: `pnpm check` → 0; `pnpm lint` → 0; `pnpm test:only` → all pass.
+**Verify**: `pnpm check` → 0; `trunk fmt && trunk check` → 0; `pnpm test:only` → all pass.
 
 ## Test plan
 

--- a/.agents/.plans/streaming-component-hardening/007-streaming-hotpath-microopts.md
+++ b/.agents/.plans/streaming-component-hardening/007-streaming-hotpath-microopts.md
@@ -87,7 +87,7 @@ fact is available at the `update` call site and can be threaded down.
 | Reuse     | `pnpm test:only src/lib/utils/streaming-token-reuse.test.ts` | all pass            |
 | Parser    | `pnpm test:only src/lib/utils/incremental-parser.test.ts`    | all pass            |
 | All unit  | `pnpm test:only`                                             | all pass            |
-| Lint      | `pnpm lint`                                                  | exit 0              |
+| Lint      | `trunk fmt && trunk check`                                   | exit 0              |
 
 ## Scope
 
@@ -138,7 +138,7 @@ check). The resulting tail-window decision must be identical to today.
 
 ### Step 3: Full suite
 
-**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `pnpm lint` → 0.
+**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `trunk fmt && trunk check` → 0.
 
 ## Test plan
 

--- a/.agents/.plans/streaming-component-hardening/008-remove-dead-html-code.md
+++ b/.agents/.plans/streaming-component-hardening/008-remove-dead-html-code.md
@@ -69,13 +69,13 @@ published `src/lib`. See Step 3 for handling that importer.
 
 ## Commands you will need
 
-| Purpose     | Command                   | Expected on success |
-| ----------- | ------------------------- | ------------------- |
-| Grep usage  | `grep -rn "<symbol>" src` | (see steps)         |
-| Typecheck   | `pnpm check`              | exit 0, 0 errors    |
-| All unit    | `pnpm test:only`          | all pass            |
-| Build (pkg) | `pnpm build`              | exit 0              |
-| Lint        | `pnpm lint`               | exit 0              |
+| Purpose     | Command                    | Expected on success |
+| ----------- | -------------------------- | ------------------- |
+| Grep usage  | `grep -rn "<symbol>" src`  | (see steps)         |
+| Typecheck   | `pnpm check`               | exit 0, 0 errors    |
+| All unit    | `pnpm test:only`           | all pass            |
+| Build (pkg) | `pnpm build`               | exit 0              |
+| Lint        | `trunk fmt && trunk check` | exit 0              |
 
 ## Scope
 
@@ -158,7 +158,7 @@ work (the packaging concern is secondary to not breaking the dev harness).
 - `pnpm test:only` → all pass.
 - `pnpm build` → exit 0 (confirms the package still builds without the deleted
   files).
-- `pnpm lint` → exit 0.
+- `trunk fmt && trunk check` → exit 0.
 
 ## Test plan
 
@@ -175,7 +175,7 @@ ALL must hold:
       → no matches.
 - [ ] `grep -rn "stream-benchmark" src` → no matches (or documented stop).
 - [ ] `pnpm check` exits 0; `pnpm test:only` exits 0; `pnpm build` exits 0;
-      `pnpm lint` exits 0.
+      `trunk fmt && trunk check` exits 0.
 - [ ] Only in-scope files modified/deleted (`git status`) — at most one file
       outside `src/lib` (`src/routes/test/perf-bench/+page.svelte`).
 - [ ] The batch `README.md` status row for 008 is updated.

--- a/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.md
+++ b/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.md
@@ -53,17 +53,18 @@ languageOptions: {
 
 Conventions: **never** use `eslint-disable` comments; use Trunk inline ignores
 `// trunk-ignore(eslint/rule-name)` when a suppression is genuinely needed
-(CLAUDE.md, "Code Style & Linting"). Lint is run via `pnpm lint`
-(`prettier --check . && eslint .`). CI runs on Node 22/24.
+(CLAUDE.md, "Code Style & Linting"). Formatting and linting run via Trunk:
+`trunk fmt` (formatters, incl. prettier) then `trunk check` (eslint et al.).
+CI runs on Node 22/24.
 
 ## Commands you will need
 
-| Purpose     | Command              | Expected on success |
-| ----------- | -------------------- | ------------------- |
-| Lint        | `pnpm lint`          | exit 0              |
-| ESLint only | `pnpm exec eslint .` | exit 0              |
-| Typecheck   | `pnpm check`         | exit 0              |
-| All unit    | `pnpm test:only`     | all pass            |
+| Purpose     | Command                    | Expected on success |
+| ----------- | -------------------------- | ------------------- |
+| Lint        | `trunk fmt && trunk check` | exit 0              |
+| ESLint only | `pnpm exec eslint .`       | exit 0              |
+| Typecheck   | `pnpm check`               | exit 0              |
+| All unit    | `pnpm test:only`           | all pass            |
 
 ## Scope
 
@@ -124,7 +125,7 @@ files or explodes the lint time unacceptably, **STOP and report** with the error
 (`svelte-eslint-parser` `parserOptions.parser`), which may exceed this plan's
 risk budget.
 
-**Verify**: `pnpm lint` → exit 0 with the new rules active.
+**Verify**: `trunk fmt && trunk check` → exit 0 with the new rules active.
 
 ### Step 3: Prove a floating promise is now caught (guard)
 
@@ -136,17 +137,17 @@ actually wired to type info, not silently inactive. Document the result in your
 report (do not commit the scratch change).
 
 **Verify**: ESLint flags the scratch floating promise; after revert,
-`pnpm lint` → exit 0.
+`trunk fmt && trunk check` → exit 0.
 
 ### Step 4: Full suite
 
-**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `pnpm lint` → 0.
+**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `trunk fmt && trunk check` → 0.
 
 ## Test plan
 
 - No new unit tests (this is tooling). The guard is Step 3 (rule provably active)
   plus a green `pnpm test:only` after any violation fixes.
-- Verification: `pnpm lint` → exit 0; `pnpm test:only` → all pass.
+- Verification: `trunk fmt && trunk check` → exit 0; `pnpm test:only` → all pass.
 
 ## Done criteria
 
@@ -156,7 +157,7 @@ ALL must hold:
       `eslint.config.mjs`.
 - [ ] `no-floating-promises` is active and provably catches a floating promise
       (Step 3), then reverted.
-- [ ] `pnpm lint` exits 0 (all surfaced violations fixed or justified via Trunk
+- [ ] `trunk fmt && trunk check` exits 0 (all surfaced violations fixed or justified via Trunk
       inline ignore — never `eslint-disable`).
 - [ ] `pnpm check` exits 0; `pnpm test:only` exits 0.
 - [ ] No `eslint-disable` comments introduced (`grep -rn "eslint-disable" src`

--- a/.agents/.plans/streaming-component-hardening/010-coverage-thresholds-engines-raf-fallback.md
+++ b/.agents/.plans/streaming-component-hardening/010-coverage-thresholds-engines-raf-fallback.md
@@ -78,7 +78,7 @@ line 133 and `vitest.setup.ts`).
 | Unit only    | `pnpm test:only`                                | all pass                                          |
 | One file     | `pnpm test:only src/lib/SvelteMarkdown.test.ts` | all pass                                          |
 | Typecheck    | `pnpm check`                                    | exit 0                                            |
-| Lint         | `pnpm lint`                                     | exit 0                                            |
+| Lint         | `trunk fmt && trunk check`                      | exit 0                                            |
 
 ## Scope
 
@@ -160,7 +160,7 @@ the new fallback test.
 
 ### Step 4: Full suite + lint
 
-**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `pnpm lint` → 0;
+**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `trunk fmt && trunk check` → 0;
 `pnpm test` → passes with thresholds enforced.
 
 ## Test plan
@@ -180,7 +180,7 @@ ALL must hold:
       the chosen floor).
 - [ ] `package.json` has `"engines": { "node": ">=22" }`.
 - [ ] New rAF-fallback test(s) pass and restore `requestAnimationFrame`.
-- [ ] `pnpm check` exits 0; `pnpm test:only` exits 0; `pnpm lint` exits 0.
+- [ ] `pnpm check` exits 0; `pnpm test:only` exits 0; `trunk fmt && trunk check` exits 0.
 - [ ] No files outside the in-scope list are modified (`git status`).
 - [ ] The batch `README.md` status row for 010 is updated.
 

--- a/.agents/.plans/streaming-component-hardening/011-unify-token-reuse-identity.md
+++ b/.agents/.plans/streaming-component-hardening/011-unify-token-reuse-identity.md
@@ -100,7 +100,7 @@ identity rule is correct on its own.
 | Parser    | `pnpm test:only src/lib/utils/incremental-parser.test.ts src/lib/utils/incremental-parser.nested-html.test.ts`                         | all pass            |
 | Streaming | `pnpm test:only src/lib/SvelteMarkdown.test.ts src/lib/SvelteMarkdown.streaming-html.test.ts src/lib/SvelteMarkdown.issue-328.test.ts` | all pass            |
 | All unit  | `pnpm test:only`                                                                                                                       | all pass            |
-| Lint      | `pnpm lint`                                                                                                                            | exit 0              |
+| Lint      | `trunk fmt && trunk check`                                                                                                             | exit 0              |
 
 ## Scope
 
@@ -190,7 +190,7 @@ behavior exactly (render-metadata depends on it).
 Remove now-unused exports. Confirm nothing in `src/lib/index.ts` exported the
 removed symbols (they are internal — verify with grep).
 
-**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `pnpm lint` → 0;
+**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `trunk fmt && trunk check` → 0;
 `grep -rn "reuseStableStreamingTokens\|canReuse\|divergeAt" src/lib` shows no
 stale references (except any intentionally kept internal usage you documented).
 
@@ -209,7 +209,7 @@ stale references (except any intentionally kept internal usage you documented).
 
 ALL must hold:
 
-- [ ] `pnpm check` exits 0; `pnpm test:only` exits 0; `pnpm lint` exits 0.
+- [ ] `pnpm check` exits 0; `pnpm test:only` exits 0; `trunk fmt && trunk check` exits 0.
 - [ ] The 5 repro cases from issue #331 exist and pass.
 - [ ] A single identity predicate governs both the parser divergence and the node
       merge (one function, both call sites).

--- a/.agents/.plans/streaming-component-hardening/012-simplify-sourceless-root-keys.md
+++ b/.agents/.plans/streaming-component-hardening/012-simplify-sourceless-root-keys.md
@@ -79,7 +79,7 @@ The three tests that MUST keep passing (in
 | Typecheck | `pnpm check`                                              | exit 0, 0 errors    |
 | 328 tests | `pnpm test:only src/lib/SvelteMarkdown.issue-328.test.ts` | all pass            |
 | All unit  | `pnpm test:only`                                          | all pass            |
-| Lint      | `pnpm lint`                                               | exit 0              |
+| Lint      | `trunk fmt && trunk check`                                | exit 0              |
 
 ## Scope
 
@@ -155,7 +155,7 @@ Confirm `previousSourceLessRoots` no longer retains per-root full-subtree `Set`s
 (inspect the new cross-pass state — it should hold representative identities or
 nothing, not whole-subtree sets).
 
-**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `pnpm lint` → 0.
+**Verify**: `pnpm check` → 0; `pnpm test:only` → all pass; `trunk fmt && trunk check` → 0.
 
 ## Test plan
 
@@ -166,7 +166,7 @@ nothing, not whole-subtree sets).
 
 ## Done criteria (if simplifying)
 
-- [ ] `pnpm check` exits 0; `pnpm test:only` exits 0; `pnpm lint` exits 0.
+- [ ] `pnpm check` exits 0; `pnpm test:only` exits 0; `trunk fmt && trunk check` exits 0.
 - [ ] The three existing source-less identity tests still pass, plus the new edge
       cases.
 - [ ] `previousSourceLessRoots` no longer retains full-subtree identity `Set`s

--- a/.agents/.plans/streaming-component-hardening/README.md
+++ b/.agents/.plans/streaming-component-hardening/README.md
@@ -10,6 +10,14 @@ This batch **absorbs and supersedes** the open GitHub issues listed under
 before planning (except #332, whose main asks already shipped — only a residual
 remains).
 
+> **Revision 2026-07-07 (guard):** All plans' lint gate changed from `pnpm lint`
+> to `trunk fmt && trunk check`. `pnpm lint` runs `prettier --check . && eslint .`,
+> which fails on pre-existing `docs/**` formatting unrelated to any plan's scope;
+> this repo lints via Trunk (`trunk fmt` to format, `trunk check` to lint). The
+> `Planned at` SHA is intentionally left at `939f154` for every plan — this is a
+> tooling-command correction only and does not change any plan's source baseline,
+> so the drift checks must keep pointing at the original audited commit.
+
 ## Execution order & status
 
 | Plan | Title                                                                                        | Priority | Effort | Risk | Depends on         | Status |
@@ -111,6 +119,6 @@ These came out of this audit and were **not** open issues before:
 - Typecheck: `pnpm check`
 - Unit tests (no coverage): `pnpm test:only` (or `pnpm test:only <file>`)
 - Unit tests + coverage gate: `pnpm test`
-- Lint: `pnpm lint`
+- Lint: `trunk fmt && trunk check`
 - Package build: `pnpm build`
 - E2E (not usually needed per-plan): `pnpm test:e2e`

--- a/.agents/.plans/streaming-component-hardening/README.md
+++ b/.agents/.plans/streaming-component-hardening/README.md
@@ -14,7 +14,7 @@ remains).
 
 | Plan | Title                                                                                        | Priority | Effort | Risk | Depends on         | Status |
 | ---- | -------------------------------------------------------------------------------------------- | -------- | ------ | ---- | ------------------ | ------ |
-| 001  | Inline-HTML fast path stops rendering unknown/dangerous tags (XSS)                           | P1       | S      | LOW  | —                  | TODO   |
+| 001  | Inline-HTML fast path stops rendering unknown/dangerous tags (XSS)                           | P1       | S      | LOW  | —                  | DONE   |
 | 002  | Offset-mode streaming rejects unbounded gaps (RangeError/DoS)                                | P1       | S      | LOW  | —                  | TODO   |
 | 003  | `shrinkHtmlTokens` preserves list-item / table-cell identity                                 | P2       | M      | MED  | —                  | TODO   |
 | 004  | Source-offset render keys extend to table body cells (`rows`)                                | P2       | S      | MED  | —                  | TODO   |

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -222,6 +222,7 @@
         token.type === 'html' &&
         !!htmlTok.tag &&
         !!renderers.html &&
+        htmlTok.tag in Html &&
         renderers.html[htmlTok.tag] === Html[htmlTok.tag] &&
         !htmlSnippetOverrides[htmlTok.tag]}
     {#if token.type === 'space' && inlineSpaceOk}

--- a/src/lib/SvelteMarkdown.test.ts
+++ b/src/lib/SvelteMarkdown.test.ts
@@ -837,6 +837,22 @@ describe('testing default renderers', () => {
             expect(container.textContent).toContain('*{color:red}')
         })
 
+        test('drops unknown meta refresh tags in the default configuration', () => {
+            const { container } = render(SvelteMarkdown, {
+                source: '<meta http-equiv="refresh" content="0;url=https://example.com">'
+            })
+
+            expect(container.querySelector('meta')).toBeNull()
+        })
+
+        test('drops unknown base tags in the default configuration', () => {
+            const { container } = render(SvelteMarkdown, {
+                source: '<base href="https://example.com/">'
+            })
+
+            expect(container.querySelector('base')).toBeNull()
+        })
+
         test('renders script tags with an explicitly approved custom renderer', () => {
             const { container } = render(SvelteMarkdown, {
                 source: '<script>alert(1)</script>',

--- a/src/lib/SvelteMarkdown.test.ts
+++ b/src/lib/SvelteMarkdown.test.ts
@@ -3,6 +3,7 @@ import { act, render, screen } from '@testing-library/svelte'
 import type { MarkedExtension } from 'marked'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import SvelteMarkdown from './SvelteMarkdown.svelte'
+import ClickRenderer from './test/snippets/ClickRenderer.svelte'
 import type { SvelteMarkdownProps } from './types.js'
 import type { Token } from './utils/markdown-parser.js'
 import * as parseAndCacheModule from './utils/parse-and-cache.js'
@@ -816,6 +817,61 @@ describe('testing default renderers', () => {
             expect(emElement.nodeName).toBe('EM')
             expect(emElement.parentElement?.nodeName).toBe('SPAN')
             expect(emElement.parentElement?.parentElement?.nodeName).toBe('DIV')
+        })
+
+        test('drops unknown script tags in the default configuration', () => {
+            const { container } = render(SvelteMarkdown, {
+                source: '<script>alert(1)</script>'
+            })
+
+            expect(container.querySelector('script')).toBeNull()
+            expect(container.textContent).toContain('alert(1)')
+        })
+
+        test('drops unknown style tags in the default configuration', () => {
+            const { container } = render(SvelteMarkdown, {
+                source: '<style>*{color:red}</style>'
+            })
+
+            expect(container.querySelector('style')).toBeNull()
+            expect(container.textContent).toContain('*{color:red}')
+        })
+
+        test('renders script tags with an explicitly approved custom renderer', () => {
+            const { container } = render(SvelteMarkdown, {
+                source: '<script>alert(1)</script>',
+                renderers: {
+                    html: {
+                        script: ClickRenderer
+                    }
+                }
+            })
+
+            const customScriptElement = container.querySelector(
+                '[data-testid="custom-tag-component"]'
+            )
+            expect(customScriptElement).toBeInTheDocument()
+            expect(customScriptElement?.textContent).toBe('alert(1)')
+            expect(container.querySelector('script')).toBeNull()
+        })
+
+        test('continues to render supported div tags', () => {
+            const { container } = render(SvelteMarkdown, {
+                source: '<div>ok</div>'
+            })
+
+            const divElement = container.firstElementChild
+            expect(divElement).toBeInTheDocument()
+            expect(divElement?.nodeName).toBe('DIV')
+            expect(divElement?.textContent).toBe('ok')
+        })
+
+        test('continues to render supported iframe tags', () => {
+            const { container } = render(SvelteMarkdown, {
+                source: '<iframe></iframe>'
+            })
+
+            expect(container.querySelector('iframe')).toBeInTheDocument()
         })
 
         test('renders html with attributes', () => {


### PR DESCRIPTION
## Summary

Closes a **default-configuration XSS** in the inline-HTML fast path. Raw markdown containing `<script>`, `<style>`, `<meta http-equiv=refresh>`, or `<base href>` was rendered as a **live** element, because the fast-path eligibility check `renderers.html[tag] === Html[tag]` evaluated `undefined === undefined → true` for any tag absent from the built-in `Html` map. The non-inline path already handled these safely (drop the tag, render children); this change makes the fast path agree with it.

Implements plan `001-xss-inline-html-fastpath` from the streaming-component-hardening batch.

## Changes

- 🔒 `Parser.svelte`: require `htmlTok.tag in Html` in `inlineHtmlOk`, so unknown tags fall through to the safe non-inline dispatch (tag dropped, children rendered) instead of rendering live.
- 🧪 `SvelteMarkdown.test.ts`: regression tests — `<script>`/`<style>`/`<meta>`/`<base>` render no live element (content neutralized to text); `<div>`/`<iframe>` still render (no over-correction); an explicitly-approved custom `script` renderer still works via the opt-in path.
- 📚 Plans batch: lint gate changed from `pnpm lint` to `trunk fmt && trunk check` (the former fails on pre-existing `docs/**` formatting outside plan scope; repo lints via Trunk), plus guard oversight artifacts (log + close-out report, verdict **PASS**) for plan 001.

Fix targets tag identity only; attribute sanitization (`sanitize.ts`) is a separate, unchanged layer.

## Verification

- `pnpm check` → 0 errors
- `pnpm test:only` → 911 passed (144 files)
- `trunk check` on changed source → ✔ No issues

## Commits

- [`596480c`](https://github.com/humanspeak/svelte-markdown/commit/596480c) test(parser): cover inline HTML tag approval
- [`9fae0ae`](https://github.com/humanspeak/svelte-markdown/commit/9fae0ae) test(parser): cover meta and base inline HTML vectors
- [`ea7a31a`](https://github.com/humanspeak/svelte-markdown/commit/ea7a31a) fix(parser): drop unknown HTML tags in inline fast path
- [`aa1d55a`](https://github.com/humanspeak/svelte-markdown/commit/aa1d55a) docs(plans): switch lint gate to trunk + add 001 guard records
