### PR TITLE
feat(streaming): add streamId prop to reset state between streams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,20 +62,29 @@ pnpm build            # Build the package
 pnpm package          # Create distributable package
 pnpm check            # Run svelte-check type checking
 
-# Code Quality
-pnpm lint             # Check linting (prettier + eslint)
-pnpm lint:fix         # Fix linting issues
-pnpm format           # Format code with prettier
+# Code Quality — use Trunk, not raw prettier/eslint
+trunk fmt             # Format changed files
+trunk check           # Lint changed files
+trunk check --fix     # Lint changed files and auto-fix
 ```
 
 ## Code Style & Linting
 
-- **Trunk** is used for linting orchestration (see `.trunk/trunk.yaml`)
-- **ESLint** with TypeScript and Svelte plugins
-- **Prettier** with svelte, organize-imports, and tailwindcss plugins
-- **Husky** pre-commit hooks run `trunk fmt` before commits
+**Always use `trunk fmt` and `trunk check` to format and lint. Do not run `pnpm lint`, `pnpm format`, `npx prettier`, or `npx eslint` directly.**
+
+Trunk is the source of truth (see `.trunk/trunk.yaml`); it orchestrates Prettier and ESLint with the repo's config and, critically, **only operates on files changed relative to the upstream branch**. The raw tools behave differently and will mislead you:
+
+- `pnpm lint` runs `prettier --check . && eslint .` across the **whole repo**, which flags ~34 pre-existing unformatted files (generated `docs/static/**/*.md`, `pnpm-lock.yaml`). These are not your changes — don't try to fix them.
+- Because that command is `&&`-chained, the Prettier failure means **ESLint never runs**, so a green-looking mental model is wrong either way.
+- `pnpm format` (`prettier --write .`) would rewrite all those unrelated files and pollute the diff. Never run it.
+- Passing files to `npx prettier` explicitly fails on `.svx` ("No parser could be inferred"); Trunk handles the repo's file types correctly.
+
+To check only what you changed: `trunk check --fix` (this is what the Husky pre-commit hook runs, followed by `pnpm check` for svelte-check types).
+
+- **Husky** pre-commit hooks run `trunk fmt`, then `trunk check --fix`, then `pnpm check`
 - Code style enforces camelCase, prefer-const, no-var
 - **Never use `eslint-disable` comments** (e.g., `eslint-disable-line`, `eslint-disable-next-line`). Always use Trunk's inline ignore syntax instead: `// trunk-ignore(eslint/rule-name)`. This applies to all files including tests.
+    - Note: raw `npx eslint` still reports these as warnings because `trunk-ignore` is a Trunk-level suppression — another reason to check via `trunk check`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -825,7 +825,43 @@ The first successful write after a reset locks the stream into one input mode:
 
 Switching modes before `resetStream()` or a `source` prop reset logs a warning and drops the chunk. Offset chunks must use a non-negative safe integer `offset`.
 
-Changing the `source` prop also resets the imperative buffer, seeds a new baseline value, and unlocks the input mode.
+Setting the `source` prop to a **new value** also resets the imperative buffer, seeds a new baseline value, and unlocks the input mode. Re-assigning the same value is not a change and resets nothing — see the warning below.
+
+#### Resetting between messages
+
+The streaming buffer, the incremental parser, and the input-mode lock are all **per-component-instance** state. They outlive any single message. If a component instance is reused for a second stream without being reset, the new stream starts on top of the previous message's buffer.
+
+This bites the common chat-transcript pattern, because Svelte reuses the component instance whenever it isn't keyed by message identity:
+
+```svelte
+<!-- ⚠️ Broken: one recycled instance, no reset between messages -->
+{#each messages as message}
+    <SvelteMarkdown bind:this={markdown} source="" streaming={true} />
+{/each}
+```
+
+Holding `source=""` for the entire conversation means the `source` prop never changes, so nothing ever triggers the implicit reset. Concretely:
+
+- **append mode** — the next message renders as `previous message + new message`.
+- **offset mode** — writes overwrite in place without truncating, so the previous message's **tail** survives past the end of the new one. This does not self-correct until the new message grows longer than the old one.
+- **either mode** — the input-mode lock from the previous stream is still in force, so the first chunk of the new stream is dropped with a warning if it uses the other chunk type.
+
+Pass a `streamId` that changes per message. Whenever its value changes, the component drops the buffer, any pending unflushed chunk, the parser, and the mode lock, then rebaselines on the current `source`:
+
+```svelte
+<!-- ✅ Correct: streamId identifies the stream -->
+{#each messages as message}
+    <SvelteMarkdown bind:this={markdown} source="" streaming={true} streamId={message.id} />
+{/each}
+```
+
+`streamId` accepts a `string` or `number` and is ignored when `streaming` is `false`. Three equivalent ways to get a clean stream, in rough order of preference:
+
+1. **`streamId={message.id}`** — declarative; works even when the instance is recycled.
+2. **`{#each messages as message (message.id)}`** — a keyed each gives each message its own instance, so there is nothing to reset. Use this when the key genuinely identifies the message rather than a slot in a virtual list.
+3. **`markdown.resetStream()`** — imperative; call it _before_ the first `writeChunk()` of the new stream.
+
+> **Note:** if you reset by changing `source` and call `writeChunk()` in the same tick, the write lands before the prop-driven reset — `writeChunk()` is synchronous while the reset runs in an effect. Prefer `streamId` or `resetStream()`, which take effect immediately.
 
 Appending directly to `source` is still supported:
 
@@ -946,6 +982,7 @@ The component emits a `parsed` event when tokens are calculated:
 | ------------------ | ----------------------- | ------------------------------------------------------------------------------------------------------ |
 | source             | `string \| Token[]`     | Markdown content or pre-parsed tokens                                                                  |
 | streaming          | `boolean`               | Enable incremental rendering for LLM streaming                                                         |
+| streamId           | `string \| number`      | Identity of the current stream. Changing it resets the streaming buffer, parser, and input-mode lock   |
 | renderers          | `Partial<Renderers>`    | Custom component overrides                                                                             |
 | options            | `SvelteMarkdownOptions` | Marked parser configuration                                                                            |
 | isInline           | `boolean`               | Toggle inline parsing mode                                                                             |

--- a/docs/src/routes/docs/advanced/llm-streaming/+page.svx
+++ b/docs/src/routes/docs/advanced/llm-streaming/+page.svx
@@ -78,7 +78,7 @@ The component works reactively by default. For best streaming performance, pass 
 - `string` for append mode
 - `{ value, offset }` for websocket-style offset patches
 
-The first successful write locks the stream into one mode until `resetStream()` or a `source` prop reset. If an offset patch skips ahead, missing positions are padded with spaces.
+The first successful write locks the stream into one mode until `resetStream()`, a [`streamId` change](#resetting-between-messages), or a `source` prop reset. If an offset patch skips ahead, missing positions are padded with spaces.
 
 ### With websocket-style offset chunks
 
@@ -99,7 +99,45 @@ markdown?.writeChunk({ value: 'Hello', offset: 0 })
 
 There is no delete or truncate behavior in offset mode, and offsets must be non-negative safe integers.
 
-Like append mode, the first successful write locks the stream shape until `resetStream()` or a `source` prop reset.
+Like append mode, the first successful write locks the stream shape until `resetStream()`, a `streamId` change, or a `source` prop reset.
+
+## Resetting Between Messages
+
+The streaming buffer, the incremental parser, and the input-mode lock are **per-component-instance** state. They outlive any single message. If one instance is reused for a second stream without being reset, the new stream starts on top of the previous message's buffer.
+
+This is easy to hit in a chat transcript, because Svelte reuses the component instance whenever it is not keyed by message identity:
+
+```svelte
+<!-- ⚠️ Broken: one recycled instance, no reset between messages -->
+{#each messages as message}
+    <SvelteMarkdown bind:this={markdown} source="" streaming={true} />
+{/each}
+```
+
+Holding `source=""` for the whole conversation means the `source` prop never changes, so nothing ever triggers the implicit reset. The symptoms differ by mode:
+
+- **Append mode** — the next message renders as `previous message + new message`.
+- **Offset mode** — writes overwrite in place without truncating, so the previous message's **tail** survives past the end of the new one. It does not self-correct until the new message grows longer than the old one.
+- **Either mode** — the previous stream's input-mode lock is still in force, so the first chunk of the new stream is dropped with a warning if it uses the other chunk type.
+
+Pass a `streamId` that changes per message. Whenever its value changes, the component drops the buffer, any pending unflushed chunk, the parser, and the mode lock, then rebaselines on the current `source`:
+
+```svelte
+<!-- ✅ Correct: streamId identifies the stream -->
+{#each messages as message}
+    <SvelteMarkdown bind:this={markdown} source="" streaming={true} streamId={message.id} />
+{/each}
+```
+
+`streamId` accepts a `string` or `number` and is ignored when `streaming` is `false`.
+
+There are three equivalent ways to start a clean stream, in rough order of preference:
+
+1. **`streamId={message.id}`** — declarative, and works even when the instance is recycled.
+2. **A keyed each** — `{#each messages as message (message.id)}` gives each message its own instance, so there is nothing to reset. Use this when the key identifies the message rather than a slot in a virtual list.
+3. **`markdown.resetStream()`** — imperative; call it _before_ the new stream's first `writeChunk()`.
+
+> **Note:** resetting by changing `source` is not safe to combine with a same-tick `writeChunk()`. `writeChunk()` runs synchronously, while a prop-driven reset runs in an effect, so the write would land on the old buffer and then be wiped. `streamId` and `resetStream()` both take effect immediately and have no such ordering hazard.
 
 ### SDK Examples
 

--- a/src/lib/SvelteMarkdown.stream-id.test.ts
+++ b/src/lib/SvelteMarkdown.stream-id.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Coverage for the `streamId` prop.
+ *
+ * Chat UIs frequently recycle a single `<SvelteMarkdown streaming>` instance
+ * across assistant turns (non-keyed `{#each}`, virtual lists, or a keyed each
+ * whose key is stable per slot rather than per message). Because the imperative
+ * buffer is instance state, a recycled component starts the next stream with the
+ * previous message still in `streamSourceBuffer` and the input mode still locked
+ * from the previous session.
+ *
+ * `streamId` gives consumers a declarative reset: change it and the component
+ * drops the buffer, the pending flush, the parser, and the input-mode lock.
+ *
+ * The three failure modes pinned here:
+ *   1. append mode  — old message prefixes the new one
+ *   2. offset mode  — old message's *tail* survives past the new write
+ *   3. mode lock    — a new session can't switch string/offset without a reset
+ */
+
+import '@testing-library/jest-dom'
+import { act, render } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import SvelteMarkdown from './SvelteMarkdown.svelte'
+import StreamIdRaceHarness from './test/streaming/StreamIdRaceHarness.svelte'
+import { tokenCache } from './utils/token-cache.js'
+
+beforeEach(() => {
+    tokenCache.clearAllTokens()
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+        return setTimeout(() => cb(performance.now()), 16) as unknown as number
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    // A failing assertion skips a test's own `mockRestore()`, and `vi.spyOn`
+    // on an already-spied method hands back the existing mock — call history
+    // included. Restore here so one failure can't cascade into the next test.
+    vi.restoreAllMocks()
+})
+
+const flushStreamingBatch = async () => {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(50)
+    })
+}
+
+describe('streamId prop', () => {
+    describe('append mode', () => {
+        test('changing streamId drops the previous message from the buffer', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 'msg-1' }
+            })
+
+            await act(() => component.writeChunk('# First message'))
+            await flushStreamingBatch()
+            expect(container.querySelector('h1')?.textContent).toBe('First message')
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 'msg-2' }))
+            expect(container.textContent?.trim()).toBe('')
+
+            await act(() => component.writeChunk('# Second message'))
+            await flushStreamingBatch()
+
+            // The old heading must not survive, and the new heading must not be
+            // a concatenation of both messages.
+            expect(container.querySelectorAll('h1')).toHaveLength(1)
+            expect(container.querySelector('h1')?.textContent).toBe('Second message')
+            expect(container.textContent).not.toContain('First message')
+        })
+
+        test('a pending (unflushed) chunk from the old stream is discarded', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 'msg-1' }
+            })
+
+            // Below STREAM_BATCH_MAX_CHARS, so this sits in the pending buffer.
+            await act(() => component.writeChunk('stale text'))
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 'msg-2' }))
+            await flushStreamingBatch()
+
+            expect(container.textContent?.trim()).toBe('')
+        })
+
+        test('writeChunk in the same tick as a streamId change targets the new stream', async () => {
+            // writeChunk() is synchronous while the prop-driven reset runs in an
+            // $effect, so a parent that swaps streamId and immediately writes must
+            // still land on the new stream's buffer, not the previous message's.
+            // Driven through a real parent: rerender() would flushSync and hide it.
+            const { component, container } = render(StreamIdRaceHarness)
+
+            await act(() => component.write('# First'))
+            await flushStreamingBatch()
+            expect(container.querySelector('h1')?.textContent).toBe('First')
+
+            await act(() => component.switchStreamAndWrite('msg-2', '# Second'))
+            await flushStreamingBatch()
+
+            expect(container.querySelectorAll('h1')).toHaveLength(1)
+            expect(container.querySelector('h1')?.textContent).toBe('Second')
+            expect(container.textContent).not.toContain('First')
+        })
+
+        test('same streamId keeps appending to the same buffer', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 'msg-1' }
+            })
+
+            await act(() => component.writeChunk('Hello'))
+            await flushStreamingBatch()
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 'msg-1' }))
+
+            await act(() => component.writeChunk(' world'))
+            await flushStreamingBatch()
+
+            expect(container.querySelector('p')?.textContent).toBe('Hello world')
+        })
+    })
+
+    describe('offset mode', () => {
+        test('changing streamId clears the stale tail of the previous message', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 'msg-1' }
+            })
+
+            await act(() => component.writeChunk({ value: 'A long first message', offset: 0 }))
+            await flushStreamingBatch()
+            expect(container.querySelector('p')?.textContent).toBe('A long first message')
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 'msg-2' }))
+
+            // Overwrite semantics preserve any suffix beyond the written span,
+            // so without a reset this would render "Shortst message".
+            await act(() => component.writeChunk({ value: 'Short', offset: 0 }))
+            await flushStreamingBatch()
+
+            expect(container.querySelector('p')?.textContent).toBe('Short')
+        })
+    })
+
+    describe('input-mode lock', () => {
+        test('changing streamId unlocks offset -> append without warning', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 'msg-1' }
+            })
+
+            await act(() => component.writeChunk({ value: 'offset stream', offset: 0 }))
+            await flushStreamingBatch()
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 'msg-2' }))
+
+            await act(() => component.writeChunk('append stream'))
+            await flushStreamingBatch()
+
+            expect(container.querySelector('p')?.textContent).toBe('append stream')
+            expect(warnSpy).not.toHaveBeenCalled()
+
+            warnSpy.mockRestore()
+        })
+
+        test('changing streamId unlocks append -> offset without warning', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 'msg-1' }
+            })
+
+            await act(() => component.writeChunk('append stream'))
+            await flushStreamingBatch()
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 'msg-2' }))
+
+            await act(() => component.writeChunk({ value: 'offset stream', offset: 0 }))
+            await flushStreamingBatch()
+
+            expect(container.querySelector('p')?.textContent).toBe('offset stream')
+            expect(warnSpy).not.toHaveBeenCalled()
+
+            warnSpy.mockRestore()
+        })
+    })
+
+    describe('source prop interaction', () => {
+        test('changing streamId reseeds the baseline from a non-empty source prop', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 'msg-1' }
+            })
+
+            await act(() => component.writeChunk('# Old'))
+            await flushStreamingBatch()
+
+            await act(() => rerender({ source: '# Seed', streaming: true, streamId: 'msg-2' }))
+            await flushStreamingBatch()
+            expect(container.querySelector('h1')?.textContent).toBe('Seed')
+
+            // Subsequent chunks append to the seeded baseline, not the old buffer.
+            await act(() => component.writeChunk('\n\ntail'))
+            await flushStreamingBatch()
+
+            expect(container.querySelector('h1')?.textContent).toBe('Seed')
+            expect(container.querySelector('p')?.textContent).toBe('tail')
+            expect(container.textContent).not.toContain('Old')
+        })
+
+        test('changing streamId and source together does not double-apply the source', async () => {
+            const { container, rerender } = render(SvelteMarkdown, {
+                props: { source: '# One', streaming: true, streamId: 'msg-1' }
+            })
+            await flushStreamingBatch()
+
+            await act(() => rerender({ source: '# Two', streaming: true, streamId: 'msg-2' }))
+            await flushStreamingBatch()
+
+            expect(container.querySelectorAll('h1')).toHaveLength(1)
+            expect(container.querySelector('h1')?.textContent).toBe('Two')
+        })
+
+        test('changing streamId with a token-array source swaps the tokens', async () => {
+            const first = [
+                {
+                    type: 'paragraph',
+                    raw: 'one',
+                    text: 'one',
+                    tokens: [{ type: 'text', raw: 'one', text: 'one' }]
+                }
+            ]
+            const second = [
+                {
+                    type: 'paragraph',
+                    raw: 'two',
+                    text: 'two',
+                    tokens: [{ type: 'text', raw: 'two', text: 'two' }]
+                }
+            ]
+
+            const { container, rerender } = render(SvelteMarkdown, {
+                props: { source: first, streaming: true, streamId: 'msg-1' }
+            })
+            await flushStreamingBatch()
+
+            await act(() => rerender({ source: second, streaming: true, streamId: 'msg-2' }))
+            await flushStreamingBatch()
+
+            expect(container.textContent).toContain('two')
+            expect(container.textContent).not.toContain('one')
+        })
+    })
+
+    describe('non-streaming and passthrough behavior', () => {
+        test('streamId is inert when streaming is false', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+            const { container, rerender } = render(SvelteMarkdown, {
+                props: { source: '# Static', streaming: false, streamId: 'msg-1' }
+            })
+
+            expect(container.querySelector('h1')?.textContent).toBe('Static')
+
+            await act(() => rerender({ source: '# Static', streaming: false, streamId: 'msg-2' }))
+
+            expect(container.querySelector('h1')?.textContent).toBe('Static')
+            expect(warnSpy).not.toHaveBeenCalled()
+
+            warnSpy.mockRestore()
+        })
+
+        test('streamId is not forwarded to the DOM as an attribute', async () => {
+            const { container } = render(SvelteMarkdown, {
+                props: { source: '# Title', streaming: true, streamId: 'msg-1' }
+            })
+            await flushStreamingBatch()
+
+            expect(container.innerHTML.toLowerCase()).not.toContain('streamid')
+        })
+
+        test('numeric streamId values are supported', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 1 }
+            })
+
+            await act(() => component.writeChunk('# One'))
+            await flushStreamingBatch()
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 2 }))
+            await act(() => component.writeChunk('# Two'))
+            await flushStreamingBatch()
+
+            expect(container.querySelectorAll('h1')).toHaveLength(1)
+            expect(container.querySelector('h1')?.textContent).toBe('Two')
+        })
+    })
+})

--- a/src/lib/SvelteMarkdown.stream-id.test.ts
+++ b/src/lib/SvelteMarkdown.stream-id.test.ts
@@ -293,4 +293,59 @@ describe('streamId prop', () => {
             expect(container.querySelector('h1')?.textContent).toBe('Two')
         })
     })
+
+    // The reset is keyed on strict inequality, so a falsy-but-present streamId
+    // must still reset. A truthiness guard (`streamId && lastStreamId !== streamId`)
+    // would still pass the 0 -> 1 case, but fails the two undefined cases.
+    describe('falsy and undefined streamId values', () => {
+        test('resets when streamId transitions from 0 to another value', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 0 }
+            })
+
+            await act(() => component.writeChunk('# Zero'))
+            await flushStreamingBatch()
+            expect(container.querySelector('h1')?.textContent).toBe('Zero')
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 1 }))
+            await act(() => component.writeChunk('# One'))
+            await flushStreamingBatch()
+
+            expect(container.querySelectorAll('h1')).toHaveLength(1)
+            expect(container.querySelector('h1')?.textContent).toBe('One')
+        })
+
+        test('resets when streamId transitions from undefined to 0', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true }
+            })
+
+            await act(() => component.writeChunk('# Unset'))
+            await flushStreamingBatch()
+            expect(container.querySelector('h1')?.textContent).toBe('Unset')
+
+            await act(() => rerender({ source: '', streaming: true, streamId: 0 }))
+            await act(() => component.writeChunk('# Zero'))
+            await flushStreamingBatch()
+
+            expect(container.querySelectorAll('h1')).toHaveLength(1)
+            expect(container.querySelector('h1')?.textContent).toBe('Zero')
+        })
+
+        test('resets when streamId transitions from a value back to undefined', async () => {
+            const { component, container, rerender } = render(SvelteMarkdown, {
+                props: { source: '', streaming: true, streamId: 'msg-1' }
+            })
+
+            await act(() => component.writeChunk('# Named'))
+            await flushStreamingBatch()
+
+            await act(() => rerender({ source: '', streaming: true, streamId: undefined }))
+            await act(() => component.writeChunk('# Unnamed'))
+            await flushStreamingBatch()
+
+            expect(container.querySelectorAll('h1')).toHaveLength(1)
+            expect(container.querySelector('h1')?.textContent).toBe('Unnamed')
+        })
+    })
 })

--- a/src/lib/SvelteMarkdown.svelte
+++ b/src/lib/SvelteMarkdown.svelte
@@ -91,6 +91,7 @@
     const {
         source = [],
         streaming = false,
+        streamId = undefined,
         renderers = {},
         options = {},
         isInline = false,
@@ -119,6 +120,11 @@
     let lastOptionsSrc: typeof options | undefined
     let lastExtensionsSrc: typeof extensions | undefined
     let lastSourceProp: typeof source | undefined
+    // Left undefined rather than seeded from the prop: when `streamId` is unset
+    // this matches on every run and falls through to the source check, and when
+    // it is set the first-run reset does exactly what the source-sync path
+    // would have done anyway (teardown + fresh parser).
+    let lastStreamId: typeof streamId
     let streamSourceBuffer = ''
     let pendingStreamAppendBuffer = ''
     let pendingStreamFullSource: string | null = null
@@ -300,6 +306,22 @@
         applyStreamingSource(nextStr, !isAppendOnly)
     }
 
+    /**
+     * Drops every trace of the previous stream and rebaselines on the current
+     * `source` prop. Used when `streamId` changes, i.e. when a recycled
+     * component instance begins rendering a different message.
+     */
+    const resetStreamingSession = () => {
+        if (Array.isArray(source)) {
+            // Also sets lastSourceProp.
+            syncStreamingSourceFromProp(source)
+            return
+        }
+
+        lastSourceProp = source
+        resetStreamingState(source as string)
+    }
+
     const canUseImperativeStreaming = (methodName: 'writeChunk' | 'resetStream'): boolean => {
         if (!streaming) {
             warnStreaming(`${methodName}() is only available when streaming={true}; call dropped.`)
@@ -348,6 +370,15 @@
     export function writeChunk(chunk: StreamingChunk): void {
         if (!canUseImperativeStreaming('writeChunk')) return
 
+        // Reconcile a pending streamId change here rather than waiting for the
+        // $effect: writeChunk() is synchronous, so a caller that swaps streamId
+        // and writes in the same tick would otherwise append to the previous
+        // stream's buffer (and have that write wiped when the effect later ran).
+        if (lastStreamId !== streamId) {
+            lastStreamId = streamId
+            resetStreamingSession()
+        }
+
         if (pendingStreamFullSource !== null) {
             flushPendingStreamChanges()
         }
@@ -388,12 +419,22 @@
             teardownStreamingBuffers()
             if (incrementalParser) clearStreamingParser()
             lastSourceProp = source
+            lastStreamId = streamId
             if (streaming && hasAsyncExtension) {
                 warnStreaming(
                     'streaming prop is ignored when async extensions are used. ' +
                         'Remove async extensions or set streaming={false} to silence this warning.'
                 )
             }
+            return
+        }
+
+        // Must precede the source check: when a new stream also carries a new
+        // source, the reset rebaselines on it rather than treating the change
+        // as an append to the previous message's buffer.
+        if (lastStreamId !== streamId) {
+            lastStreamId = streamId
+            resetStreamingSession()
             return
         }
 

--- a/src/lib/test/streaming/StreamIdRaceHarness.svelte
+++ b/src/lib/test/streaming/StreamIdRaceHarness.svelte
@@ -1,0 +1,37 @@
+<!--
+@component
+
+Test harness that reproduces the same-tick `streamId` swap a real chat parent
+performs: assign the new stream identity, then immediately call `writeChunk()`
+for that stream's first chunk. Because Svelte 5 flushes effects in a microtask,
+`writeChunk()` runs *before* the component's streaming `$effect` observes the
+new `streamId` — so the reset must be reconciled inside `writeChunk()` itself.
+
+`@testing-library/svelte`'s `rerender()` calls `flushSync`, which hides this
+ordering; driving the prop from a real parent does not. The stream starts as
+`msg-1`; call `switchStreamAndWrite()` to move it.
+-->
+<script lang="ts">
+    import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
+    import type { StreamingChunk } from '$lib/types.js'
+
+    let streamId = $state('msg-1')
+    let markdown = $state<
+        | {
+              writeChunk: (chunk: StreamingChunk) => void // trunk-ignore(eslint/no-unused-vars)
+          }
+        | undefined
+    >()
+
+    export function write(chunk: StreamingChunk): void {
+        markdown?.writeChunk(chunk)
+    }
+
+    /** Swap the stream identity and write its first chunk without an intervening flush. */
+    export function switchStreamAndWrite(nextStreamId: string, chunk: StreamingChunk): void {
+        streamId = nextStreamId
+        markdown?.writeChunk(chunk)
+    }
+</script>
+
+<SvelteMarkdown bind:this={markdown} source="" streaming={true} {streamId} />

--- a/src/lib/test/streaming/StreamIdRaceHarness.svelte
+++ b/src/lib/test/streaming/StreamIdRaceHarness.svelte
@@ -23,12 +23,12 @@ ordering; driving the prop from a real parent does not. The stream starts as
         | undefined
     >()
 
-    export function write(chunk: StreamingChunk): void {
+    export const write = (chunk: StreamingChunk): void => {
         markdown?.writeChunk(chunk)
     }
 
     /** Swap the stream identity and write its first chunk without an intervening flush. */
-    export function switchStreamAndWrite(nextStreamId: string, chunk: StreamingChunk): void {
+    export const switchStreamAndWrite = (nextStreamId: string, chunk: StreamingChunk): void => {
         streamId = nextStreamId
         markdown?.writeChunk(chunk)
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -256,6 +256,30 @@ export type SvelteMarkdownProps<T extends Renderers = Renderers> = {
     streaming?: boolean
 
     /**
+     * Identity of the current stream. Changing this value resets all streaming
+     * state: the internal source buffer, any pending (unflushed) chunk, the
+     * incremental parser, and the input-mode lock set by the first
+     * {@link SvelteMarkdownProps.streaming | streaming} write.
+     *
+     * Use this when a single component instance is recycled across streams —
+     * a chat transcript rendered with a non-keyed `{#each}`, a virtual list, or
+     * a keyed each whose key identifies the slot rather than the message. In
+     * those cases the imperative buffer is instance state that outlives the
+     * message, so the next stream would otherwise start with the previous
+     * message still buffered.
+     *
+     * Only meaningful when `streaming` is `true`; ignored otherwise.
+     *
+     * @defaultValue `undefined`
+     *
+     * @example
+     * ```svelte
+     * <SvelteMarkdown bind:this={markdown} source="" streaming streamId={message.id} />
+     * ```
+     */
+    streamId?: string | number
+
+    /**
      * Callback invoked after the source has been parsed into tokens.
      *
      * Receives the full token array before rendering begins. Useful for


### PR DESCRIPTION
## Summary

Adds a `streamId` prop that resets streaming state when a `<SvelteMarkdown streaming>` instance is reused across messages.

The streaming buffer, incremental parser, and input-mode lock are **per-component-instance** state that outlives a single message. They only reset when the `source` prop changes *value* — which never happens in the canonical `source=""` + `writeChunk()` pattern. A recycled component (non-keyed `{#each}`, virtual list, or a keyed each whose key identifies a *slot* rather than a message) therefore starts each new stream on top of the previous message's buffer.

This was reported from the field as an intermittent "corrupted frame" during mid-stream rendering that appeared to self-heal. It reproduces deterministically once you know where to look.

### Symptoms by mode

| Mode | Symptom |
| --- | --- |
| append | Next message renders as `previous + new` |
| offset | Writes overwrite without truncating, so the previous message's **tail** survives past the end of the new one — and does **not** self-correct until the new message grows longer |
| either | The previous stream's mode lock is still in force, so the new stream's first chunk is dropped with a warning if it uses the other chunk type |

Changing `streamId` now drops the buffer, any pending unflushed chunk, the parser, and the mode lock, then rebaselines on the current `source`.

### A second, sharper bug found while testing

`writeChunk()` now reconciles a pending `streamId` change **synchronously** rather than deferring to the `$effect`. Otherwise a parent that swaps `streamId` and writes in the same tick would append to the *old* buffer and then have that write wiped when the effect ran — **silent loss of the new stream's first chunk**, not merely corruption.

This is invisible to the obvious test: `@testing-library/svelte`'s `rerender()` calls `flushSync`, so effects always run before `writeChunk` and the bug never appears. It's covered by a parent-driven harness that mutates state and writes in one synchronous block, verified by mutation-testing (removing the guard fails the test with **zero** rendered elements).

### Known limitation (not addressed here)

The per-instance `Slugger` also survives across streams, so a recycled component will suffix duplicate heading ids (`intro-1`, `intro-2`) across messages. Resetting it on `streamId` change looked right, but `render-metadata.ts` snapshots slugger occurrences and disturbing that belongs in its own change.

The pre-existing `source`-prop version of the same-tick race also still exists; it's documented as a hazard rather than changing `source` semantics, which would be a behavior change on a public API.

## Changes

✨ **New features**

- `streamId?: string | number` prop on `SvelteMarkdown`. Ignored when `streaming` is `false`; not forwarded to the DOM.

🐛 **Bug fixes**

- `writeChunk()` reconciles a pending `streamId` change synchronously, closing a same-tick race that silently dropped the new stream's first chunk.

🧪 **Testing**

- `SvelteMarkdown.stream-id.test.ts` — 13 tests covering append mode, offset mode (stale-tail), input-mode unlock in both directions, `source` prop interaction, token-array sources, non-streaming inertness, and DOM passthrough.
- `test/streaming/StreamIdRaceHarness.svelte` — parent-driven harness that reproduces the same-tick race that `rerender()`'s `flushSync` hides.

📚 **Documentation**

- README: new "Resetting between messages" section, `streamId` in the props table.
- Docs site (`docs/advanced/llm-streaming`): matching section with the broken vs. correct `{#each}` patterns and the three ways to start a clean stream.
- Corrects the README's claim that changing `source` resets the buffer — true only when the value actually *changes*.
- `CLAUDE.md`: records that `trunk fmt` / `trunk check` are the lint gate, not raw `prettier`/`eslint` (`pnpm lint` is `&&`-chained across the whole repo, so its Prettier failure on ~34 pre-existing files means ESLint never runs).

## Verification

- 914 unit tests pass (13 new)
- `pnpm check` — 0 errors (4 warnings, all pre-existing, none in touched files)
- `trunk fmt` + `trunk check` — clean across all modified files
- No public API breakage: `streamId` is optional and inert when unset

## Commits

- [`8d52a86`](https://github.com/humanspeak/svelte-markdown/commit/8d52a86e68271f87b5ad05e6c41648adfc04f970) feat(streaming): add streamId prop to reset state between streams
- [`8c7c291`](https://github.com/humanspeak/svelte-markdown/commit/8c7c29183dcf0a74fb8786f4a3d9f7f5c306aa93) docs: record trunk fmt/check as the lint gate
