### PR TITLE
chore(lint): lint test files and enable type-aware promise rules

### DIFF
--- a/.agents/.plans/streaming-component-hardening/008-remove-dead-html-code.md
+++ b/.agents/.plans/streaming-component-hardening/008-remove-dead-html-code.md
@@ -33,7 +33,7 @@ read as one coherent HTML pipeline.
 
 Grep results confirming the dead code (run these yourself to re-confirm):
 
-```
+```text
 grep -rn "parseHtmlBlock\|processHtmlTokens\|containsMultipleTags" src --include='*.ts' --include='*.svelte' -l
   → only: token-cleanup.ts (definitions) and *.test.ts files
 grep -rn "stream-benchmark" src -l

--- a/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.guard-report.md
+++ b/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.guard-report.md
@@ -1,0 +1,71 @@
+# Guard report — 009 lint-test-files-and-typed-lint
+
+**Recommendation: PASS** — every done criterion reproduced green by guard, and the type-aware promise rules are proven active in all three parser paths rather than merely configured.
+**Reviewed at** `0f77f55` · 2026-07-09 14:13 · **Plan planned at** `939f154`
+**Integrated** — PR opened via the `pr` skill for the reviewed snapshot commit (`0f77f55`). See "Integration" below.
+
+## Done criteria
+
+| Criterion                                                                     | Result | Evidence                                                                                                                                                                              |
+| ----------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'**/*.test.ts'` no longer in top-level `ignores`                             | met    | `eslint.config.mjs:27-31` — only `**/dist` remains alongside the lockfiles                                                                                                            |
+| `no-floating-promises` active and provably catches a floating promise         | met    | `trunk check` on three throwaway files → fires in `.ts` (2:5), `.test.ts` (4:9), `.svelte` (4:9). Files deleted, `git status` clean. Re-run against this snapshot, not checkpoint 1's |
+| `trunk fmt && trunk check` exit 0; `trunk check --all` exit 0                 | met    | `trunk check --all` → `Checked 575 files · ✔ No issues`                                                                                                                               |
+| Violations fixed or justified via Trunk inline ignore, never `eslint-disable` | met    | `git diff 1ba528d...HEAD -- src tests`: `eslint-disable` → 0 hits; `trunk-ignore` → exactly 1, at `parse-and-cache.ts:128`, with rationale                                            |
+| No rule switched `'off'` to force green                                       | met    | `await-thenable` restored to `['error']` (`eslint.config.mjs:95`); six remaining `'off'` rules audited with counts below                                                              |
+| Every `'off'` rule reported with rationale + violation count                  | met    | See "Rule-disable audit". Recorded here rather than in an executor report — see the note on that criterion                                                                            |
+| `pnpm check` exits 0; `pnpm test:only` exits 0                                | met    | `pnpm check` → 1004 files, 0 errors. `pnpm test:only` → 142 files, 917 tests, all pass                                                                                                |
+| Batch `README.md` status row for 009 updated                                  | met    | Row 009 → `DONE`                                                                                                                                                                      |
+
+Drift check (`git diff --stat 939f154..HEAD -- eslint.config.mjs`) was empty at execution start (checkpoint 1). It now reports 36 insertions — that is this plan's own change to that file, not external drift.
+
+## Spirit
+
+The plan exists because a promise-heavy streaming library had two lint blind spots: ~150 unlinted test files, and no type information reaching `no-floating-promises` / `no-misused-promises`. Both are genuinely closed, and I verified it the hard way rather than trusting a green `trunk check`: a floating promise now errors in a plain `.ts`, inside a `.test.ts` (proving the newly-linted files actually reach type info), and inside a `.svelte` file (the plan's named risk, and the path most likely to be silently inactive — a config can look right while the Svelte parser never wires up type services at all).
+
+The strongest evidence that this is real-bug-prevention and not cosmetics came from the correction cycle. Checkpoint 1 found `await-thenable` blanket-disabled; the plan's own maintenance note tells the reviewer to reject exactly that. Restoring it surfaced four genuine `await <non-Promise>` sites where Playwright `Locator`s were being awaited. Those are behaviourally inert but precisely the confusion the plan is meant to catch, and they would have shipped invisibly. The single false positive that motivated the disable (`parse-and-cache.ts:128`, where marked types `walkTokens` as `void`-returning and so hides the real promises async callbacks put in the result array) is now suppressed the way the plan prescribes — one inline `trunk-ignore` with a stated reason, not a global kill switch.
+
+The `void`-marked fire-and-forget promises each carry the one-line rationale the plan demanded (`MermaidRenderer.svelte:38,45,61`, `incremental-parser.ts:540`, `parse-and-cache.ts:78`, three test routes). `incremental-parser.ts:540` also quietly fixes a latent bug: `newTokens.forEach(this.options.walkTokens)` fed `(token, index, array)` into a one-argument callback; the `for…of` rewrite passes only `token`.
+
+## Scope & conduct
+
+- **In-scope only?** Two crossings, both cosmetic and non-blocking. `.coderabbit.yaml:71` (`labels: ['coderabbit']` → `[coderabbit]`) is an incidental `trunk fmt` requote of a file the plan never listed; reverting it would only make `trunk fmt` redo it. The executor also edited a plan file — `008-remove-dead-html-code.md:36`, a markdownlint fence fix. Plans are guard's to write, so this is flagged in both checkpoints; it altered no contract text.
+- **STOP conditions respected?** Yes. No source drift at start. Typed linting resolved `.svelte` files without parser rework beyond `extraFileExtensions` + `svelteConfig`, so the second STOP never triggered, and lint time is fine (`trunk check --all`, 575 files, ~39s). The third STOP — a real floating-promise bug in `src/lib/**` — did not fire: the four `await`-on-`Locator` finds are in `tests/`, not `src/lib`, and are inert.
+- **Plan amendments during execution:** one, 2026-07-09, operator-directed. Plan 009 was the last plan hardcoding raw ESLint (`pnpm exec eslint .` ×4); CLAUDE.md makes Trunk the source of truth. Replaced with `trunk check` / `trunk check --all`. Step 3 was **strengthened** to require proving the rule in all three parser paths, and the done criteria were **strengthened** with `trunk check --all` plus a rationale-and-count requirement for any `'off'` rule. `Planned at` deliberately left at `939f154`, matching the batch README's 2026-07-07 precedent: a tooling-command correction changes no source baseline, so the drift check must keep pointing at the audited commit.
+
+## Rule-disable audit
+
+Six `recommendedTypeChecked` rules remain `'off'`. Measured, not assumed — scoped to `src/lib/utils` + `SvelteMarkdown.svelte`:
+
+| Rule                            | Violations (subset) | Assessment                                           |
+| ------------------------------- | ------------------- | ---------------------------------------------------- |
+| `no-unsafe-member-access`       | 29                  | Migration exemption — marked's `Token` union         |
+| `no-unnecessary-type-assertion` | 17                  | Stylistic; not correctness                           |
+| `no-unsafe-argument`            | 6                   | Migration exemption                                  |
+| `no-unsafe-assignment`          | 4                   | Migration exemption                                  |
+| `no-unsafe-return`              | 3                   | Migration exemption                                  |
+| `require-await`                 | 2                   | Stylistic; an `async` fn without `await` is harmless |
+| `no-unsafe-call`                | 2                   | Migration exemption                                  |
+
+None is promise-correctness. The `no-unsafe-*` family (44 in this subset alone) is the ordinary cost of adopting typed lint against `marked`'s types and `HtmlRenderers`' `[key: string]: Component<any, any, any>` index signature (`src/lib/renderers/html/index.ts:107`); clearing it is separate work. The one rule where a disable genuinely hid promise risk — `await-thenable` — is back on.
+
+**A note on that criterion, stated plainly because it is a judgment call the operator may overrule.** "Every `'off'` rule reported with rationale + count" is a criterion _guard added at checkpoint 1_, after the executor had already done the work. Holding an executor to a goalpost moved in behind it would be unfair, and dropping it silently to wave the work through would be the laundering this role exists to prevent. So guard did the measurement itself and recorded it above: the criterion's substance — that no disabled rule hides a real problem — is verified, not waived. What is genuinely missing is an inline rationale comment in `eslint.config.mjs`; that is a follow-up, not a merge blocker.
+
+## Corrections to guard's own earlier claims
+
+Both are in the log; repeated here because a report that hides its own misfires isn't evidence.
+
+- Checkpoint 1 suspected `rendererKeys.ts:41` had widened the public `htmlRendererKeys` export from `HtmlKey[]` to `string[]`. It had not. `HtmlRenderers` carries an index signature, so `HtmlKey` already collapses to `string`; the assertion was genuinely unnecessary and its removal is a no-op on the exported type.
+- Guard briefly measured `await-thenable` at "0 violations." That number came from a run it had killed, not a clean result. The true count is 1, at `parse-and-cache.ts:128`.
+
+## Residual risk / follow-ups
+
+- **Typed lint is slow outside Trunk.** A full-repo `pnpm exec eslint .` did not finish in 12 minutes under this config; `trunk check --all` does the same work in ~39s because of Trunk's caching and change-scoping. This is now written into the plan and the batch README. Anyone reaching for raw ESLint will be badly surprised.
+- **`eslint.config.mjs` carries no inline rationale** for the six `'off'` rules. Worth a small follow-up plan to either fix the ~63 violations or comment the exemptions at the call site, so the reasoning survives without this report.
+- **New source dirs silently lose typed coverage** if they fall outside the tsconfig that `projectService` resolves — the plan's own maintenance note, still true.
+- **E2E is red locally, and it predates this branch.** `tests/issues/issue-192.test.ts` and `tests/reactivity.test.ts` fail with `Test timeout … waiting for getByRole(...)`. Guard restored the pre-edit version of `issue-192.test.ts` from `0418585` (identical to `1ba528d`'s, still carrying `await page.getByRole(...)`) and it **failed identically** — so the executor's `await` removals are not the cause, and could not be: `await` on a non-thenable `Locator` is a no-op. E2E sits outside this plan's Done criteria; CI is the authority. A merger should still know these specs do not pass on a local run today.
+- `{files: ['*.ts'], ...disableTypeChecked}` (`eslint.config.mjs:107-110`) exempts only repo-root configs (`playwright.config.ts`, `vite.config.ts`, `vitest.setup.ts`) — correct as written. If anyone "fixes" that glob to `**/*.ts`, it would silently disable every type-aware rule in the repo. Leave it alone.
+
+## Integration
+
+The reviewed snapshot is `0f77f55`. Two commits carry the executor's work (`0418585`, `0f77f55`); guard's log and the plan amendment are separate commits. PR opened via the `pr` skill against `main`. **Merging is the operator's call — guard never merges.**

--- a/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.guard-report.md
+++ b/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.guard-report.md
@@ -2,7 +2,7 @@
 
 **Recommendation: PASS** — every done criterion reproduced green by guard, and the type-aware promise rules are proven active in all three parser paths rather than merely configured.
 **Reviewed at** `0f77f55` · 2026-07-09 14:13 · **Plan planned at** `939f154`
-**Integrated** — PR opened via the `pr` skill for the reviewed snapshot commit (`0f77f55`). See "Integration" below.
+**Integrated** — PR <https://github.com/humanspeak/svelte-markdown/pull/352> opened via the `pr` skill for the reviewed snapshot commit (`0f77f55`).
 
 ## Done criteria
 
@@ -68,4 +68,4 @@ Both are in the log; repeated here because a report that hides its own misfires 
 
 ## Integration
 
-The reviewed snapshot is `0f77f55`. Two commits carry the executor's work (`0418585`, `0f77f55`); guard's log and the plan amendment are separate commits. PR opened via the `pr` skill against `main`. **Merging is the operator's call — guard never merges.**
+The reviewed snapshot is `0f77f55`. Two commits carry the executor's work (`0418585`, `0f77f55`); guard's log and the plan amendment are separate commits (`1dff968`, `2590f3d`). PR <https://github.com/humanspeak/svelte-markdown/pull/352> opened via the `pr` skill against `main`, assigned to `jaysin586`, labelled `javascript,enhancement`. **Merging is the operator's call — guard never merges.**

--- a/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.guard.md
+++ b/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.guard.md
@@ -48,3 +48,52 @@ Reported to operator. Plan amended per operator agreement (revision notes added 
 Not a PASS as it stands. The plan's own maintenance note asks the reviewer to reject blanket-disabled rules, and seven are disabled with no rationale recorded. **To flip to PASS**, the executor should either restore `@typescript-eslint/await-thenable` to `error` and suppress the single `parse-and-cache.ts:128` report with an inline `// trunk-ignore(eslint/@typescript-eslint/await-thenable)` carrying the marked-types rationale, or record a written justification for each of the seven `'off'` rules with its violation count (new done criterion). The `no-unsafe-*` family is a defensible migration-time exemption; `await-thenable` and `require-await` are cheap and on-theme, and should carry an explicit argument if they stay off.
 
 No PR opened — this is a mid-run checkpoint, not `guard final`.
+
+## Checkpoint 2 — 2026-07-09 14:13 — ON TRACK
+
+`0f77f55` · final close-out; executor's corrective work snapshotted, every done criterion re-run, full three-dot diff read
+
+### Corrective work landed
+
+Checkpoint 1's blocking finding is resolved, and the fix paid for itself:
+
+- `eslint.config.mjs:95` — `await-thenable` restored to `['error']`.
+- `parse-and-cache.ts:128` — the single false positive suppressed with an inline `// trunk-ignore(eslint/@typescript-eslint/await-thenable)` carrying the marked-types rationale, exactly as the plan's Done criteria require. It is the **only** suppression added anywhere in the diff (`git diff 1ba528d...HEAD -- src tests | grep '^+.*trunk-ignore'` → 1 hit; `eslint-disable` → none).
+- Re-enabling the rule caught **four real `await <non-Promise>` sites** the executor then fixed: `tests/issues/issue-192.test.ts:12,17` and `tests/reactivity.test.ts:135,139` awaited a Playwright `Locator`, which is not thenable. Behaviourally inert, but exactly the class of confusion the plan exists to prevent. This vindicates checkpoint 1's call that `await-thenable` was not a free disable.
+
+### Done criteria, re-run against `0f77f55`
+
+- Step 3 re-proved against the _final_ config (it changed since checkpoint 1), this time through the amended plan's own command: `trunk check` on three throwaway files → `no-floating-promises` fires in `.ts` (2:5), `.test.ts` (4:9) and `.svelte` (4:9). Files deleted; `git status` clean.
+- `trunk check --all` → 575 files, `✔ No issues`.
+- `pnpm check` → 1004 files, 0 errors. `pnpm test:only` → 142 files, 917 tests, all pass.
+- `'**/*.test.ts'` absent from top-level `ignores`; batch README row 009 = DONE.
+
+### Rule-disable audit (the criterion added at checkpoint 1)
+
+Six `recommendedTypeChecked` rules remain `'off'`. Guard measured them rather than accepting them, scoped to `src/lib/utils` + `SvelteMarkdown.svelte`:
+
+| Rule                            | Violations (subset) | Assessment                                             |
+| ------------------------------- | ------------------- | ------------------------------------------------------ |
+| `no-unsafe-member-access`       | 29                  | Migration exemption — driven by marked's `Token` union |
+| `no-unnecessary-type-assertion` | 17                  | Stylistic; not correctness                             |
+| `no-unsafe-argument`            | 6                   | Migration exemption                                    |
+| `no-unsafe-assignment`          | 4                   | Migration exemption                                    |
+| `no-unsafe-return`              | 3                   | Migration exemption                                    |
+| `require-await`                 | 2                   | Stylistic; an `async` fn without `await` is harmless   |
+| `no-unsafe-call`                | 2                   | Migration exemption                                    |
+
+None is promise-correctness. The `no-unsafe-*` family (44 in this subset alone) is the standard, well-understood cost of adopting typed lint against `marked`'s types and `HtmlRenderers`' `[key: string]: Component<any,any,any>` index signature; fixing them is a separate body of work, not this plan's. The one rule where a disable genuinely hid promise risk — `await-thenable` — is now on.
+
+### Findings carried forward (non-blocking)
+
+- `eslint.config.mjs` carries no inline rationale comment for the six remaining `'off'` rules. The rationale and counts now live in the close-out report instead. Recommend a follow-up plan to either fix or comment them.
+- `.coderabbit.yaml:71` (`labels: ['coderabbit']` → `[coderabbit]`) — out-of-scope, cosmetic, incidental to `trunk fmt`. Reverting would only make `trunk fmt` redo it.
+- Executor edited `008-remove-dead-html-code.md:36` (fence → ` ```text `), a markdownlint fix. Plans are guard's to write. Cosmetic, no contract text changed. Flagged both checkpoints; not escalated.
+
+### Pre-existing condition (not caused by this plan)
+
+`pnpm exec playwright test tests/issues/issue-192.test.ts tests/reactivity.test.ts --project=chromium` → 9 failed locally, all `Test timeout … waiting for getByRole('link', { name: 'image' })`. Guard checked out the **pre-edit** version of `issue-192.test.ts` from `0418585` (the version still carrying `await page.getByRole(...)`, identical to `1ba528d`'s) and re-ran it: **fails identically**. The failure therefore predates this branch and is not attributable to the executor's `await` removals — `await` on a non-thenable `Locator` cannot change behavior. Tree restored, clean. E2E is outside this plan's Done criteria; CI is the authority.
+
+### Action (close-out)
+
+Close-out report written. PASS → PR opened via the `pr` skill. Merging remains the operator's call.

--- a/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.guard.md
+++ b/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.guard.md
@@ -1,0 +1,50 @@
+# Guard log — 009 lint-test-files-and-typed-lint
+
+## Checkpoint 1 — 2026-07-09 13:53 — DRIFTING · PLAN AMENDED
+
+`0418585` · first checkpoint; executor's full working tree snapshotted and reviewed against the whole plan
+
+### Drift check
+
+- `git diff --stat 939f154..HEAD -- eslint.config.mjs` → empty. No source drift since planning. "Current state" excerpt still matches live code.
+
+### Done criteria, re-run by guard (not taken on report)
+
+- `'**/*.test.ts'` removed from top-level `ignores` — confirmed at `eslint.config.mjs:27-31`.
+- `no-floating-promises` provably active. Guard ran plan Step 3 itself with three throwaway files, then deleted them (`git status` clean afterward):
+    - `src/lib/__guard_scratch.ts:2:5` → `error @typescript-eslint/no-floating-promises`
+    - `src/lib/__guard_scratch.test.ts:4:9` → `error` (proves the newly-linted test files reach type info)
+    - `src/lib/__GuardScratch.svelte:4:9` → `error` (proves the `.svelte` parser path reaches type info — the plan's stated risk)
+- `trunk fmt && trunk check` → exit 0. `trunk check --all` → 574 files, 0 ESLint issues, ~39s.
+- `pnpm check` → 0 errors (1004 files). `pnpm test:only` → 142 files, 917 tests, all pass.
+- No `eslint-disable` introduced: `git diff 1ba528d..HEAD | grep '^+.*eslint-disable'` → none.
+- Batch `README.md` row for 009 flipped TODO → DONE.
+
+### Findings
+
+- **Blanket rule disabling (drift).** `eslint.config.mjs:94-102` sets seven `recommendedTypeChecked` rules to `'off'`: `await-thenable`, `no-unnecessary-type-assertion`, `no-unsafe-{argument,assignment,call,member-access,return}`, `require-await`. The plan's Done criteria require violations be "fixed or justified via Trunk inline ignore"; the maintenance note explicitly tells the reviewer to check "that no rule was blanket-disabled to force green". Turning the rule off is a third path the plan did not sanction. `await-thenable` is the one that bites: it is promise-correctness, it is squarely within `Why this matters` ("promise-heavy streaming library"), and it has exactly **one** report repo-wide — `src/lib/utils/parse-and-cache.ts:128`, `await Promise.all(results)`. That report is very likely a false positive (marked types `walkTokens` as returning `void`, so `Marked.walkTokens`'s result array is typed non-thenable even though async callbacks put real promises in it at runtime — lines 122-124's comment describes the intended behavior, and it holds). The correct remedy per this plan is one `// trunk-ignore(eslint/@typescript-eslint/await-thenable)` with that rationale, not a global `'off'` that also silences every future `await <non-promise>` in this library.
+- **Out-of-scope edit.** `.coderabbit.yaml:71` (`labels: ['coderabbit']` → `[coderabbit]`) is a cosmetic yaml requote, incidental to `trunk fmt`. Not in the plan's In-scope list. Harmless, but it is a boundary crossing.
+- **Executor edited a plan file.** `008-remove-dead-html-code.md:36` (` ``` ` → ` ```text `) — a markdownlint MD040 fix. Cosmetic, changes no contract text, but plans are guard's to write. Flagged, not escalated.
+
+### Cleared (suspected, then disproved by evidence)
+
+- `rendererKeys.ts:41` `Object.keys(Html) as HtmlKey[]` → `Object.keys(Html)` first read as a public-API type regression (`htmlRendererKeysInternal` is re-exported as `htmlRendererKeys` at `index.ts:106`). It is **not**: `HtmlRenderers` carries an index signature `[key: string]` (`src/lib/renderers/html/index.ts:107`), so `HtmlKey = keyof typeof Html & string` collapses to `string`. The assertion was genuinely unnecessary and its removal is a no-op on the exported type. The retained `as RendererKey[]` on `rendererKeysInternal` is correct and the asymmetry is principled, not arbitrary. Same reasoning clears the `as any` removals in `unsupportedHtmlRenderers.test.ts:59,66`. `tsc --noEmit -p tsconfig.json` is clean, and `src/**/*.ts` (test files included) is inside the checked project.
+- `eslint.config.mjs:107-110` `{files: ['*.ts'], ...disableTypeChecked}` reads like a glob that would disable typed rules everywhere. It does not — flat-config `*.ts` matches only repo-root files (`playwright.config.ts`, `vite.config.ts`, `vitest.setup.ts`), which is a deliberate and correct exemption. Proven by the Step 3 scratch file at `src/lib/__guard_scratch.ts` still erroring.
+- `void`-marked promises each carry a one-line rationale as the plan required (`MermaidRenderer.svelte:38,45,61`, `incremental-parser.ts:540`, `parse-and-cache.ts:78`, plus the three test routes). `incremental-parser.ts:540` also silently fixes a latent bug: `newTokens.forEach(this.options.walkTokens)` passed `(token, index, array)` into a one-arg callback; the `for…of` rewrite passes only `token`.
+
+### Plan amendment (operator-directed)
+
+Operator instruction: "We dont use eslint... we use trunk fmt and trunk check", then "Please update all the plans for this".
+
+- Plan 009 was the sole remaining plan hardcoding raw ESLint; the batch README's 2026-07-07 revision had converted `pnpm lint` → Trunk everywhere but missed four `pnpm exec eslint .` call sites (commands table, Step 1 verify ×2, Step 3). All four replaced with `trunk check` / `trunk check --all`. Plans 010-012 held no raw ESLint references.
+- Step 3 strengthened to require proving the rule fires in all three parser paths (`.ts`, `.test.ts`, `.svelte`), since each can be silently inactive independently — this is what guard actually had to do to trust the criterion.
+- Done criteria strengthened, not weakened: added `trunk check --all` (this plan enables repo-wide rules, so a changed-files-only gate under-verifies) and added a criterion requiring every `'off'` rule to be reported with a rationale and violation count. This closes the hole the first finding came through.
+- `Planned at` deliberately **not** re-stamped, matching the README's 2026-07-07 precedent: a tooling-command correction changes no source baseline, so the drift check must keep pointing at the audited commit `939f154`.
+
+### Action
+
+Reported to operator. Plan amended per operator agreement (revision notes added to `009-...md` and batch `README.md`).
+
+Not a PASS as it stands. The plan's own maintenance note asks the reviewer to reject blanket-disabled rules, and seven are disabled with no rationale recorded. **To flip to PASS**, the executor should either restore `@typescript-eslint/await-thenable` to `error` and suppress the single `parse-and-cache.ts:128` report with an inline `// trunk-ignore(eslint/@typescript-eslint/await-thenable)` carrying the marked-types rationale, or record a written justification for each of the seven `'off'` rules with its violation count (new done criterion). The `no-unsafe-*` family is a defensible migration-time exemption; `await-thenable` and `require-await` are cheap and on-theme, and should carry an explicit argument if they stay off.
+
+No PR opened — this is a mid-run checkpoint, not `guard final`.

--- a/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.md
+++ b/.agents/.plans/streaming-component-hardening/009-lint-test-files-and-typed-lint.md
@@ -6,6 +6,14 @@
 >
 > **Drift check (run first)**: `git diff --stat 939f154..HEAD -- eslint.config.mjs`
 > On any change, compare "Current state" facts to live code; mismatch ⇒ STOP.
+>
+> **Revision 2026-07-09 (guard):** Replaced this plan's four `pnpm exec eslint .`
+> invocations with Trunk equivalents. CLAUDE.md makes Trunk the source of truth
+> and forbids running raw ESLint/Prettier. Use `trunk check` for changed files
+> and `trunk check --all` for a full-repo pass. The `Planned at` SHA stays
+> `939f154` — a tooling-command correction only, matching the batch README's
+> 2026-07-07 revision, so the drift check keeps pointing at the originally
+> audited commit.
 
 ## Status
 
@@ -59,12 +67,18 @@ CI runs on Node 22/24.
 
 ## Commands you will need
 
-| Purpose     | Command                    | Expected on success |
-| ----------- | -------------------------- | ------------------- |
-| Lint        | `trunk fmt && trunk check` | exit 0              |
-| ESLint only | `pnpm exec eslint .`       | exit 0              |
-| Typecheck   | `pnpm check`               | exit 0              |
-| All unit    | `pnpm test:only`           | all pass            |
+| Purpose       | Command                    | Expected on success |
+| ------------- | -------------------------- | ------------------- |
+| Lint          | `trunk fmt && trunk check` | exit 0              |
+| Lint one file | `trunk check <path>`       | exit 0              |
+| Lint all      | `trunk check --all`        | exit 0              |
+| Typecheck     | `pnpm check`               | exit 0              |
+| All unit      | `pnpm test:only`           | all pass            |
+
+Never run `pnpm lint`, `pnpm format`, `npx prettier`, or `npx eslint` (CLAUDE.md).
+Plain `trunk check` only inspects files changed relative to the upstream branch —
+that covers a new/untracked scratch file from Step 3. Because this plan turns on
+repo-wide rules, also run `trunk check --all` once before declaring done.
 
 ## Scope
 
@@ -99,9 +113,10 @@ block scoped to `**/*.test.ts` that relaxes rules that don't fit tests (e.g.
 allow non-null assertions or `any` where the existing tests rely on them) — but
 keep correctness rules on. Run ESLint and triage what surfaces.
 
-**Verify**: `pnpm exec eslint .` runs over test files (no longer skipped). Fix
-surfaced violations minimally, or relax clearly test-inappropriate rules in the
-override. Target: `pnpm exec eslint .` → exit 0.
+**Verify**: `trunk check` now reports on test files (no longer skipped) — confirm
+by running it against a changed `*.test.ts`. Fix surfaced violations minimally, or
+relax clearly test-inappropriate rules in the override. Target:
+`trunk fmt && trunk check` → exit 0.
 
 ### Step 2: Enable type-aware linting for the promise rules
 
@@ -131,13 +146,15 @@ risk budget.
 
 Temporarily introduce an obvious floating promise in a scratch spot (e.g. a
 `Promise.resolve()` statement with no `await`/`void` in a `.ts` file under
-`src/lib`), run `pnpm exec eslint .`, and confirm it reports
-`no-floating-promises`. Then revert the scratch change. This proves the rule is
-actually wired to type info, not silently inactive. Document the result in your
-report (do not commit the scratch change).
+`src/lib`), run `trunk check <scratch-path>`, and confirm it reports
+`no-floating-promises`. Do this in **three** scratch files — a plain `.ts`, a
+`.test.ts`, and a `.svelte` — since each reaches type info by a different parser
+path and any one of them can be silently inactive. Then delete the scratch files.
+This proves the rule is actually wired to type info. Document the result in your
+report (do not commit the scratch files).
 
-**Verify**: ESLint flags the scratch floating promise; after revert,
-`trunk fmt && trunk check` → exit 0.
+**Verify**: Trunk flags the floating promise in all three scratch files; after
+deleting them, `trunk fmt && trunk check` → exit 0 and `git status` is clean.
 
 ### Step 4: Full suite
 
@@ -157,8 +174,12 @@ ALL must hold:
       `eslint.config.mjs`.
 - [ ] `no-floating-promises` is active and provably catches a floating promise
       (Step 3), then reverted.
-- [ ] `trunk fmt && trunk check` exits 0 (all surfaced violations fixed or justified via Trunk
-      inline ignore — never `eslint-disable`).
+- [ ] `trunk fmt && trunk check` exits 0, and `trunk check --all` exits 0 (all
+      surfaced violations fixed or justified via Trunk inline ignore — never
+      `eslint-disable`, and never by switching a rule `'off'` in
+      `eslint.config.mjs` to force green).
+- [ ] Any rule from `recommendedTypeChecked` set to `'off'` in the config is
+      listed in your report with a one-line rationale and its violation count.
 - [ ] `pnpm check` exits 0; `pnpm test:only` exits 0.
 - [ ] No `eslint-disable` comments introduced (`grep -rn "eslint-disable" src`
       shows none added by this change).

--- a/.agents/.plans/streaming-component-hardening/README.md
+++ b/.agents/.plans/streaming-component-hardening/README.md
@@ -30,7 +30,7 @@ remains).
 | 006  | Heading-id dedup snapshots slugger occurrences (#337)                                        | P3       | M      | MED  | —                  | DONE   |
 | 007  | Streaming hot-path micro-opts: single-pass reuse array + dedupe `startsWith` (#332 residual) | P3       | S      | LOW  | —                  | DONE   |
 | 008  | Remove dead legacy HTML-pairing code + bench module                                          | P2       | S      | LOW  | —                  | DONE   |
-| 009  | Lint test files + enable type-aware promise rules                                            | P2       | M      | MED  | 008 (soft)         | TODO   |
+| 009  | Lint test files + enable type-aware promise rules                                            | P2       | M      | MED  | 008 (soft)         | DONE   |
 | 010  | Coverage thresholds + `engines` + rAF-fallback test                                          | P3       | S      | LOW  | —                  | TODO   |
 | 011  | Unify streaming token-reuse identity + generic child walk (#331, #333)                       | P2       | L      | HIGH | 003,005,007 (soft) | TODO   |
 | 012  | Simplify source-less root-key matching (#339) — investigate-then-shrink                      | P3       | M      | MED  | 004 (soft)         | TODO   |

--- a/.agents/.plans/streaming-component-hardening/README.md
+++ b/.agents/.plans/streaming-component-hardening/README.md
@@ -18,6 +18,12 @@ remains).
 > tooling-command correction only and does not change any plan's source baseline,
 > so the drift checks must keep pointing at the original audited commit.
 
+> **Revision 2026-07-09 (guard):** Plan 009 retained four `pnpm exec eslint .`
+> invocations that the 2026-07-07 revision missed; these are now Trunk commands.
+> Raw ESLint is forbidden by CLAUDE.md. Use `trunk check` for changed files and
+> `trunk check --all` for a full-repo pass (574 files in ~39s under 009's
+> type-aware config). `Planned at` SHAs remain unchanged for the reason above.
+
 ## Execution order & status
 
 | Plan | Title                                                                                        | Priority | Effort | Risk | Depends on         | Status |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -68,7 +68,7 @@ reviews:
         enabled: false
         auto_incremental_review: false
         ignore_title_keywords: []
-        labels: ['coderabbit']
+        labels: [coderabbit]
         drafts: false
         base_branches: []
     finishing_touches:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import globals from 'globals'
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import ts from 'typescript-eslint'
+import svelteConfig from './svelte.config.js'
 const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url))
 const tsconfigRootDir = dirname(fileURLToPath(import.meta.url))
 
@@ -26,12 +27,11 @@ export default [
             '**/pnpm-lock.yaml',
             '**/package-lock.json',
             '**/yarn.lock',
-            '**/dist',
-            '**/*.test.ts'
+            '**/dist'
         ]
     },
     js.configs.recommended,
-    ...ts.configs.recommended,
+    ...ts.configs.recommendedTypeChecked,
     ...svelte.configs['flat/recommended'],
     prettier,
     ...svelte.configs['flat/prettier'],
@@ -42,6 +42,7 @@ export default [
                 ...globals.node
             },
             parserOptions: {
+                projectService: true,
                 tsconfigRootDir
             }
         },
@@ -89,19 +90,49 @@ export default [
                     argsIgnorePattern: '^_',
                     ignoreRestSiblings: true
                 }
-            ]
+            ],
+
+            '@typescript-eslint/await-thenable': 'off',
+            '@typescript-eslint/no-floating-promises': ['error'],
+            '@typescript-eslint/no-misused-promises': ['error'],
+            '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+            '@typescript-eslint/no-unsafe-argument': 'off',
+            '@typescript-eslint/no-unsafe-assignment': 'off',
+            '@typescript-eslint/no-unsafe-call': 'off',
+            '@typescript-eslint/no-unsafe-member-access': 'off',
+            '@typescript-eslint/no-unsafe-return': 'off',
+            '@typescript-eslint/require-await': 'off'
         }
+    },
+    {
+        files: ['**/*.{js,mjs,cjs}'],
+        ...ts.configs.disableTypeChecked
+    },
+    {
+        files: ['*.ts'],
+        ...ts.configs.disableTypeChecked
     },
     {
         files: ['**/*.svelte', '**/*.svelte.ts'],
         languageOptions: {
             parserOptions: {
-                parser: ts.parser
+                extraFileExtensions: ['.svelte'],
+                parser: ts.parser,
+                svelteConfig
             }
         },
         rules: {
             'prefer-const': ['off'],
             'svelte/no-navigation-without-resolve': ['off'] // Allow external links
+        }
+    },
+    {
+        files: ['**/*.test.ts'],
+        rules: {
+            camelcase: 'off',
+            'no-unused-vars': 'off',
+            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-unused-vars': 'off'
         }
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,7 +92,7 @@ export default [
                 }
             ],
 
-            '@typescript-eslint/await-thenable': 'off',
+            '@typescript-eslint/await-thenable': ['error'],
             '@typescript-eslint/no-floating-promises': ['error'],
             '@typescript-eslint/no-misused-promises': ['error'],
             '@typescript-eslint/no-unnecessary-type-assertion': 'off',

--- a/src/lib/SvelteMarkdown.issue-328.test.ts
+++ b/src/lib/SvelteMarkdown.issue-328.test.ts
@@ -104,52 +104,47 @@ const buildLargeHeadingSource = (sections: number) => {
 const buildDuplicateHeadingSource = (count: number) =>
     Array.from({ length: count }, () => '## Intro\n\n').join('')
 
-const textToken = (text: string): Token =>
-    ({
-        type: 'text',
-        raw: text,
-        text
-    }) as Token
+const textToken = (text: string): Token => ({
+    type: 'text',
+    raw: text,
+    text
+})
 
-const paragraphToken = (text: string, raw = text): Token =>
-    ({
-        type: 'paragraph',
-        raw,
-        text,
-        tokens: [textToken(text)]
-    }) as Token
+const paragraphToken = (text: string, raw = text): Token => ({
+    type: 'paragraph',
+    raw,
+    text,
+    tokens: [textToken(text)]
+})
 
-const listItemToken = (text: string): Token =>
-    ({
-        type: 'list_item',
-        raw: `- ${text}`,
-        text,
-        tokens: [textToken(text)]
-    }) as Token
+const listItemToken = (text: string): Token => ({
+    type: 'list_item',
+    raw: `- ${text}`,
+    text,
+    tokens: [textToken(text)]
+})
 
-const listToken = (items: Token[]): Token =>
-    ({
-        type: 'list',
-        raw: items.map((item) => item.raw).join('\n'),
-        ordered: false,
-        start: 1,
-        loose: false,
-        items
-    }) as unknown as Token
+const listToken = (items: Token[]): Token => ({
+    type: 'list',
+    raw: items.map((item) => item.raw).join('\n'),
+    ordered: false,
+    start: 1,
+    loose: false,
+    items
+})
 
 const tableCell = (text: string) => ({
     text,
     tokens: [textToken(text)]
 })
 
-const tableToken = (rows: Array<Array<ReturnType<typeof tableCell>>>): Token =>
-    ({
-        type: 'table',
-        raw: '',
-        align: [null, null],
-        header: [tableCell('Label'), tableCell('Value')],
-        rows
-    }) as unknown as Token
+const tableToken = (rows: Array<Array<ReturnType<typeof tableCell>>>): Token => ({
+    type: 'table',
+    raw: '',
+    align: [null, null],
+    header: [tableCell('Label'), tableCell('Value')],
+    rows
+})
 
 const findBodyRow = (container: HTMLElement, text: string) =>
     Array.from(container.querySelectorAll('tbody tr')).find((row) => row.textContent === text)

--- a/src/lib/SvelteMarkdown.svelte
+++ b/src/lib/SvelteMarkdown.svelte
@@ -269,11 +269,11 @@
         if (Array.isArray(nextSource)) {
             teardownStreamingBuffers()
             clearStreamingParser()
-            streamTokens = [...(nextSource as Token[])]
+            streamTokens = [...nextSource]
             return
         }
 
-        const nextStr = nextSource as string
+        const nextStr = nextSource
         // Reuse the existing IncrementalParser when the new source extends
         // the buffered source. Without this, prop-driven streaming (the
         // common LLM-token-by-token case) drops the parser's prevTokens
@@ -319,7 +319,7 @@
         }
 
         lastSourceProp = source
-        resetStreamingState(source as string)
+        resetStreamingState(source)
     }
 
     const canUseImperativeStreaming = (methodName: 'writeChunk' | 'resetStream'): boolean => {

--- a/src/lib/extensions/mermaid/MermaidRenderer.svelte
+++ b/src/lib/extensions/mermaid/MermaidRenderer.svelte
@@ -35,13 +35,15 @@
 
     $effect(() => {
         if (mermaidModule) {
-            renderDiagram(text)
+            // renderDiagram catches its own errors; effects cannot await.
+            void renderDiagram(text)
         }
     })
 
     onMount(() => {
         let observer: MutationObserver
-        ;(async () => {
+        // Initialization owns its loading/error state; onMount cannot await it.
+        void (async () => {
             try {
                 const mod = (await import('mermaid')).default
                 mod.initialize({ startOnLoad: false, securityLevel: 'strict' })
@@ -56,7 +58,8 @@
         observer = new MutationObserver((mutations) => {
             for (const mutation of mutations) {
                 if (mutation.attributeName === 'class') {
-                    renderDiagram(text)
+                    // renderDiagram catches its own errors; observers cannot await.
+                    void renderDiagram(text)
                     return
                 }
             }

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -45,7 +45,7 @@ describe('index.ts exports', () => {
 
         // Create dummy tokens list to verify type exports
         const dummyTokensList: TokensList = Object.assign([dummyToken], {
-            links: {} as TokensList['links']
+            links: {}
         })
         expect(dummyTokensList).toBeDefined()
         expect(Array.isArray(dummyTokensList)).toBe(true)

--- a/src/lib/utils/incremental-parser.nested-html.test.ts
+++ b/src/lib/utils/incremental-parser.nested-html.test.ts
@@ -46,7 +46,7 @@ const summarize = (tokens: ReadonlyArray<Token>): TreeNode[] =>
             type: t.type,
             ...(tag ? { tag } : {}),
             children: kids ? summarize(kids) : []
-        } as TreeNode
+        }
     })
 
 const singleShot = (source: string): Token[] => new IncrementalParser(opts()).update(source).tokens

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -218,7 +218,8 @@ describe('IncrementalParser', () => {
 
             expect(lexSpy).toHaveBeenCalledTimes(2)
             expect(lexSpy.mock.calls[1]?.[0]).toBe('First paragraph\n\nSecond paragraph')
-            expect((lexSpy.mock.calls[1]?.[0] as string).length).toBeLessThan(
+            const reparsedTail = lexSpy.mock.calls[1]?.[0] ?? ''
+            expect(reparsedTail.length).toBeLessThan(
                 '# Title\n\nFirst paragraph\n\nSecond paragraph'.length
             )
         })
@@ -270,7 +271,8 @@ describe('IncrementalParser', () => {
             const result = parser.update(appended)
 
             expect(lexSpy.mock.calls[2]?.[0]).toBe(appended.slice(boundary.reparseOffset))
-            expect((lexSpy.mock.calls[2]?.[0] as string).length).toBeLessThan(appended.length)
+            const reparsedTail = lexSpy.mock.calls[2]?.[0] ?? ''
+            expect(reparsedTail.length).toBeLessThan(appended.length)
             expect(result.divergeAt).toBeGreaterThan(0)
             expect(result.canReuse).toBe(true)
         })

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -537,7 +537,10 @@ export class IncrementalParser {
 
         // Apply walkTokens if configured
         if (typeof this.options.walkTokens === 'function') {
-            newTokens.forEach(this.options.walkTokens)
+            for (const token of newTokens) {
+                // Incremental parsing is sync; async callbacks use the async parse path.
+                void this.options.walkTokens(token)
+            }
         }
 
         // Reference definitions can change inline children without changing raw,

--- a/src/lib/utils/parse-and-cache.ts
+++ b/src/lib/utils/parse-and-cache.ts
@@ -37,7 +37,7 @@ export const lexAndClean = (
 ): Token[] => {
     const lexer = new Lexer(options)
     const parsedTokens = isInline ? lexer.inlineTokens(source) : lexer.lex(source)
-    return shrinkHtmlTokens(parsedTokens) as Token[]
+    return shrinkHtmlTokens(parsedTokens)
 }
 
 /**
@@ -75,7 +75,10 @@ export const parseAndCacheTokens = (
     const cleanedTokens = lexAndClean(source, options, isInline)
 
     if (typeof options.walkTokens === 'function') {
-        cleanedTokens.forEach(options.walkTokens)
+        for (const token of cleanedTokens) {
+            // Sync parsing cannot await walkTokens; async callbacks use parseAndCacheTokensAsync.
+            void options.walkTokens(token)
+        }
     }
 
     // Cache the cleaned tokens for next time

--- a/src/lib/utils/parse-and-cache.ts
+++ b/src/lib/utils/parse-and-cache.ts
@@ -125,6 +125,7 @@ export const parseAndCacheTokensAsync = async (
         const marked = new Marked()
         marked.defaults = { ...marked.defaults, ...options }
         const results = marked.walkTokens(cleanedTokens, options.walkTokens)
+        // trunk-ignore(eslint/@typescript-eslint/await-thenable): Marked types hide async walkTokens returns.
         await Promise.all(results)
     }
 

--- a/src/lib/utils/rendererKeys.ts
+++ b/src/lib/utils/rendererKeys.ts
@@ -38,4 +38,4 @@ export type HtmlKey = keyof typeof Html & string
  *
  * Re-exported publicly as `htmlRendererKeys`.
  */
-export const htmlRendererKeysInternal = Object.keys(Html) as HtmlKey[]
+export const htmlRendererKeysInternal = Object.keys(Html)

--- a/src/lib/utils/unsupportedHtmlRenderers.test.ts
+++ b/src/lib/utils/unsupportedHtmlRenderers.test.ts
@@ -56,14 +56,14 @@ describe('unsupported HTML negative tests', () => {
     })
 
     it('allowHtmlOnly with all invalid tags maps every key to UnsupportedHTML', () => {
-        const map = allowHtmlOnly(['fake-tag-1', 'fake-tag-2'] as any)
+        const map = allowHtmlOnly(['fake-tag-1', 'fake-tag-2'])
         for (const key of htmlRendererKeysInternal) {
             expect(map[key], `${key} should be UnsupportedHTML`).toBe(UnsupportedHTML)
         }
     })
 
     it('excludeHtmlOnly with invalid tags silently ignores them', () => {
-        const map = excludeHtmlOnly(['not-a-tag'] as any)
+        const map = excludeHtmlOnly(['not-a-tag'])
         for (const key of htmlRendererKeysInternal) {
             expect(map[key], `${key} should be default`).toBe(Html[key])
         }

--- a/src/routes/test/imperative-streaming/+page.svelte
+++ b/src/routes/test/imperative-streaming/+page.svelte
@@ -342,7 +342,13 @@ Offset chunks let the component reconcile display state while callers stay dumb.
         await recordRender(appendMetrics, startedAt, appendPreviewEl)
 
         if (appendIsStreaming && runId === appendSessionId) {
-            appendTimeoutId = setTimeout(() => streamNextAppend(runId), Math.max(0, getDelay()))
+            appendTimeoutId = setTimeout(
+                () => {
+                    // Timer loop owns the session; streamNextAppend records its own render metrics.
+                    void streamNextAppend(runId)
+                },
+                Math.max(0, getDelay())
+            )
         }
     }
 
@@ -364,7 +370,13 @@ Offset chunks let the component reconcile display state while callers stay dumb.
         await recordRender(offsetMetrics, startedAt, offsetPreviewEl)
 
         if (offsetIsStreaming && runId === offsetSessionId) {
-            offsetTimeoutId = setTimeout(() => streamNextOffset(runId), Math.max(0, getDelay()))
+            offsetTimeoutId = setTimeout(
+                () => {
+                    // Timer loop owns the session; streamNextOffset records its own render metrics.
+                    void streamNextOffset(runId)
+                },
+                Math.max(0, getDelay())
+            )
         }
     }
 
@@ -382,7 +394,8 @@ Offset chunks let the component reconcile display state while callers stay dumb.
         appendIsStreaming = true
         appendLastFrameTime = 0
         appendFrameId = requestAnimationFrame(trackAppendFrames)
-        streamNextAppend(appendSessionId)
+        // Fire-and-forget start of the timer-owned streaming loop.
+        void streamNextAppend(appendSessionId)
     }
 
     const startOffsetSimulation = () => {
@@ -399,7 +412,8 @@ Offset chunks let the component reconcile display state while callers stay dumb.
         offsetIsStreaming = true
         offsetLastFrameTime = 0
         offsetFrameId = requestAnimationFrame(trackOffsetFrames)
-        streamNextOffset(offsetSessionId)
+        // Fire-and-forget start of the timer-owned streaming loop.
+        void streamNextOffset(offsetSessionId)
     }
 
     const resetAppendWithSeed = () => {

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -47,7 +47,7 @@
     }
 
     const svmWindow = (): SVMWindow | undefined =>
-        typeof window === 'undefined' ? undefined : (window as SVMWindow)
+        typeof window === 'undefined' ? undefined : window
 
     // ---- Corpus generators ----------------------------------------------------
 
@@ -708,8 +708,12 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
                     return
                 }
                 renderDurations.push(performance.now() - t0)
-                streamHandle = setTimeout(step, baseDelay)
+                streamHandle = setTimeout(() => {
+                    // Timer loop resolves the surrounding Promise when streaming ends.
+                    void step()
+                }, baseDelay)
             }
+            // Fire-and-forget start of the timer-owned streaming loop.
             void step()
         })
         const wallMs = performance.now() - startWall
@@ -828,8 +832,12 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
                 // leave the final iteration's gap as 0.
                 const gap = chunkDelays[idx - 1] ?? 0
                 gapDurations.push(gap)
-                streamHandle = setTimeout(step, gap)
+                streamHandle = setTimeout(() => {
+                    // Timer loop resolves the surrounding Promise when streaming ends.
+                    void step()
+                }, gap)
             }
+            // Fire-and-forget start of the timer-owned streaming loop.
             void step()
         })
         const wallMs = performance.now() - startWall

--- a/src/routes/test/streaming/+page.svelte
+++ b/src/routes/test/streaming/+page.svelte
@@ -203,7 +203,13 @@ For more information, visit the [Svelte documentation](https://svelte.dev/docs) 
         }
 
         if (isStreaming && runId === sessionId) {
-            timeoutId = setTimeout(() => streamNext(runId), Math.max(0, getDelay()))
+            timeoutId = setTimeout(
+                () => {
+                    // Timer loop owns the session; streamNext records its own render metrics.
+                    void streamNext(runId)
+                },
+                Math.max(0, getDelay())
+            )
         }
     }
 
@@ -221,7 +227,8 @@ For more information, visit the [Svelte documentation](https://svelte.dev/docs) 
         isStreaming = true
         lastFrameTime = 0
         rafId = requestAnimationFrame(trackFrames)
-        streamNext(sessionId)
+        // Fire-and-forget start of the timer-owned streaming loop.
+        void streamNext(sessionId)
     }
 
     const stop = () => {

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -23,7 +23,7 @@ test.describe('Edge Cases', () => {
 ## مرحبا بالعالم
 ### Привет, мир!
 #### ¡Hòla, món!
-##### Zero-width space: [​]
+##### Zero-width space: [\u200b]
 ###### Emojis: 🌈 🚀 🎨
 `
         await textarea.fill(specialContent)

--- a/tests/issues/issue-192.test.ts
+++ b/tests/issues/issue-192.test.ts
@@ -9,12 +9,12 @@ test.describe('Issue 192: Image inside link rendering', () => {
         page
     }) => {
         // Find the link that wraps the image (by accessible name)
-        const link = await page.getByRole('link', { name: 'image' })
+        const link = page.getByRole('link', { name: 'image' })
         const linkHref = await link.getAttribute('href')
         expect(linkHref).toBe('https://stackblitz.com/edit')
 
         // Find the image inside the link
-        const img = await link.locator('img[alt="image"]')
+        const img = link.locator('img[alt="image"]')
         expect(await img.count()).toBe(1)
         expect(await img.getAttribute('src')).toBe(
             'https://avatars.githubusercontent.com/u/162604590?s=64&u=548f358e716a223731ab372776a09723cf815f4d&v=4'

--- a/tests/reactivity.test.ts
+++ b/tests/reactivity.test.ts
@@ -132,11 +132,11 @@ test.describe('SvelteMarkdown', () => {
         await page.waitForSelector('h1')
 
         // Verify the text content is rendered correctly
-        const paragraph = await page.locator('p').first()
+        const paragraph = page.locator('p').first()
         await expect(paragraph).toHaveText('Some text!!!')
 
         // Verify the HTML tag is rendered correctly
-        const heading = await page.locator('h1')
+        const heading = page.locator('h1')
         await expect(heading).toHaveText('Something')
 
         // Verify the order of elements


### PR DESCRIPTION
## Summary

Closes two lint blind spots in a promise-heavy streaming library: ~150 test files were excluded from ESLint entirely, and the config used `ts.configs.recommended` with no `parserOptions.project`, so no type information reached `@typescript-eslint/no-floating-promises` or `no-misused-promises` — the exact rules that catch a dropped `await` in the async parse path, rAF scheduling, and imperative `writeChunk` callers.

This is bug-prevention, not cosmetics. Turning `await-thenable` back on surfaced four real `await <non-Promise>` sites where Playwright `Locator`s were being awaited. The rules are verified active in all three parser paths (`.ts`, `.test.ts`, `.svelte`) rather than merely configured — a config can look correct while the Svelte parser never wires up type services at all.

Implements plan 009 of the `streaming-component-hardening` batch. Guard verdict: **PASS** — see `009-lint-test-files-and-typed-lint.guard-report.md`.

## Changes

🔧 **Lint configuration**

- Remove `'**/*.test.ts'` from the top-level `ignores` so test files are linted
- Switch `ts.configs.recommended` → `recommendedTypeChecked`, add `parserOptions.projectService: true`
- Wire the Svelte parser for typed lint (`extraFileExtensions`, `svelteConfig`)
- Enable `no-floating-promises`, `no-misused-promises`, and `await-thenable` as errors
- Add a `**/*.test.ts` override relaxing `any`/unused-vars while keeping correctness rules on
- Exempt repo-root config files (`vite.config.ts` et al.) from type-aware rules

🐛 **Violations fixed**

- `void`-mark genuinely fire-and-forget promises, each with a one-line rationale (Mermaid effects/observer, timer-driven streaming loops in the test routes)
- `incremental-parser.ts`: replace `newTokens.forEach(this.options.walkTokens)` with a `for…of` — `forEach` was feeding `(token, index, array)` into a one-argument callback
- Drop no-op `await`s on Playwright `Locator`s in `tests/issues/issue-192.test.ts` and `tests/reactivity.test.ts`
- Remove now-unnecessary type assertions surfaced by type-aware linting

🔒 **Suppression discipline**

- Exactly one suppression added, an inline `trunk-ignore` at `parse-and-cache.ts:128` where `marked` types `walkTokens` as `void`-returning and so hides the real promises async callbacks put in the result array. No `eslint-disable` comments anywhere.

📚 **Plans**

- Plan 009 amended to use `trunk check` / `trunk check --all` instead of raw ESLint (CLAUDE.md makes Trunk the source of truth); done criteria strengthened
- Guard log and close-out report for plan 009

## Verification

- `trunk check --all` → 575 files, no issues
- `pnpm check` → 1004 files, 0 errors
- `pnpm test:only` → 142 files, 917 tests, all pass

Note: `tests/issues/issue-192.test.ts` and `tests/reactivity.test.ts` fail on a local Playwright run. This predates the branch — re-running the pre-edit version of the spec fails identically. `await` on a non-thenable `Locator` cannot change behavior.

## Commits

- [`0418585`](https://github.com/humanspeak/svelte-markdown/commit/04185858a98dde3da1464a0997e56c4b7e1e81fd) chore(lint): lint test files; enable type-aware promise rules
- [`1dff968`](https://github.com/humanspeak/svelte-markdown/commit/1dff968c2dd1d5ca3f8a084aeaa9a128897206b5) docs(guard): checkpoint 1 for plan 009; amend plan to Trunk-only lint
- [`0f77f55`](https://github.com/humanspeak/svelte-markdown/commit/0f77f55e3c5634fa77b40293e90dcb82a5304100) fix(lint): restore await-thenable; drop no-op awaits on Playwright locators
- [`2590f3d`](https://github.com/humanspeak/svelte-markdown/commit/2590f3de85c014b6f3e34c4bb28dd91fb7ec857f) docs(guard): final checkpoint and close-out report for plan 009 — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
