### PR TITLE
fix(docs): ship FAQ schema and align playground header

### DIFF
--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -510,10 +510,21 @@ Happy coding! <span style="color: hotpink">♥</span>`
                 <p>Edit markdown on the left, see it rendered on the right.</p>
             </div>
             <div class="panel">
-                <div class="head">
-                    <span class="tab on">editor.md</span>
-                    <span class="grow"></span>
-                    <button class="ctrl" type="button" onclick={resetPlayground}>⟲ reset</button>
+                <div class="bar">
+                    <span>
+                        <span class="lbl">file</span> ·
+                        <span class="v">markdown-playground.svelte</span>
+                    </span>
+                    <span>
+                        <span class="lbl">chars</span>
+                        <span class="v">{editorText.length}</span>
+                    </span>
+                    <span>
+                        <span class="lbl">render</span>
+                        <span class="v">400ms debounce</span>
+                    </span>
+                    <span class="live">● LIVE</span>
+                    <button class="ctrl" type="button" onclick={resetPlayground}>↻ reset</button>
                 </div>
                 <div class="body">
                     <div class="col">
@@ -1072,7 +1083,8 @@ Happy coding! <span style="color: hotpink">♥</span>`
         border: 1px solid var(--brut-rule);
         background: var(--brut-bg);
     }
-    .brut-stream .panel .bar {
+    .brut-stream .panel .bar,
+    .brut-play .panel .bar {
         display: flex;
         align-items: center;
         gap: 18px;
@@ -1083,17 +1095,21 @@ Happy coding! <span style="color: hotpink">♥</span>`
         background: var(--brut-bg-2);
         flex-wrap: wrap;
     }
-    .brut-stream .panel .bar .lbl {
+    .brut-stream .panel .bar .lbl,
+    .brut-play .panel .bar .lbl {
         color: var(--brut-ink-3);
     }
-    .brut-stream .panel .bar .v {
+    .brut-stream .panel .bar .v,
+    .brut-play .panel .bar .v {
         color: var(--brut-ink);
     }
-    .brut-stream .panel .bar .live {
+    .brut-stream .panel .bar .live,
+    .brut-play .panel .bar .live {
         margin-left: auto;
         color: var(--brut-accent);
     }
-    .brut-stream .panel .ctrl {
+    .brut-stream .panel .ctrl,
+    .brut-play .panel .ctrl {
         background: transparent;
         border: 1px solid var(--brut-rule);
         padding: 4px 10px;
@@ -1102,7 +1118,8 @@ Happy coding! <span style="color: hotpink">♥</span>`
         color: var(--brut-ink-2);
         cursor: pointer;
     }
-    .brut-stream .panel .ctrl:hover {
+    .brut-stream .panel .ctrl:hover,
+    .brut-play .panel .ctrl:hover {
         background: var(--brut-bg);
         color: var(--brut-ink);
     }
@@ -1342,37 +1359,6 @@ Happy coding! <span style="color: hotpink">♥</span>`
         gap: 24px;
         border-bottom: 1px solid var(--brut-rule);
         scroll-margin-top: 80px;
-    }
-    .brut-play .panel .head {
-        display: flex;
-        padding: 8px 14px;
-        border-bottom: 1px solid var(--brut-rule);
-        font-size: 11px;
-        color: var(--brut-ink-3);
-        background: var(--brut-bg-2);
-        align-items: center;
-        gap: 12px;
-    }
-    .brut-play .panel .head .tab {
-        padding: 0 12px;
-        border-right: 1px solid var(--brut-rule);
-        margin-right: -1px;
-    }
-    .brut-play .panel .head .tab.on {
-        color: var(--brut-ink);
-        background: var(--brut-bg);
-    }
-    .brut-play .panel .head .grow {
-        flex: 1;
-    }
-    .brut-play .panel .head .ctrl {
-        background: transparent;
-        border: 0;
-        padding: 0 8px;
-        font-family: inherit;
-        font-size: 11px;
-        color: var(--brut-accent);
-        cursor: pointer;
     }
     .brut-play .panel .body {
         display: grid;

--- a/docs/src/routes/docs/+layout.svelte
+++ b/docs/src/routes/docs/+layout.svelte
@@ -48,6 +48,7 @@
     siteUrl={SITE_URL}
     breadcrumbResolver={buildBreadcrumbs}
     {faqs}
+    faqRoute="/docs/getting-started"
     sitemapManifest={sitemapManifest as Record<string, string>}
 >
     {@render children()}


### PR DESCRIPTION
## Summary

Ensure the documentation site's FAQ schema is emitted on a live, indexable page instead of the redirecting `/docs` route. Also align the homepage playground header with the established streaming-demo chrome.

## Changes

- 🐛 Pin `faqRoute` to `/docs/getting-started`, where the existing FAQPage JSON-LD now ships in served HTML.
- 🎨 Replace the playground's tab-style header with the shared file, metrics, live-status, and reset bar used by the streaming demo.
- 🧪 Verify formatting, linting, Svelte diagnostics, the production docs build, and rendered FAQPage output with all four configured questions.

## Commits

- [`a8bec19`](https://github.com/humanspeak/svelte-markdown/commit/a8bec191046745c940ee07239d3b815fe5a5158e) style(docs): align playground and streaming headers
- [`5bcab5d`](https://github.com/humanspeak/svelte-markdown/commit/5bcab5dddbbff6134ded59671279ff2d1fffb804) fix(docs): emit FAQ schema on getting-started page
