### PR TITLE
fix(html): stop attribute values truncating at embedded quotes

### DIFF
--- a/src/lib/utils/extract-attributes.test.ts
+++ b/src/lib/utils/extract-attributes.test.ts
@@ -114,4 +114,31 @@ describe('extractAttributes', () => {
             class: 'foo bar'
         })
     })
+
+    it('preserves an apostrophe inside a double-quoted value', () => {
+        expect(extractAttributes(`<img alt="it's a cat" src="/c.png">`)).toEqual({
+            alt: "it's a cat",
+            src: '/c.png'
+        })
+    })
+
+    it('preserves a double quote inside a single-quoted value', () => {
+        expect(extractAttributes(`<div title='say "hi"' id="x">`)).toEqual({
+            title: 'say "hi"',
+            id: 'x'
+        })
+    })
+
+    it('does not truncate URLs containing an apostrophe', () => {
+        expect(extractAttributes(`<a href="https://x.com/?a='b&c=d" title="hi">`)).toEqual({
+            href: "https://x.com/?a='b&c=d",
+            title: 'hi'
+        })
+    })
+
+    it('closes an unclosed value containing an other-type quote at end of string', () => {
+        expect(extractAttributes(`<div title="it's unfinished`)).toEqual({
+            title: "it's unfinished"
+        })
+    })
 })

--- a/src/lib/utils/token-cleanup.ts
+++ b/src/lib/utils/token-cleanup.ts
@@ -96,18 +96,24 @@ const formatSelfClosingHtmlToken = (token: Token): Token => {
 export const extractAttributes = (raw: string): Record<string, string> => {
     const attributes: Record<string, string> = {}
 
-    // First pass: handle regular and unclosed quoted attributes
-    const quotedRegex = /([a-zA-Z][\w-]*?)=["']([^"']*?)(?:["']|$)/g
+    // First pass: handle regular and unclosed quoted attributes. The value
+    // class matches only the same quote that opened it, so an apostrophe inside
+    // a double-quoted value (or a double quote inside a single-quoted value)
+    // does not terminate the match early. The `(?:"|$)` / `(?:'|$)` closers
+    // keep support for streaming-truncated tags like `<div class="foo`.
+    const quotedRegex = /([a-zA-Z][\w-]*)=(?:"([^"]*)(?:"|$)|'([^']*)(?:'|$))/g
     let match
     while ((match = quotedRegex.exec(raw)) !== null) {
-        const [, key, value] = match
+        const key = match[1]
+        const value = match[2] ?? match[3] ?? ''
         attributes[key] = value.trim()
     }
 
     // Strip quoted attribute blocks before the boolean pass so word-like
     // tokens inside a value (e.g. `bar` in `title="foo bar baz"`) aren't
-    // mistakenly harvested as boolean attributes.
-    const stripped = raw.replace(/[a-zA-Z][\w-]*?=["'][^"']*?(?:["']|$)/g, ' ')
+    // mistakenly harvested as boolean attributes. Mirrors the quote-type-aware
+    // matching above so embedded other-type quotes stay inside the value.
+    const stripped = raw.replace(/[a-zA-Z][\w-]*=(?:"[^"]*(?:"|$)|'[^']*(?:'|$))/g, ' ')
 
     // Second pass: handle boolean attributes
     const booleanRegex = /(?:^|\s)([a-zA-Z][\w-]*?)(?=[\s>]|$)/g


### PR DESCRIPTION
## Summary

Fixes `extractAttributes` truncating any HTML attribute value that contains the other quote type. The quoted-value regex used a character class excluding **both** quote characters, so `alt="it's a cat"` parsed as `{ alt: "it", s: "", a: "" }` and `href="https://x.com/?a='b&c=d"` was cut at the apostrophe. Both regexes are now quote-type-aware (the value class matches only the quote that opened it), preserving the end-of-string closers that support streaming-truncated tags.

Executed by an Opus 4.8 agent from plan `002-extract-attributes-quote-desync` (bigger-faster-stronger batch) under guard supervision: red tests were observed failing before the fix, and all gates were independently re-run by the guard.

## Changes

- 🐛 `src/lib/utils/token-cleanup.ts` — quote-type-aware `quotedRegex` and strip regex in `extractAttributes`; boolean pass unchanged
- 🧪 `src/lib/utils/extract-attributes.test.ts` — 4 new regression tests (apostrophe in double-quoted value, double quote in single-quoted value, URL with apostrophe, unclosed value with embedded other-type quote); all 15 pre-existing tests pass unmodified

## Verification

- Red-first: all 4 new tests failed against the previous code with the exact truncation the plan predicted
- `pnpm test` → 923/923 across 142 files, coverage gates hold; `pnpm check` → 0 errors; `trunk check` → no issues

## Commits

- [`e7164e5`](https://github.com/humanspeak/svelte-markdown/commit/e7164e5) fix(html): stop attribute values truncating at embedded quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
