### PR TITLE
fix(cache): verify source on token-cache hit to guard hash collisions

### DIFF
--- a/src/lib/utils/token-cache.test.ts
+++ b/src/lib/utils/token-cache.test.ts
@@ -456,4 +456,50 @@ describe('TokenCache', () => {
             expect(cache.getTokens(source, options2)).toEqual(tokens2)
         })
     })
+
+    describe('Hash collision safety', () => {
+        /*
+         * Verified 32-bit FNV-1a collision pair: both strings are distinct but
+         * hashString() maps them to the same value ('17dpyl2'). Found via a
+         * birthday-bound search over random short ASCII strings (collision hit
+         * after ~65k strings, <0.1s). The self-check test below fails loudly if
+         * the hash implementation ever changes and the pair stops colliding —
+         * regenerate the pair if that happens.
+         */
+        const COLLISION_A = 'dq6qA'
+        const COLLISION_B = 'dmIwH'
+
+        it('uses a genuine FNV-1a collision pair (self-check)', () => {
+            expect(COLLISION_A).not.toBe(COLLISION_B)
+            expect(hashString(COLLISION_A)).toBe(hashString(COLLISION_B))
+        })
+
+        it('does not serve tokens for a different source with a colliding hash', () => {
+            const options: SvelteMarkdownOptions = {}
+            const tokensA: Token[] = [{ type: 'heading', raw: COLLISION_A, depth: 1, text: 'A' }]
+
+            cache.setTokens(COLLISION_A, options, tokensA)
+
+            // COLLISION_B hashes to the same key but is a different source: the
+            // cache must treat it as a miss, never return A's tokens.
+            expect(cache.getTokens(COLLISION_B, options)).toBeUndefined()
+        })
+
+        it('always returns tokens matching the requested source across the shared key', () => {
+            const options: SvelteMarkdownOptions = {}
+            const tokensA: Token[] = [{ type: 'heading', raw: COLLISION_A, depth: 1, text: 'A' }]
+            const tokensB: Token[] = [{ type: 'heading', raw: COLLISION_B, depth: 1, text: 'B' }]
+
+            cache.setTokens(COLLISION_A, options, tokensA)
+            // Colliding source B is a guarded miss, not a wrong hit.
+            expect(cache.getTokens(COLLISION_B, options)).toBeUndefined()
+
+            // Storing B overwrites the shared key (last writer wins per-key).
+            cache.setTokens(COLLISION_B, options, tokensB)
+            expect(cache.getTokens(COLLISION_B, options)).toEqual(tokensB)
+            // A now misses rather than returning B's tokens — the invariant is
+            // that a returned entry always matches the requested source.
+            expect(cache.getTokens(COLLISION_A, options)).toBeUndefined()
+        })
+    })
 })

--- a/src/lib/utils/token-cache.ts
+++ b/src/lib/utils/token-cache.ts
@@ -19,6 +19,20 @@ import { MemoryCache } from '$lib/utils/cache.js'
 import type { Token, TokensList } from '$lib/utils/markdown-parser.js'
 
 /**
+ * Internal cache entry shape.
+ *
+ * The parsed tokens are stored alongside the exact source string that produced
+ * them. Because cache keys are derived from a 32-bit FNV-1a hash (not
+ * collision-resistant), a hit is only trusted when the stored `source` matches
+ * the requested source — otherwise a hash collision could serve one document's
+ * tokens for a different document. See {@link TokenCache.getTokens}.
+ */
+type TokenCacheEntry = {
+    source: string
+    tokens: Token[] | TokensList
+}
+
+/**
  * Fast non-cryptographic hash function using FNV-1a algorithm.
  * Optimized for speed over cryptographic security.
  *
@@ -112,13 +126,24 @@ const getCacheKey = (source: string, options: SvelteMarkdownOptions): string => 
  * - TTL-based expiration for time-sensitive content
  * - Advanced deletion (deleteByPrefix, deleteByMagicString)
  *
+ * Collision safety:
+ * - Each entry stores the exact source string alongside its tokens. On a hit
+ *   the stored source is compared to the requested source, so a 32-bit
+ *   FNV-1a hash collision is treated as a miss rather than serving a
+ *   different document's tokens (relevant under a shared SSR singleton).
+ *
  * Performance characteristics:
- * - Cache hit: <1ms (vs 50-200ms parsing)
- * - Memory: ~5MB for 50 cached documents (default maxSize)
+ * - Cache hit: <1ms (vs 50-200ms parsing) plus one string comparison
+ * - Memory: ~5MB of tokens for 50 cached documents (default maxSize); the
+ *   retained source strings roughly double this for text-heavy documents
  * - Hash computation: ~0.05ms for 10KB, ~0.5ms for 100KB
  *
+ * Note: the inherited raw `get()`/`set()` operate on the wrapped
+ * {@link TokenCacheEntry} shape (`{ source, tokens }`), not on the bare token
+ * array — use `getTokens`/`setTokens` for token access.
+ *
  * @class TokenCache
- * @extends MemoryCache<Token[] | TokensList>
+ * @extends MemoryCache<TokenCacheEntry>
  *
  * @example
  * ```typescript
@@ -139,7 +164,7 @@ const getCacheKey = (source: string, options: SvelteMarkdownOptions): string => 
  * cache.setTokens(markdown, options, tokens)
  * ```
  */
-export class TokenCache extends MemoryCache<Token[] | TokensList> {
+export class TokenCache extends MemoryCache<TokenCacheEntry> {
     /**
      * Creates a new TokenCache instance.
      *
@@ -169,7 +194,15 @@ export class TokenCache extends MemoryCache<Token[] | TokensList> {
      */
     getTokens(source: string, options: SvelteMarkdownOptions): Token[] | TokensList | undefined {
         const key = getCacheKey(source, options)
-        return this.get(key)
+        const entry = this.get(key)
+        // Guard against 32-bit hash collisions: only trust a hit when the
+        // stored source matches the requested source. On mismatch, treat it as
+        // a miss — the parse path will re-parse and overwrite the colliding
+        // entry (acceptable LRU behavior).
+        if (entry === undefined || entry.source !== source) {
+            return undefined
+        }
+        return entry.tokens
     }
 
     /**
@@ -188,7 +221,9 @@ export class TokenCache extends MemoryCache<Token[] | TokensList> {
      */
     setTokens(source: string, options: SvelteMarkdownOptions, tokens: Token[] | TokensList): void {
         const key = getCacheKey(source, options)
-        this.set(key, tokens)
+        // Store the source alongside the tokens so getTokens can verify a hit
+        // against hash collisions.
+        this.set(key, { source, tokens })
     }
 
     /**

--- a/src/lib/utils/token-cache.ts
+++ b/src/lib/utils/token-cache.ts
@@ -29,6 +29,7 @@ import type { Token, TokensList } from '$lib/utils/markdown-parser.js'
  */
 type TokenCacheEntry = {
     source: string
+    // trunk-ignore(eslint/@typescript-eslint/no-redundant-type-constituents): TokensList resolves as an error type in CI's lint program; union matches the pre-existing getTokens/setTokens signatures
     tokens: Token[] | TokensList
 }
 


### PR DESCRIPTION
## Summary

Hardens the shared `tokenCache` singleton against hash collisions. Entries were stored and served purely by a 32-bit FNV-1a key with no verification of the source on a hit, so a collision — accidental, or engineered against attacker-influenced markdown — could return a **different document's parsed tokens**, including cross-request under a shared SvelteKit SSR process. Each entry now stores the exact source string alongside its tokens, and `getTokens` trusts a hit only when the stored source matches the request; a mismatch is a miss that the parse path overwrites. Public `getTokens`/`setTokens` signatures are unchanged, so no call sites move.

Executed by an Opus 4.8 agent from plan `001-token-cache-collision-guard` (bigger-faster-stronger batch) under guard supervision: the red test used a brute-forced, verified FNV-1a collision pair (`dq6qA` / `dmIwH` → `17dpyl2`) and was observed failing before the fix; the guard independently re-verified the collision pair and re-ran all gates.

## Changes

- 🔒 `src/lib/utils/token-cache.ts` — entries wrap to `{ source, tokens }`; `getTokens` compares stored source on hit; JSDoc updated (memory note, raw `get()`/`set()` shape)
- 🧪 `src/lib/utils/token-cache.test.ts` — `Hash collision safety` suite: self-checking collision pair, wrong-source guarded miss, and per-key last-writer-wins semantics

## Verification

- Red-first: the collision test failed against the previous code (returned document A's tokens for source B)
- `pnpm test` → 142 files pass with coverage gates; `pnpm check` → 0 errors; `trunk check` → no issues

## Commits

- [`0d78006`](https://github.com/humanspeak/svelte-markdown/commit/0d78006) fix(cache): verify source on token-cache hit to guard hash collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
