### PR TITLE
perf(streaming): keep extension streams incremental via tail-safe markers

### DIFF
--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -78,6 +78,14 @@ function parseStats(s) {
         streamGapAvgMs: num(grab('streamGapAvgMs')),
         streamGapP95Ms: num(grab('streamGapP95Ms')),
         streamGapPeakMs: num(grab('streamGapPeakMs')),
+        // stream-extensions-only: per-chunk parse cost over the first vs last
+        // third of the stream and their ratio. extGrowthRatio ≈ 1 ⇒ the
+        // incremental tail-window is engaged; a climbing ratio is the O(N²)
+        // re-lex signature. extTailWindow is the derived human label.
+        extParseFirstMs: num(grab('extParseFirstMs')),
+        extParseLastMs: num(grab('extParseLastMs')),
+        extGrowthRatio: num(grab('extGrowthRatio')),
+        extTailWindow: grab('extTailWindow'),
         longestTaskMs: grab('longestTaskMs'),
         longTasks10s: grab('longTasks10s'),
         rafP95Ms: num(grab('rafP95Ms')),
@@ -142,6 +150,14 @@ async function runStreamingLarge(page) {
     return runDocScenario(page, 'stream-large', { timeout: 120_000 })
 }
 
+async function runStreamingExtensions(page) {
+    // Same ~30tps word-chunk cadence as `stream-30tps`, but the corpus mixes
+    // katex math + GitHub alerts and the parser runs with those extensions
+    // registered. Historically that disabled the incremental tail-window and
+    // re-lexed the whole accumulated source per chunk — watch `extGrowthRatio`.
+    return runDocScenario(page, 'stream-extensions', { timeout: 120_000 })
+}
+
 async function runAll(label, page) {
     console.log(`\n=== ${label} run ===`)
     const out = {}
@@ -182,6 +198,10 @@ async function runAll(label, page) {
     console.log('  → stream-large…')
     out.streamLarge = await runStreamingLarge(page)
     console.log('   ', JSON.stringify(out.streamLarge))
+
+    console.log('  → stream-extensions…')
+    out.streamExtensions = await runStreamingExtensions(page)
+    console.log('   ', JSON.stringify(out.streamExtensions))
 
     return out
 }

--- a/src/lib/extensions/alert/markedAlert.ts
+++ b/src/lib/extensions/alert/markedAlert.ts
@@ -1,4 +1,4 @@
-import { markTailWindowSafe } from '$lib/types.js'
+import { tailWindowSafeExtension } from '$lib/utils/tail-window.js'
 import type { MarkedExtension } from 'marked'
 
 /**
@@ -73,12 +73,6 @@ export function markedAlert(): MarkedExtension {
     }
     // The alert tokenizer is block-anchored (`> [!NOTE]`) and inspects only
     // `src` from the current position, so it is safe inside the streaming
-    // tail-window. Mark the function reference Marked stores in
-    // `options.extensions.block`.
-    for (const entry of ext.extensions ?? []) {
-        if ('tokenizer' in entry && typeof entry.tokenizer === 'function') {
-            markTailWindowSafe(entry.tokenizer)
-        }
-    }
-    return ext
+    // tail-window.
+    return tailWindowSafeExtension(ext)
 }

--- a/src/lib/extensions/alert/markedAlert.ts
+++ b/src/lib/extensions/alert/markedAlert.ts
@@ -1,3 +1,4 @@
+import { markTailWindowSafe } from '$lib/types.js'
 import type { MarkedExtension } from 'marked'
 
 /**
@@ -39,7 +40,7 @@ const ALERT_TYPES: ReadonlySet<string> = new Set(['note', 'tip', 'important', 'w
  * @returns A `MarkedExtension` with a single block-level `alert` tokenizer
  */
 export function markedAlert(): MarkedExtension {
-    return {
+    const ext: MarkedExtension = {
         extensions: [
             {
                 name: 'alert',
@@ -70,4 +71,14 @@ export function markedAlert(): MarkedExtension {
             }
         ]
     }
+    // The alert tokenizer is block-anchored (`> [!NOTE]`) and inspects only
+    // `src` from the current position, so it is safe inside the streaming
+    // tail-window. Mark the function reference Marked stores in
+    // `options.extensions.block`.
+    for (const entry of ext.extensions ?? []) {
+        if ('tokenizer' in entry && typeof entry.tokenizer === 'function') {
+            markTailWindowSafe(entry.tokenizer)
+        }
+    }
+    return ext
 }

--- a/src/lib/extensions/katex/markedKatex.ts
+++ b/src/lib/extensions/katex/markedKatex.ts
@@ -1,4 +1,4 @@
-import { markTailWindowSafe } from '$lib/types.js'
+import { tailWindowSafeExtension } from '$lib/utils/tail-window.js'
 import type { MarkedExtension } from 'marked'
 
 /** Token type emitted for inline math (`\(...\)`, opt-in `$...$`). */
@@ -195,12 +195,6 @@ export function markedKatex(options: MarkedKatexOptions = {}): MarkedExtension {
     }
     // Both tokenizers are block-anchored (`$$`, `\[`, AMS envs) or delimiter-
     // scoped (`\(…\)`, `$…$`) and inspect only `src` from the current position,
-    // so they are safe to run inside the streaming tail-window. Mark the
-    // function references Marked stores in `options.extensions.block/inline`.
-    for (const entry of ext.extensions ?? []) {
-        if ('tokenizer' in entry && typeof entry.tokenizer === 'function') {
-            markTailWindowSafe(entry.tokenizer)
-        }
-    }
-    return ext
+    // so they are safe to run inside the streaming tail-window.
+    return tailWindowSafeExtension(ext)
 }

--- a/src/lib/extensions/katex/markedKatex.ts
+++ b/src/lib/extensions/katex/markedKatex.ts
@@ -1,3 +1,4 @@
+import { markTailWindowSafe } from '$lib/types.js'
 import type { MarkedExtension } from 'marked'
 
 /** Token type emitted for inline math (`\(...\)`, opt-in `$...$`). */
@@ -191,6 +192,15 @@ export function markedKatex(options: MarkedKatexOptions = {}): MarkedExtension {
                 }
             }
         ]
+    }
+    // Both tokenizers are block-anchored (`$$`, `\[`, AMS envs) or delimiter-
+    // scoped (`\(…\)`, `$…$`) and inspect only `src` from the current position,
+    // so they are safe to run inside the streaming tail-window. Mark the
+    // function references Marked stores in `options.extensions.block/inline`.
+    for (const entry of ext.extensions ?? []) {
+        if ('tokenizer' in entry && typeof entry.tokenizer === 'function') {
+            markTailWindowSafe(entry.tokenizer)
+        }
     }
     return ext
 }

--- a/src/lib/extensions/mermaid/markedMermaid.ts
+++ b/src/lib/extensions/mermaid/markedMermaid.ts
@@ -1,4 +1,4 @@
-import { markTailWindowSafe } from '$lib/types.js'
+import { tailWindowSafeExtension } from '$lib/utils/tail-window.js'
 import type { MarkedExtension } from 'marked'
 
 /**
@@ -51,12 +51,6 @@ export function markedMermaid(): MarkedExtension {
     }
     // The mermaid tokenizer is block-anchored (a ` ```mermaid ` fence) and
     // inspects only `src` from the current position, so it is safe inside the
-    // streaming tail-window. Mark the function reference Marked stores in
-    // `options.extensions.block`.
-    for (const entry of ext.extensions ?? []) {
-        if ('tokenizer' in entry && typeof entry.tokenizer === 'function') {
-            markTailWindowSafe(entry.tokenizer)
-        }
-    }
-    return ext
+    // streaming tail-window.
+    return tailWindowSafeExtension(ext)
 }

--- a/src/lib/extensions/mermaid/markedMermaid.ts
+++ b/src/lib/extensions/mermaid/markedMermaid.ts
@@ -1,3 +1,4 @@
+import { markTailWindowSafe } from '$lib/types.js'
 import type { MarkedExtension } from 'marked'
 
 /**
@@ -27,7 +28,7 @@ import type { MarkedExtension } from 'marked'
  * @returns A `MarkedExtension` with a single block-level `mermaid` tokenizer
  */
 export function markedMermaid(): MarkedExtension {
-    return {
+    const ext: MarkedExtension = {
         extensions: [
             {
                 name: 'mermaid',
@@ -48,4 +49,14 @@ export function markedMermaid(): MarkedExtension {
             }
         ]
     }
+    // The mermaid tokenizer is block-anchored (a ` ```mermaid ` fence) and
+    // inspects only `src` from the current position, so it is safe inside the
+    // streaming tail-window. Mark the function reference Marked stores in
+    // `options.extensions.block`.
+    for (const entry of ext.extensions ?? []) {
+        if ('tokenizer' in entry && typeof entry.tokenizer === 'function') {
+            markTailWindowSafe(entry.tokenizer)
+        }
+    }
+    return ext
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,55 +24,6 @@ import type { MarkedOptions, Renderers } from './utils/markdown-parser.js'
 import type { HtmlKey } from './utils/rendererKeys.js'
 import type { SanitizeAttributesFn, SanitizeUrlFn } from './utils/sanitize.js'
 
-/**
- * Marker key for extension tokenizer **functions** that are safe to run inside
- * the streaming incremental tail-window.
- *
- * The streaming {@link IncrementalParser} normally disables its tail-window
- * (which re-lexes only the appended tail and reuses a stable token prefix) the
- * moment any extension tokenizer is registered, because a tokenizer whose
- * output depends on prefix content would produce wrong tokens when the prefix
- * is not re-lexed. A tokenizer that carries this marker promises to be
- * **block-anchored and stateless** — it inspects only `src` from the current
- * position, exactly like Marked's built-in block rules — so re-lexing the tail
- * from a stable block boundary is guaranteed to match a full re-lex.
- *
- * Marked's `use()` stores the tokenizer **function reference** in
- * `options.extensions.block` / `options.extensions.inline`, so the marker must
- * live on the function itself (which survives by reference); it is invisible to
- * `Marked` otherwise. This is a global-registry symbol so the promise is
- * checkable across module boundaries without importing the same binding.
- *
- * @remarks This is a promise about tokenizer statelessness. Any extension with
- * cross-block state (e.g. footnotes, whose definitions and references interact
- * across blocks) must **not** carry it.
- */
-export const TAIL_WINDOW_SAFE: unique symbol = Symbol.for('svelte-markdown.tailWindowSafe')
-
-/**
- * Tags an extension tokenizer function as tail-window safe (see
- * {@link TAIL_WINDOW_SAFE}) and returns it, for fluent use where a tokenizer
- * function is defined. Only apply to block-anchored, stateless tokenizers.
- *
- * @param tokenizer - The tokenizer function to mark
- * @returns The same function, now carrying the {@link TAIL_WINDOW_SAFE} marker
- */
-export const markTailWindowSafe = <F>(tokenizer: F): F => {
-    ;(tokenizer as unknown as Record<symbol, boolean>)[TAIL_WINDOW_SAFE] = true
-    return tokenizer
-}
-
-/**
- * True when `value` is a tail-window-safe tokenizer function carrying the
- * {@link TAIL_WINDOW_SAFE} marker.
- *
- * @param value - Candidate entry from `options.extensions.block`/`.inline`
- * @returns `true` if the entry is a function marked tail-window safe
- */
-export const isTailWindowSafe = (value: unknown): boolean =>
-    typeof value === 'function' &&
-    (value as unknown as Record<symbol, unknown>)[TAIL_WINDOW_SAFE] === true
-
 // --- Markdown snippet prop types ---
 
 export interface ParagraphSnippetProps {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,55 @@ import type { MarkedOptions, Renderers } from './utils/markdown-parser.js'
 import type { HtmlKey } from './utils/rendererKeys.js'
 import type { SanitizeAttributesFn, SanitizeUrlFn } from './utils/sanitize.js'
 
+/**
+ * Marker key for extension tokenizer **functions** that are safe to run inside
+ * the streaming incremental tail-window.
+ *
+ * The streaming {@link IncrementalParser} normally disables its tail-window
+ * (which re-lexes only the appended tail and reuses a stable token prefix) the
+ * moment any extension tokenizer is registered, because a tokenizer whose
+ * output depends on prefix content would produce wrong tokens when the prefix
+ * is not re-lexed. A tokenizer that carries this marker promises to be
+ * **block-anchored and stateless** — it inspects only `src` from the current
+ * position, exactly like Marked's built-in block rules — so re-lexing the tail
+ * from a stable block boundary is guaranteed to match a full re-lex.
+ *
+ * Marked's `use()` stores the tokenizer **function reference** in
+ * `options.extensions.block` / `options.extensions.inline`, so the marker must
+ * live on the function itself (which survives by reference); it is invisible to
+ * `Marked` otherwise. This is a global-registry symbol so the promise is
+ * checkable across module boundaries without importing the same binding.
+ *
+ * @remarks This is a promise about tokenizer statelessness. Any extension with
+ * cross-block state (e.g. footnotes, whose definitions and references interact
+ * across blocks) must **not** carry it.
+ */
+export const TAIL_WINDOW_SAFE: unique symbol = Symbol.for('svelte-markdown.tailWindowSafe')
+
+/**
+ * Tags an extension tokenizer function as tail-window safe (see
+ * {@link TAIL_WINDOW_SAFE}) and returns it, for fluent use where a tokenizer
+ * function is defined. Only apply to block-anchored, stateless tokenizers.
+ *
+ * @param tokenizer - The tokenizer function to mark
+ * @returns The same function, now carrying the {@link TAIL_WINDOW_SAFE} marker
+ */
+export const markTailWindowSafe = <F>(tokenizer: F): F => {
+    ;(tokenizer as unknown as Record<symbol, boolean>)[TAIL_WINDOW_SAFE] = true
+    return tokenizer
+}
+
+/**
+ * True when `value` is a tail-window-safe tokenizer function carrying the
+ * {@link TAIL_WINDOW_SAFE} marker.
+ *
+ * @param value - Candidate entry from `options.extensions.block`/`.inline`
+ * @returns `true` if the entry is a function marked tail-window safe
+ */
+export const isTailWindowSafe = (value: unknown): boolean =>
+    typeof value === 'function' &&
+    (value as unknown as Record<symbol, unknown>)[TAIL_WINDOW_SAFE] === true
+
 // --- Markdown snippet prop types ---
 
 export interface ParagraphSnippetProps {

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -714,15 +714,33 @@ describe('IncrementalParser', () => {
         })
     })
 
-    // Builds parser options exactly the way `SvelteMarkdown.svelte` does
-    // (via `buildParserOptions`), so the extension tokenizers land in
-    // `options.extensions.block` / `.inline` where the constructor reads them.
+    /**
+     * Builds parser options exactly the way `SvelteMarkdown.svelte` does
+     * (via `buildParserOptions`), so the extension tokenizers land in
+     * `options.extensions.block` / `.inline` where the constructor reads them.
+     *
+     * @param extensions - Marked extensions to register
+     * @returns Parser options with the extensions merged in
+     * @example
+     * ```ts
+     * const options = createExtensionOptions([markedKatex(), markedAlert()])
+     * ```
+     */
     const createExtensionOptions = (
         extensions: Parameters<typeof buildParserOptions>[1]
     ): SvelteMarkdownOptions => buildParserOptions({ gfm: true }, extensions)
 
-    // Word-chunk a source the same way the streaming perf-bench does, so the
-    // parity tests replay a realistic LLM-style token cadence.
+    /**
+     * Word-chunks a source the same way the streaming perf-bench does, so the
+     * parity tests replay a realistic LLM-style token cadence.
+     *
+     * @param source - Markdown source to split
+     * @returns Word-sized chunks (word + trailing whitespace)
+     * @example
+     * ```ts
+     * wordChunks('a b') // => ['a ', 'b']
+     * ```
+     */
     const wordChunks = (source: string): string[] => {
         const chunks: string[] = []
         const re = /\S+\s*/g
@@ -731,13 +749,33 @@ describe('IncrementalParser', () => {
         return chunks
     }
 
-    // Feeds `chunks` cumulatively into a parser and returns the final tokens.
-    const streamThrough = (parser: IncrementalParser, chunks: string[]): Token[] => {
+    /**
+     * Feeds `chunks` cumulatively into a parser, asserting after EVERY append
+     * that the incremental tokens deep-equal a one-shot lex of the accumulated
+     * source — a malformed intermediate parse cannot self-correct on the final
+     * append and still pass.
+     *
+     * @param parser - Parser under test
+     * @param chunks - Chunks appended cumulatively
+     * @param options - The same options the parser was constructed with, for
+     *   the per-append one-shot comparison lex
+     * @returns Tokens from the final append
+     * @example
+     * ```ts
+     * const tokens = streamThrough(parser, wordChunks(source), options)
+     * ```
+     */
+    const streamThrough = (
+        parser: IncrementalParser,
+        chunks: string[],
+        options: SvelteMarkdownOptions
+    ): Token[] => {
         let accumulated = ''
         let tokens: Token[] = []
         for (const chunk of chunks) {
             accumulated += chunk
             tokens = parser.update(accumulated).tokens
+            expect(tokens).toEqual(parseAndCacheModule.lexAndClean(accumulated, options, false))
         }
         return tokens
     }
@@ -772,7 +810,7 @@ describe('IncrementalParser', () => {
             const options = createExtensionOptions([markedKatex(), markedAlert()])
             const parser = new IncrementalParser(options)
 
-            const streamed = streamThrough(parser, wordChunks(EXTENSION_CORPUS))
+            const streamed = streamThrough(parser, wordChunks(EXTENSION_CORPUS), options)
             const oneShot = parseAndCacheModule.lexAndClean(EXTENSION_CORPUS, options, false)
 
             expect(streamed).toEqual(oneShot)
@@ -789,8 +827,36 @@ describe('IncrementalParser', () => {
                 chunks.push(EXTENSION_CORPUS.slice(i, i + 7))
             }
 
-            const streamed = streamThrough(parser, chunks)
+            const streamed = streamThrough(parser, chunks, options)
             const oneShot = parseAndCacheModule.lexAndClean(EXTENSION_CORPUS, options, false)
+
+            expect(streamed).toEqual(oneShot)
+        })
+
+        it('streams a mermaid fence split across chunks to the same tokens as a one-shot lex', () => {
+            const options = createExtensionOptions([markedMermaid()])
+            const parser = new IncrementalParser(options)
+            const source = [
+                'Intro prose before the diagram.',
+                '',
+                '```mermaid',
+                'graph TD',
+                '    A[Start] --> B{Decision}',
+                '    B -->|yes| C[Done]',
+                '```',
+                '',
+                'Closing prose after the diagram.'
+            ].join('\n')
+
+            // Fixed-size chunking deliberately splits inside the fence so the
+            // mermaid tokenizer sees partial fences on intermediate appends.
+            const chunks: string[] = []
+            for (let i = 0; i < source.length; i += 5) {
+                chunks.push(source.slice(i, i + 5))
+            }
+
+            const streamed = streamThrough(parser, chunks, options)
+            const oneShot = parseAndCacheModule.lexAndClean(source, options, false)
 
             expect(streamed).toEqual(oneShot)
         })
@@ -800,7 +866,7 @@ describe('IncrementalParser', () => {
             const parser = new IncrementalParser(options)
             const source = 'Cost is $5 but energy is $E = mc^2$ across the board.\n\nTail prose.'
 
-            const streamed = streamThrough(parser, wordChunks(source))
+            const streamed = streamThrough(parser, wordChunks(source), options)
             const oneShot = parseAndCacheModule.lexAndClean(source, options, false)
 
             expect(streamed).toEqual(oneShot)

--- a/src/lib/utils/incremental-parser.test.ts
+++ b/src/lib/utils/incremental-parser.test.ts
@@ -1,6 +1,11 @@
+import { markedAlert } from '$lib/extensions/alert/markedAlert.js'
+import { markedFootnote } from '$lib/extensions/footnote/markedFootnote.js'
+import { markedKatex } from '$lib/extensions/katex/markedKatex.js'
+import { markedMermaid } from '$lib/extensions/mermaid/markedMermaid.js'
 import type { SvelteMarkdownOptions } from '$lib/types.js'
 import type { Token } from '$lib/utils/markdown-parser.js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildParserOptions } from './extension-options.js'
 import { IncrementalParser } from './incremental-parser.js'
 import * as parseAndCacheModule from './parse-and-cache.js'
 
@@ -17,6 +22,7 @@ interface InternalParser {
         source: string,
         boundary: { prefixCount: number; reparseOffset: number }
     ) => boolean
+    tailWindowDisabled: boolean
 }
 
 /** Expose the private tail-window internals without repeating the cast per test. */
@@ -705,6 +711,263 @@ describe('IncrementalParser', () => {
             parser.update('Rewritten [ref0] content\n\n[ref0]: /b')
 
             expect(Math.max(...scannedLengths)).toBeLessThan(source.length)
+        })
+    })
+
+    // Builds parser options exactly the way `SvelteMarkdown.svelte` does
+    // (via `buildParserOptions`), so the extension tokenizers land in
+    // `options.extensions.block` / `.inline` where the constructor reads them.
+    const createExtensionOptions = (
+        extensions: Parameters<typeof buildParserOptions>[1]
+    ): SvelteMarkdownOptions => buildParserOptions({ gfm: true }, extensions)
+
+    // Word-chunk a source the same way the streaming perf-bench does, so the
+    // parity tests replay a realistic LLM-style token cadence.
+    const wordChunks = (source: string): string[] => {
+        const chunks: string[] = []
+        const re = /\S+\s*/g
+        let match: RegExpExecArray | null
+        while ((match = re.exec(source)) !== null) chunks.push(match[0])
+        return chunks
+    }
+
+    // Feeds `chunks` cumulatively into a parser and returns the final tokens.
+    const streamThrough = (parser: IncrementalParser, chunks: string[]): Token[] => {
+        let accumulated = ''
+        let tokens: Token[] = []
+        for (const chunk of chunks) {
+            accumulated += chunk
+            tokens = parser.update(accumulated).tokens
+        }
+        return tokens
+    }
+
+    describe('Extension streaming parity', () => {
+        // A corpus that interleaves prose, block `$$…$$` math, inline `\(…\)`
+        // math, and `> [!NOTE]` alerts — the token shapes the marketed katex +
+        // alert extensions handle.
+        const EXTENSION_CORPUS = [
+            '# Streaming Extensions',
+            '',
+            'Intro prose with inline math \\(a_0 = 1\\) and a [link](https://example.com).',
+            '',
+            '$$',
+            'E = mc^2 + \\sum_{k=0}^{3} \\frac{k}{4}',
+            '$$',
+            '',
+            '> [!NOTE]',
+            '> Remember to normalize the coefficient before the next section.',
+            '',
+            '## Section Two',
+            '',
+            'More prose with another inline expression \\(b = \\pi r^2\\).',
+            '',
+            '> [!WARNING]',
+            '> Watch out for the boundary condition here.',
+            '',
+            'Closing remarks after the alert.'
+        ].join('\n')
+
+        it('streams katex + alert content to the same tokens as a one-shot lex', () => {
+            const options = createExtensionOptions([markedKatex(), markedAlert()])
+            const parser = new IncrementalParser(options)
+
+            const streamed = streamThrough(parser, wordChunks(EXTENSION_CORPUS))
+            const oneShot = parseAndCacheModule.lexAndClean(EXTENSION_CORPUS, options, false)
+
+            expect(streamed).toEqual(oneShot)
+        })
+
+        it('matches a one-shot lex when chunk boundaries fall inside math and alerts', () => {
+            const options = createExtensionOptions([markedKatex(), markedAlert()])
+            const parser = new IncrementalParser(options)
+
+            // Fixed-size chunking deliberately splits inside `$$…$$`, inside
+            // `\(…\)`, and mid-alert, exercising partial-token appends.
+            const chunks: string[] = []
+            for (let i = 0; i < EXTENSION_CORPUS.length; i += 7) {
+                chunks.push(EXTENSION_CORPUS.slice(i, i + 7))
+            }
+
+            const streamed = streamThrough(parser, chunks)
+            const oneShot = parseAndCacheModule.lexAndClean(EXTENSION_CORPUS, options, false)
+
+            expect(streamed).toEqual(oneShot)
+        })
+
+        it('keeps single-dollar inline katex parity when enabled', () => {
+            const options = createExtensionOptions([markedKatex({ singleDollarInline: true })])
+            const parser = new IncrementalParser(options)
+            const source = 'Cost is $5 but energy is $E = mc^2$ across the board.\n\nTail prose.'
+
+            const streamed = streamThrough(parser, wordChunks(source))
+            const oneShot = parseAndCacheModule.lexAndClean(source, options, false)
+
+            expect(streamed).toEqual(oneShot)
+        })
+    })
+
+    describe('Full-reparse metadata prefix offset', () => {
+        // A custom extension whose tokenizer never matches: normal markdown is
+        // produced, but its mere presence keeps the parser on the full-reparse
+        // path (no `tailWindowSafe` marker), exactly like a user extension.
+        const noopExtension = {
+            extensions: [
+                {
+                    name: 'noopBlock',
+                    level: 'block' as const,
+                    start: () => undefined,
+                    tokenizer: () => undefined
+                }
+            ]
+        }
+
+        it('reports the absolute source offset of the first changed token on the full-reparse path', () => {
+            const options = createExtensionOptions([noopExtension])
+            const parser = new IncrementalParser(options)
+            // Confirm we are genuinely on the full-reparse (tail-window-off) path.
+            expect(asInternalParser(parser).tailWindowDisabled).toBe(true)
+
+            const base = '# Alpha\n\nBravo paragraph.\n\n'
+            parser.update(base)
+            const appended = `${base}Charlie paragraph.`
+
+            const result = parser.update(appended)
+
+            expect(result.canReuse).toBe(true)
+            expect(result.divergeAt).toBeGreaterThan(0)
+            expect(result.divergeOffset).toBe(base.length)
+            // The offset must point at the first byte of the appended token.
+            expect(appended.slice(result.divergeOffset)).toBe('Charlie paragraph.')
+        })
+
+        it('falls back to an undefined offset when an unknown HTML span sits in the reused prefix', () => {
+            const options = createExtensionOptions([noopExtension])
+            const parser = new IncrementalParser(options)
+            expect(asInternalParser(parser).tailWindowDisabled).toBe(true)
+
+            // An unclosed `<details>` opening (its `</details>` never arrives)
+            // has no known source span, so any offset at or beyond it is
+            // untrustworthy. It sits at the head of the reused prefix.
+            const base = '<details>\n<summary>Title</summary>\n\nBoxed paragraph.\n\n'
+            parser.update(base)
+            const appended = `${base}Trailing paragraph.`
+
+            const result = parser.update(appended)
+
+            // Sanity: the unclosed opening really is an unknown-span html token
+            // sitting in the matched prefix.
+            const internal = asInternalParser(parser)
+            const openingIsUnknownSpan = internal.prevTokens.some(
+                (token) => token.type === 'html' && internal.hasHtmlSpanMismatch(token)
+            )
+            expect(openingIsUnknownSpan).toBe(true)
+            expect(result.canReuse).toBe(true)
+            expect(result.divergeOffset).toBeUndefined()
+        })
+    })
+
+    describe('Tail-safe built-in extensions', () => {
+        it('engages the tail-window for katex + alert streams', () => {
+            const options = createExtensionOptions([markedKatex(), markedAlert()])
+            const parser = new IncrementalParser(options)
+            // The tail-safe marker must flip the constructor decision.
+            expect(asInternalParser(parser).tailWindowDisabled).toBe(false)
+
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const base =
+                '# Math\n\n$$\nE = mc^2\n$$\n\n> [!NOTE]\n> Normalize the coefficient.\n\nProse tail.\n\n'
+            parser.update(base)
+
+            const internal = asInternalParser(parser)
+            const boundary = internal.getTailWindowBoundary()
+            expect(boundary.reparseOffset).toBeGreaterThan(0)
+
+            const appended = `${base}Appended paragraph after warm-up.`
+            expect(internal.canUseTailWindow(appended, boundary)).toBe(true)
+
+            parser.update(appended)
+
+            // Tail-window engaged: the second update re-lexes only the appended
+            // tail slice, never the whole accumulated source.
+            const lastLexInput = lexSpy.mock.calls.at(-1)?.[0]
+            expect(lastLexInput).toBe(appended.slice(boundary.reparseOffset))
+            expect((lastLexInput as string).length).toBeLessThan(appended.length)
+        })
+
+        it('produces the same tokens on the tail-window path as a one-shot lex (katex + alert)', () => {
+            const options = createExtensionOptions([markedKatex(), markedAlert()])
+            const source =
+                '# Doc\n\nIntro \\(x\\) prose.\n\n$$\na^2 + b^2 = c^2\n$$\n\n' +
+                '> [!TIP]\n> Keep it simple.\n\nMiddle prose.\n\n$$\n\\int_0^1 x\\,dx\n$$\n\nEnd.'
+
+            // Warm-up update so the tail-window is primed, then a final append.
+            const parser = new IncrementalParser(options)
+            const warm = `${source}\n\n`
+            parser.update(warm)
+            const final = `${warm}> [!WARNING]\n> Final alert.\n`
+            const streamed = parser.update(final)
+            const oneShot = parseAndCacheModule.lexAndClean(final, options, false)
+
+            expect(streamed.tokens).toEqual(oneShot)
+        })
+
+        it('marks katex, alert, and mermaid as tail-safe', () => {
+            for (const extensions of [
+                [markedKatex()],
+                [markedAlert()],
+                [markedMermaid()],
+                [markedKatex(), markedAlert(), markedMermaid()]
+            ]) {
+                const parser = new IncrementalParser(createExtensionOptions(extensions))
+                expect(asInternalParser(parser).tailWindowDisabled).toBe(false)
+            }
+        })
+
+        it('keeps footnote streams on the full-reparse path (footnote is not tail-safe)', () => {
+            const options = createExtensionOptions([markedFootnote()])
+            const parser = new IncrementalParser(options)
+            expect(asInternalParser(parser).tailWindowDisabled).toBe(true)
+
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const base = 'Body text[^1].\n\n[^1]: A footnote definition.\n\n'
+            parser.update(base)
+            const appended = `${base}More streamed text.`
+            parser.update(appended)
+
+            // Full reparse: the whole accumulated source is re-lexed each update.
+            expect(lexSpy.mock.calls.at(-1)?.[0]).toBe(appended)
+        })
+
+        it('disables the tail-window when any registered extension is not tail-safe', () => {
+            // katex (safe) mixed with footnote (unsafe) ⇒ conservative disable.
+            const options = createExtensionOptions([markedKatex(), markedFootnote()])
+            const parser = new IncrementalParser(options)
+            expect(asInternalParser(parser).tailWindowDisabled).toBe(true)
+        })
+
+        it('keeps a user-supplied custom extension without the marker on the full-reparse path', () => {
+            const customExtension = {
+                extensions: [
+                    {
+                        name: 'customInline',
+                        level: 'inline' as const,
+                        start: () => undefined,
+                        tokenizer: () => undefined
+                    }
+                ]
+            }
+            const options = createExtensionOptions([customExtension])
+            const parser = new IncrementalParser(options)
+            expect(asInternalParser(parser).tailWindowDisabled).toBe(true)
+
+            const lexSpy = vi.spyOn(parseAndCacheModule, 'lexAndClean')
+            const base = '# Heading\n\nStable paragraph.\n\n'
+            parser.update(base)
+            const appended = `${base}Appended paragraph.`
+            parser.update(appended)
+
+            expect(lexSpy.mock.calls.at(-1)?.[0]).toBe(appended)
         })
     })
 })

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -9,7 +9,7 @@
  * @module incremental-parser
  */
 
-import type { SvelteMarkdownOptions } from '$lib/types.js'
+import { isTailWindowSafe, type SvelteMarkdownOptions } from '$lib/types.js'
 import type { Token } from '$lib/utils/markdown-parser.js'
 import { lexAndClean } from '$lib/utils/parse-and-cache.js'
 
@@ -112,16 +112,26 @@ export class IncrementalParser {
     constructor(options: SvelteMarkdownOptions) {
         this.options = options
 
+        // Marked's `use()` stores each extension's tokenizer FUNCTION (by
+        // reference) in `options.extensions.block` / `.inline`. A registered
+        // tokenizer only forces a full re-lex per chunk if it might depend on
+        // prefix content; block-anchored, stateless tokenizers (marked with
+        // `TAIL_WINDOW_SAFE` — katex, alert, mermaid) can safely run inside the
+        // tail-window, exactly like Marked's built-in block rules. Custom
+        // extensions and footnotes (cross-block ref/def state) carry no marker
+        // and keep the conservative full-reparse behavior.
         const exts = (options as Record<string, unknown>).extensions as
             { block?: unknown[]; inline?: unknown[] } | undefined
-        const hasExtensionTokenizers =
-            (exts?.block != null && exts.block.length > 0) ||
-            (exts?.inline != null && exts.inline.length > 0)
+        const tokenizerEntries = [...(exts?.block ?? []), ...(exts?.inline ?? [])]
+        const hasExtensionTokenizers = tokenizerEntries.length > 0
+        const hasUnsafeExtensionTokenizer = tokenizerEntries.some(
+            (entry) => !isTailWindowSafe(entry)
+        )
 
         this.tailWindowDisabled =
             typeof options.walkTokens === 'function' ||
             options.tokenizer != null ||
-            hasExtensionTokenizers
+            (hasExtensionTokenizers && hasUnsafeExtensionTokenizer)
     }
 
     private getTailWindowBoundary = (): TailWindowBoundary => {
@@ -560,8 +570,19 @@ export class IncrementalParser {
         // `raw === '<div>'` but very different `.tokens` children. Without
         // this check the streaming consumer would never see the partial-
         // to-closed transition. See #291.
+        // `divergeOffset` is the absolute source offset of the first diverged
+        // token, letting `SvelteMarkdown.svelte` skip render-metadata work for
+        // the reused prefix. The tail-window path seeds it with the already
+        // -known `boundary.reparseOffset` (the reused prefix is covered) and
+        // only sums tokens past the prefix. The full-reparse path (which still
+        // re-lexes the whole source, e.g. when a built-in extension is not
+        // tail-safe) starts at 0 and sums every matched token from index 0, so
+        // an append-only update with a stable prefix can still skip the prefix
+        // metadata walk even though the tail-window was bypassed.
         let divergeAt = 0
-        let divergeOffset = parseResult.usedTailWindow ? boundary.reparseOffset : undefined
+        let divergeOffset: number | undefined = parseResult.usedTailWindow
+            ? boundary.reparseOffset
+            : 0
         if (!referenceSensitive) {
             const minLen = Math.min(this.prevTokens.length, newTokens.length)
             while (divergeAt < minLen) {
@@ -574,12 +595,24 @@ export class IncrementalParser {
                     if ((prevKids === undefined) !== (nextKids === undefined)) break
                     if (prevKids && nextKids && prevKids.length !== nextKids.length) break
                 }
-                if (
-                    parseResult.usedTailWindow &&
-                    divergeOffset !== undefined &&
-                    divergeAt >= boundary.prefixCount
-                ) {
-                    divergeOffset += this.getTokenSourceLength(next)
+                if (parseResult.usedTailWindow) {
+                    // Tail-window path (unchanged): tokens up to `prefixCount`
+                    // are the reused prefix already covered by `reparseOffset`.
+                    if (divergeOffset !== undefined && divergeAt >= boundary.prefixCount) {
+                        divergeOffset += this.getTokenSourceLength(next)
+                    }
+                } else if (divergeOffset !== undefined) {
+                    // Full-reparse path: accumulate the absolute offset from
+                    // index 0. A matched-prefix HTML token with an unknown
+                    // source span (unclosed opening) breaks the offset→source
+                    // mapping — null the offset so the consumer falls back to a
+                    // full metadata walk. A wrong offset silently corrupts
+                    // source keys and DOM identity; `undefined` is always safe.
+                    if (this.hasHtmlSpanMismatch(next)) {
+                        divergeOffset = undefined
+                    } else {
+                        divergeOffset += this.getTokenSourceLength(next)
+                    }
                 }
                 divergeAt++
             }

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -9,9 +9,10 @@
  * @module incremental-parser
  */
 
-import { isTailWindowSafe, type SvelteMarkdownOptions } from '$lib/types.js'
+import type { SvelteMarkdownOptions } from '$lib/types.js'
 import type { Token } from '$lib/utils/markdown-parser.js'
 import { lexAndClean } from '$lib/utils/parse-and-cache.js'
+import { isTailWindowSafe } from '$lib/utils/tail-window.js'
 
 /**
  * The shape of an HTML token after the cleanup pipeline. Marked's base
@@ -52,6 +53,8 @@ export interface IncrementalUpdateResult {
     divergeOffset?: number
     /** Whether consumers can safely reuse stable token objects from the previous parse */
     canReuse: boolean
+    /** Whether this update re-lexed only the appended tail (vs the whole source) */
+    usedTailWindow: boolean
 }
 
 /**
@@ -123,15 +126,11 @@ export class IncrementalParser {
         const exts = (options as Record<string, unknown>).extensions as
             { block?: unknown[]; inline?: unknown[] } | undefined
         const tokenizerEntries = [...(exts?.block ?? []), ...(exts?.inline ?? [])]
-        const hasExtensionTokenizers = tokenizerEntries.length > 0
-        const hasUnsafeExtensionTokenizer = tokenizerEntries.some(
-            (entry) => !isTailWindowSafe(entry)
-        )
 
         this.tailWindowDisabled =
             typeof options.walkTokens === 'function' ||
             options.tokenizer != null ||
-            (hasExtensionTokenizers && hasUnsafeExtensionTokenizer)
+            tokenizerEntries.some((entry) => !isTailWindowSafe(entry))
     }
 
     private getTailWindowBoundary = (): TailWindowBoundary => {
@@ -619,6 +618,12 @@ export class IncrementalParser {
         }
 
         this.updateCachedState(source, parseResult, isAppendOnly, appendAddsDefinition)
-        return { tokens: newTokens, divergeAt, divergeOffset, canReuse }
+        return {
+            tokens: newTokens,
+            divergeAt,
+            divergeOffset,
+            canReuse,
+            usedTailWindow: parseResult.usedTailWindow
+        }
     }
 }

--- a/src/lib/utils/tail-window.ts
+++ b/src/lib/utils/tail-window.ts
@@ -1,0 +1,69 @@
+/**
+ * Tail-window safety markers for extension tokenizers.
+ *
+ * The streaming `IncrementalParser` normally disables its tail-window (which
+ * re-lexes only the appended tail and reuses a stable token prefix) the moment
+ * any extension tokenizer is registered, because a tokenizer whose output
+ * depends on prefix content would produce wrong tokens when the prefix is not
+ * re-lexed. Tokenizers carrying the marker defined here promise to be
+ * **block-anchored and stateless** — they inspect only `src` from the current
+ * position, exactly like Marked's built-in block rules — so re-lexing the tail
+ * from a stable block boundary is guaranteed to match a full re-lex.
+ *
+ * Marked's `use()` stores the tokenizer **function reference** in
+ * `options.extensions.block` / `options.extensions.inline`, so the marker must
+ * live on the function itself (which survives by reference); it is invisible
+ * to `Marked` otherwise. This is a global-registry symbol so the promise is
+ * checkable across module boundaries without importing the same binding.
+ *
+ * @remarks This is a promise about tokenizer statelessness. Any extension with
+ * cross-block state (e.g. footnotes, whose definitions and references interact
+ * across blocks) must **not** carry it.
+ *
+ * @module tail-window
+ */
+
+import type { MarkedExtension } from 'marked'
+
+/** Marker key carried by tail-window-safe tokenizer functions. */
+export const TAIL_WINDOW_SAFE: unique symbol = Symbol.for('svelte-markdown.tailWindowSafe')
+
+/**
+ * Tags a single extension tokenizer function as tail-window safe (see the
+ * module doc). Only apply to block-anchored, stateless tokenizers; prefer
+ * {@link tailWindowSafeExtension} to mark a whole extension atomically.
+ *
+ * @param tokenizer - The tokenizer function to mark
+ */
+export const markTailWindowSafe = (tokenizer: (..._args: never[]) => unknown): void => {
+    ;(tokenizer as unknown as Record<symbol, boolean>)[TAIL_WINDOW_SAFE] = true
+}
+
+/**
+ * Marks every tokenizer in a Marked extension as tail-window safe and returns
+ * the extension. This is the whole-extension form of the promise: all of the
+ * extension's tokenizers are block-anchored and stateless, so none of them can
+ * be half-applied or forgotten when a tokenizer is added later.
+ *
+ * @param ext - The Marked extension whose tokenizers are all tail-window safe
+ * @returns The same extension, with every tokenizer marked
+ */
+export const tailWindowSafeExtension = (ext: MarkedExtension): MarkedExtension => {
+    for (const entry of ext.extensions ?? []) {
+        if ('tokenizer' in entry && typeof entry.tokenizer === 'function') {
+            markTailWindowSafe(entry.tokenizer)
+        }
+    }
+    return ext
+}
+
+/**
+ * True when `value` is a tail-window-safe tokenizer function carrying the
+ * {@link TAIL_WINDOW_SAFE} marker.
+ *
+ * @param value - Candidate entry from `options.extensions.block`/`.inline`
+ * @returns `true` if the entry is a function marked tail-window safe
+ */
+export const isTailWindowSafe = (value: unknown): boolean =>
+    typeof value === 'function' &&
+    (value as unknown as Record<symbol, unknown>)[TAIL_WINDOW_SAFE] === true

--- a/src/lib/utils/tail-window.ts
+++ b/src/lib/utils/tail-window.ts
@@ -34,6 +34,11 @@ export const TAIL_WINDOW_SAFE: unique symbol = Symbol.for('svelte-markdown.tailW
  * {@link tailWindowSafeExtension} to mark a whole extension atomically.
  *
  * @param tokenizer - The tokenizer function to mark
+ * @returns Nothing — the marker is attached to the function in place
+ * @example
+ * ```ts
+ * markTailWindowSafe(myBlockTokenizer)
+ * ```
  */
 export const markTailWindowSafe = (tokenizer: (..._args: never[]) => unknown): void => {
     ;(tokenizer as unknown as Record<symbol, boolean>)[TAIL_WINDOW_SAFE] = true
@@ -47,6 +52,10 @@ export const markTailWindowSafe = (tokenizer: (..._args: never[]) => unknown): v
  *
  * @param ext - The Marked extension whose tokenizers are all tail-window safe
  * @returns The same extension, with every tokenizer marked
+ * @example
+ * ```ts
+ * return tailWindowSafeExtension({ extensions: [{ name: 'math', level: 'block', tokenizer }] })
+ * ```
  */
 export const tailWindowSafeExtension = (ext: MarkedExtension): MarkedExtension => {
     for (const entry of ext.extensions ?? []) {
@@ -63,6 +72,10 @@ export const tailWindowSafeExtension = (ext: MarkedExtension): MarkedExtension =
  *
  * @param value - Candidate entry from `options.extensions.block`/`.inline`
  * @returns `true` if the entry is a function marked tail-window safe
+ * @example
+ * ```ts
+ * isTailWindowSafe(options.extensions?.block?.[0]) // true only for marked tokenizers
+ * ```
  */
 export const isTailWindowSafe = (value: unknown): boolean =>
     typeof value === 'function' &&

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
     import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
+    import {
+        AlertRenderer,
+        KatexRenderer,
+        markedAlert,
+        markedKatex
+    } from '$lib/extensions/index.js'
     import type {
         HtmlSnippetProps,
         ParagraphSnippetProps,
@@ -7,12 +13,42 @@
         StreamingChunk,
         TextSnippetProps
     } from '$lib/types.js'
+    import { buildParserOptions } from '$lib/utils/extension-options.js'
     import { IncrementalParser } from '$lib/utils/incremental-parser.js'
-    import { Lexer, Slugger, type Token } from '$lib/utils/markdown-parser.js'
+    import {
+        Lexer,
+        type RendererComponent,
+        type Renderers,
+        Slugger,
+        type Token
+    } from '$lib/utils/markdown-parser.js'
     import { parseAndCacheTokens } from '$lib/utils/parse-and-cache.js'
     import { hashString, tokenCache } from '$lib/utils/token-cache.js'
     import { shrinkHtmlTokens } from '$lib/utils/token-cleanup.js'
+    import type { MarkedExtension } from 'marked'
     import { onMount, tick } from 'svelte'
+    // KaTeX stylesheet so the streamed block/inline math in the
+    // `stream-extensions` scenario renders legibly for a human operator.
+    import 'katex/dist/katex.css'
+
+    // Extension-token renderer keys layered onto the built-in Renderers map,
+    // mirroring the katex route's typing idiom.
+    interface StreamExtensionRenderers extends Renderers {
+        inlineKatex: RendererComponent
+        blockKatex: RendererComponent
+        alert: RendererComponent
+    }
+
+    // Built-in extensions exercised by the `stream-extensions` scenario.
+    // Created once so their object identity is stable across renders — a
+    // fresh array/renderer map each render would force the component to
+    // rebuild its IncrementalParser every chunk and defeat the measurement.
+    const STREAM_EXTENSIONS: MarkedExtension[] = [markedKatex(), markedAlert()]
+    const STREAM_EXTENSION_RENDERERS: Partial<StreamExtensionRenderers> = {
+        blockKatex: KatexRenderer,
+        inlineKatex: KatexRenderer,
+        alert: AlertRenderer
+    }
 
     /**
      * Performance baseline fixture for svelte-markdown.
@@ -257,6 +293,40 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
 *Thanks for reading.*
 `
 
+    /**
+     * Streaming corpus that interleaves prose, `$$…$$` block math, inline
+     * `\(…\)` math, and `> [!NOTE]` GitHub alerts — the exact token shapes the
+     * marketed katex/alert extensions handle. Used by the `stream-extensions`
+     * scenario to measure the extension streaming path (which historically
+     * disabled the incremental tail-window and re-lexed the whole accumulated
+     * source per chunk → O(N²) over a stream). Sized near ~4KB so the
+     * per-chunk parse cost visibly grows with document length on the
+     * unoptimized path.
+     */
+    const generateStreamExtensions = (sections: number): string => {
+        const out: string[] = ['# Streaming Extensions Corpus\n']
+        out.push(
+            'This document interleaves prose, block/inline math, and GitHub alerts to exercise the katex + alert extension streaming path.\n'
+        )
+        for (let i = 0; i < sections; i++) {
+            out.push(`## Section ${i}: Field Notes`)
+            out.push(
+                `A paragraph of prose for section ${i} with an inline math reference \\(a_{${i}} = ${i} \\cdot \\pi\\) plus **bold** and a [link](https://example.com/${i}).`
+            )
+            out.push('$$')
+            out.push(`E_{${i}} = mc^2 + \\sum_{k=0}^{${i}} \\frac{k}{${i + 1}}`)
+            out.push('$$\n')
+            out.push(`> [!NOTE]`)
+            out.push(`> Note ${i}: remember to normalize the coefficient before section ${i + 1}.`)
+            out.push('')
+            out.push(
+                `Closing remarks for section ${i}. The renderer must keep the reused prefix stable while the tail grows.`
+            )
+            out.push('')
+        }
+        return out.join('\n')
+    }
+
     // ---- Per-scenario reactive state -----------------------------------------
 
     let source = $state('')
@@ -314,7 +384,18 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         // scenario): wall-clock distribution of inter-chunk gaps.
         streamGapAvgMs: 0,
         streamGapP95Ms: 0,
-        streamGapPeakMs: 0
+        streamGapPeakMs: 0,
+        // stream-extensions scenario only: quadratic-growth diagnostics.
+        // `extParseFirstMs`/`extParseLastMs` are the mean per-chunk parse
+        // times over the first vs last third of the stream; their ratio
+        // (`extGrowthRatio`) is ≈1 when the incremental tail-window is
+        // engaged and climbs with document length when every chunk re-lexes
+        // the whole accumulated source. `extTailWindow` is the human label
+        // derived from that ratio.
+        extParseFirstMs: 0,
+        extParseLastMs: 0,
+        extGrowthRatio: 0,
+        extTailWindow: 'n/a'
     })
 
     // ---- Rolling-10s observer state ------------------------------------------
@@ -348,6 +429,12 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
     // override path and never show up in the bench.
     let useOverrides = $state(false)
 
+    // When true, the live preview mounts SvelteMarkdown with the built-in
+    // katex + alert extensions (and their renderers). Drives the
+    // `stream-extensions` scenario so the extension streaming path is
+    // measured end-to-end, not just in the isolated parse benchmark.
+    let useExtensions = $state(false)
+
     // ---- Helpers --------------------------------------------------------------
 
     const percentile = (values: number[], p: number): number => {
@@ -380,8 +467,29 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             chunkCount: chunks.length,
             totalParseMs,
             p95ParseMs: percentile(parseDurationsMs, 0.95),
-            peakParseMs: parseDurationsMs.length > 0 ? Math.max(...parseDurationsMs) : 0
+            peakParseMs: parseDurationsMs.length > 0 ? Math.max(...parseDurationsMs) : 0,
+            // Per-chunk timings, in stream order — the `stream-extensions`
+            // scenario slices these into first/last thirds to measure whether
+            // per-chunk parse cost scales with document length (the O(N²)
+            // signature) or stays flat (tail-window engaged).
+            parseDurationsMs
         }
+    }
+
+    /**
+     * Mean per-chunk parse time over the first and last third of a stream,
+     * plus their ratio. A ratio near 1 means per-chunk cost does not scale
+     * with accumulated document length (the incremental tail-window is
+     * engaged); a large ratio means every chunk re-lexes the whole source.
+     */
+    const parseGrowthProfile = (durations: number[]) => {
+        const mean = (xs: number[]) =>
+            xs.length === 0 ? 0 : xs.reduce((s, d) => s + d, 0) / xs.length
+        const third = Math.max(1, Math.floor(durations.length / 3))
+        const firstMs = mean(durations.slice(0, third))
+        const lastMs = mean(durations.slice(-third))
+        const ratio = firstMs > 0 ? lastMs / firstMs : 0
+        return { firstMs, lastMs, ratio }
     }
 
     const asHeadingBenchNodes = (value: unknown): HeadingBenchNode[] =>
@@ -463,7 +571,11 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             headingIdMismatches: 0,
             streamGapAvgMs: 0,
             streamGapP95Ms: 0,
-            streamGapPeakMs: 0
+            streamGapPeakMs: 0,
+            extParseFirstMs: 0,
+            extParseLastMs: 0,
+            extGrowthRatio: 0,
+            extTailWindow: 'n/a'
         }
     }
 
@@ -741,6 +853,112 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
     }
 
     /**
+     * Extension streaming scenario (the plan's red measurement). Mirrors
+     * `runStreaming` — same word-chunk cadence at ~30 chunks/sec — but the
+     * corpus interleaves `$$…$$` math, inline `\(…\)` math, and `> [!NOTE]`
+     * alerts, and both the parse benchmark and the live component run with
+     * the katex + alert extensions registered.
+     *
+     * Registering any extension tokenizer historically disabled the
+     * incremental tail-window, so every chunk re-lexed the whole accumulated
+     * source (O(N²) over the stream). The `extGrowthRatio` diagnostic makes
+     * that visible: it stays ≈1 when the tail-window is engaged and climbs
+     * with document length when it is not.
+     */
+    const runStreamingExtensions = async (chunksPerSecondTarget = 30) => {
+        if (isStreaming) return
+        scenario = 'stream-extensions'
+        resetStat()
+        useExtensions = true
+        source = ''
+        tokenCache.clearAllTokens()
+        await tick()
+
+        const corpus = generateStreamExtensions(12)
+        const chunks: string[] = []
+        const re = /\S+\s*/g
+        let match
+        while ((match = re.exec(corpus)) !== null) chunks.push(match[0])
+
+        // Up-front pure-parse benchmark WITH the extensions registered, so the
+        // IncrementalParser exercises the same tail-window decision the live
+        // component makes. Independent of wall-clock pacing.
+        const extOpts = buildParserOptions(
+            { gfm: true, breaks: false, headerIds: true, headerPrefix: '' },
+            STREAM_EXTENSIONS
+        )
+        const bench = benchmarkAppendParse(chunks, extOpts)
+        const growth = parseGrowthProfile(bench.parseDurationsMs)
+        // Tail-window engaged ⇒ per-chunk parse cost does not scale with
+        // document length. Ratio < 1.6 catches that directly. At the very
+        // small absolute times the engaged path produces (a tail re-lex of a
+        // few hundred bytes), timer noise can inflate the ratio, so also treat
+        // a flat last-third mean below FLAT_PARSE_FLOOR_MS as engaged — a full
+        // re-lex of this multi-KB corpus per chunk cannot stay that cheap.
+        const FLAT_PARSE_FLOOR_MS = 0.1
+        const tailWindow =
+            growth.ratio === 0
+                ? 'n/a'
+                : growth.ratio < 1.6 || growth.lastMs < FLAT_PARSE_FLOOR_MS
+                  ? 'engaged'
+                  : 'disabled'
+
+        // Real-time replay against the mounted (extension-enabled) component.
+        const baseDelay = 1000 / chunksPerSecondTarget
+        const renderDurations: number[] = []
+        let i = 0
+        isStreaming = true
+        const startWall = performance.now()
+        await new Promise<void>((resolve) => {
+            const step = async () => {
+                if (!isStreaming || i >= chunks.length) {
+                    resolve()
+                    return
+                }
+                const t0 = performance.now()
+                source += chunks[i]
+                i++
+                await tick()
+                if (!isStreaming) {
+                    resolve()
+                    return
+                }
+                renderDurations.push(performance.now() - t0)
+                streamHandle = setTimeout(() => {
+                    void step()
+                }, baseDelay)
+            }
+            void step()
+        })
+        const wallMs = performance.now() - startWall
+        isStreaming = false
+        if (streamHandle !== null) {
+            clearTimeout(streamHandle)
+            streamHandle = null
+        }
+
+        const renderTotal = renderDurations.reduce((s, d) => s + d, 0)
+        stat = {
+            ...stat,
+            srcKb: round(corpus.length / 1024, 1),
+            streamChunks: chunks.length,
+            streamTotalMs: round(renderTotal),
+            streamAvgMs: round(renderTotal / chunks.length, 3),
+            streamP95Ms: round(percentile(renderDurations, 0.95), 3),
+            streamPeakMs: round(Math.max(...renderDurations), 3),
+            chunksPerSec: round((chunks.length / wallMs) * 1000, 1),
+            parseChunkAvgMs: round(bench.totalParseMs / bench.chunkCount, 3),
+            parseChunkP95Ms: round(bench.p95ParseMs, 3),
+            parseChunkPeakMs: round(bench.peakParseMs, 3),
+            extParseFirstMs: round(growth.firstMs, 4),
+            extParseLastMs: round(growth.lastMs, 4),
+            extGrowthRatio: round(growth.ratio, 2),
+            extTailWindow: tailWindow
+        }
+        scenario = 'stream-extensions-done'
+    }
+
+    /**
      * Bursty streaming variant. Real LLM token streams are not steady
      * — they arrive in 1–10 token bursts separated by 0–200ms pauses,
      * occasionally with a 50+ token slug landing in one chunk after a
@@ -954,6 +1172,7 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         }
         isStreaming = false
         useOverrides = false
+        useExtensions = false
         source = ''
         tokenCache.clearAllTokens()
         resetStat()
@@ -1176,8 +1395,69 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         >
             {isStreaming ? 'Streaming…' : 'Stream large'}
         </button>
+        <button
+            data-testid="stream-extensions"
+            onclick={() => runStreamingExtensions(30)}
+            disabled={isStreaming}
+        >
+            {isStreaming ? 'Streaming…' : 'Stream extensions'}
+        </button>
         <button data-testid="clear" onclick={clear}>Clear</button>
     </div>
+
+    {#if scenario === 'stream-extensions' || scenario === 'stream-extensions-done'}
+        <div
+            class="ext-diag"
+            class:ext-diag--engaged={stat.extTailWindow === 'engaged'}
+            class:ext-diag--disabled={stat.extTailWindow === 'disabled'}
+            data-testid="ext-diagnostics"
+        >
+            <div class="ext-diag__head">
+                <span class="ext-diag__title">Extension streaming — katex + alerts</span>
+                <span class="ext-diag__state">
+                    {scenario === 'stream-extensions-done' ? '✓ done' : '… streaming'}
+                </span>
+            </div>
+            <div class="ext-diag__grid">
+                <div class="ext-diag__cell">
+                    <span class="ext-diag__label">doc size</span>
+                    <span class="ext-diag__value">{stat.srcKb} KB</span>
+                </div>
+                <div class="ext-diag__cell">
+                    <span class="ext-diag__label">chunks</span>
+                    <span class="ext-diag__value">{stat.streamChunks}</span>
+                </div>
+                <div class="ext-diag__cell">
+                    <span class="ext-diag__label">parse avg / chunk</span>
+                    <span class="ext-diag__value">{stat.parseChunkAvgMs} ms</span>
+                </div>
+                <div class="ext-diag__cell">
+                    <span class="ext-diag__label">parse peak / chunk</span>
+                    <span class="ext-diag__value">{stat.parseChunkPeakMs} ms</span>
+                </div>
+                <div class="ext-diag__cell">
+                    <span class="ext-diag__label">parse first⅓ → last⅓</span>
+                    <span class="ext-diag__value">
+                        {stat.extParseFirstMs} → {stat.extParseLastMs} ms
+                    </span>
+                </div>
+                <div class="ext-diag__cell ext-diag__cell--wide">
+                    <span class="ext-diag__label">growth ratio (last⅓ / first⅓)</span>
+                    <span class="ext-diag__value ext-diag__value--ratio">
+                        {stat.extGrowthRatio}×
+                        <span class="ext-diag__badge">
+                            tail-window {stat.extTailWindow}
+                        </span>
+                    </span>
+                </div>
+            </div>
+            <p class="ext-diag__note">
+                Ratio ≈ 1 means per-chunk parse cost is flat as the document grows (incremental
+                tail-window engaged). A ratio that climbs with document length is the O(N²)
+                re-lex-everything signature this scenario exists to catch.
+            </p>
+        </div>
+    {/if}
 
     <div class="stats" data-testid="perf-stats">
         scenario={scenario} srcKb={stat.srcKb} tokenCount={stat.tokenCount} parseColdMs={stat.parseColdMs}
@@ -1191,9 +1471,9 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         chunksPerSec={stat.chunksPerSec} parseChunkAvgMs={stat.parseChunkAvgMs} parseChunkP95Ms={stat.parseChunkP95Ms}
         parseChunkPeakMs={stat.parseChunkPeakMs} headingCount={stat.headingCount}
         headingIdMismatches={stat.headingIdMismatches} streamGapAvgMs={stat.streamGapAvgMs}
-        streamGapP95Ms={stat.streamGapP95Ms} streamGapPeakMs={stat.streamGapPeakMs} · longestTaskMs={longTaskSupported
-            ? displayLongestTaskMs
-            : 'n/a'}
+        streamGapP95Ms={stat.streamGapP95Ms} streamGapPeakMs={stat.streamGapPeakMs} · extParseFirstMs={stat.extParseFirstMs}
+        extParseLastMs={stat.extParseLastMs} extGrowthRatio={stat.extGrowthRatio} extTailWindow={stat.extTailWindow}
+        · longestTaskMs={longTaskSupported ? displayLongestTaskMs : 'n/a'}
         longTasks10s={longTaskSupported ? displayLongTaskCount : 'n/a'} rafP95Ms={displayRafP95Ms}
         mutations10s={displayMutationCount} loaf10s={loafSupported ? displayLoafCount : 'n/a'}
         loafScriptMaxMs={loafSupported ? displayLoafScriptMaxMs : 'n/a'} heapAllocKbPerSec={heapSupported
@@ -1216,7 +1496,21 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
     {/snippet}
 
     <div class="preview" data-testid="perf-preview" bind:this={previewEl}>
-        {#if useOverrides}
+        {#if useExtensions}
+            <!--
+                Extension-streaming scenario: mount with the built-in katex +
+                alert extensions and their renderers so the live component
+                exercises the same tail-window decision the parse benchmark
+                measures.
+            -->
+            <SvelteMarkdown
+                bind:this={markdown}
+                {source}
+                streaming={isStreaming}
+                extensions={STREAM_EXTENSIONS}
+                renderers={STREAM_EXTENSION_RENDERERS}
+            />
+        {:else if useOverrides}
             <!--
                 Slow-path scenario: pass markdown + html snippet overrides
                 so the dispatch in Parser.svelte goes through the
@@ -1295,5 +1589,96 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         border-radius: 0.25rem;
         padding: 0.75rem;
         background: white;
+    }
+    .ext-diag {
+        border: 2px solid #cbd5e0;
+        border-radius: 0.4rem;
+        padding: 0.6rem 0.85rem;
+        background: #f8fafc;
+    }
+    .ext-diag--engaged {
+        border-color: #38a169;
+        background: #f0fff4;
+    }
+    .ext-diag--disabled {
+        border-color: #dd6b20;
+        background: #fffaf0;
+    }
+    .ext-diag__head {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
+    .ext-diag__title {
+        font-weight: 700;
+        font-size: 0.95rem;
+        color: #1a202c;
+    }
+    .ext-diag__state {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: #4a5568;
+    }
+    .ext-diag__grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.5rem;
+    }
+    .ext-diag__cell {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        padding: 0.35rem 0.5rem;
+        background: white;
+        border: 1px solid #e2e8f0;
+        border-radius: 0.3rem;
+    }
+    .ext-diag__cell--wide {
+        grid-column: 1 / -1;
+    }
+    .ext-diag__label {
+        font-size: 0.68rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: #718096;
+    }
+    .ext-diag__value {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 1rem;
+        font-weight: 700;
+        color: #2d3748;
+    }
+    .ext-diag__value--ratio {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-size: 1.35rem;
+    }
+    .ext-diag__badge {
+        font-family: inherit;
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 0.12rem 0.5rem;
+        border-radius: 999px;
+        background: #e2e8f0;
+        color: #2d3748;
+    }
+    .ext-diag--engaged .ext-diag__badge {
+        background: #38a169;
+        color: white;
+    }
+    .ext-diag--disabled .ext-diag__badge {
+        background: #dd6b20;
+        color: white;
+    }
+    .ext-diag__note {
+        margin: 0.5rem 0 0;
+        font-size: 0.72rem;
+        line-height: 1.4;
+        color: #4a5568;
     }
 </style>

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -551,6 +551,13 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         new Promise((resolve) => requestAnimationFrame(() => resolve()))
 
     const resetStat = () => {
+        // Preview modes are mutually exclusive and scenario-owned: every
+        // scenario starts from the default mount, then re-asserts the one
+        // flag it needs (e.g. `useExtensions = true`) after this call.
+        // Without this, a flag set by one scenario leaks into the next and
+        // the live component silently measures the wrong configuration.
+        useOverrides = false
+        useExtensions = false
         stat = {
             srcKb: 0,
             tokenCount: 0,
@@ -824,12 +831,16 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             void step()
         })
         const wallMs = performance.now() - startWall
+        // `clear()` cancels a run by flipping `isStreaming` false mid-stream;
+        // on natural completion it is still true here (we reset it ourselves).
+        // Callers must not publish stats for a cancelled, partial replay.
+        const completed = isStreaming && i === chunks.length
         isStreaming = false
         if (streamHandle !== null) {
             clearTimeout(streamHandle)
             streamHandle = null
         }
-        return { renderDurations, wallMs }
+        return { renderDurations, wallMs, completed }
     }
 
     /** Common stream-scenario stat fields from a replay + parse benchmark. */
@@ -875,7 +886,13 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         const opts = { gfm: true, breaks: false, headerIds: true, headerPrefix: '' }
         const bench = benchmarkAppendParse(chunks, opts)
 
-        const { renderDurations, wallMs } = await replayChunks(chunks, chunksPerSecondTarget)
+        const { renderDurations, wallMs, completed } = await replayChunks(
+            chunks,
+            chunksPerSecondTarget
+        )
+        // A cancelled run means `clear()` already reset the page state —
+        // publishing partial stats would overwrite it with garbage.
+        if (!completed) return
 
         stat = {
             ...stat,
@@ -931,7 +948,13 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
                   ? 'engaged'
                   : 'disabled'
 
-        const { renderDurations, wallMs } = await replayChunks(chunks, chunksPerSecondTarget)
+        const { renderDurations, wallMs, completed } = await replayChunks(
+            chunks,
+            chunksPerSecondTarget
+        )
+        // A cancelled run means `clear()` already reset the page state —
+        // publishing partial stats would overwrite it with garbage.
+        if (!completed) return
 
         stat = {
             ...stat,
@@ -1079,7 +1102,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         if (isStreaming) return
         scenario = 'stream-large'
         resetStat()
-        useOverrides = false
         source = ''
         tokenCache.clearAllTokens()
         isStreaming = true
@@ -1155,8 +1177,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             streamHandle = null
         }
         isStreaming = false
-        useOverrides = false
-        useExtensions = false
         source = ''
         tokenCache.clearAllTokens()
         resetStat()

--- a/src/routes/test/perf-bench/+page.svelte
+++ b/src/routes/test/perf-bench/+page.svelte
@@ -449,16 +449,27 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         return Math.round(n * m) / m
     }
 
+    /** Splits text into word-sized chunks (word + trailing whitespace). */
+    const wordChunks = (text: string): string[] => {
+        const chunks: string[] = []
+        const re = /\S+\s*/g
+        let match
+        while ((match = re.exec(text)) !== null) chunks.push(match[0])
+        return chunks
+    }
+
     const benchmarkAppendParse = (chunks: string[], options: SvelteMarkdownOptions) => {
         const parser = new IncrementalParser(options)
         const parseDurationsMs: number[] = []
+        let tailWindowChunks = 0
         let streamedSource = ''
 
         for (const chunk of chunks) {
             streamedSource += chunk
             const start = performance.now()
-            parser.update(streamedSource)
+            const result = parser.update(streamedSource)
             parseDurationsMs.push(performance.now() - start)
+            if (result.usedTailWindow) tailWindowChunks++
         }
 
         const totalParseMs = parseDurationsMs.reduce((sum, duration) => sum + duration, 0)
@@ -468,6 +479,9 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             totalParseMs,
             p95ParseMs: percentile(parseDurationsMs, 0.95),
             peakParseMs: parseDurationsMs.length > 0 ? Math.max(...parseDurationsMs) : 0,
+            // Ground truth from the parser: how many appends re-lexed only the
+            // tail. The first chunk always full-parses (empty prevSource).
+            tailWindowChunks,
             // Per-chunk timings, in stream order — the `stream-extensions`
             // scenario slices these into first/last thirds to measure whether
             // per-chunk parse cost scales with document length (the O(N²)
@@ -773,31 +787,14 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
     }
 
     /**
-     * Real-time streaming scenario. Word-chunks the corpus, appends one
-     * chunk per tick at ~30 chunks/sec, and times each parse+render
-     * cycle. The live SvelteMarkdown component is mounted in streaming
-     * mode so the IncrementalParser is exercised. Rolling observers
-     * pick up longtasks/rAF/mutations during the run.
+     * Steady-cadence replay of pre-split chunks against the mounted
+     * component: appends one chunk to `source` per timer tick, measuring
+     * the render duration of each append. Shared by `runStreaming` and
+     * `runStreamingExtensions` (the bursty variant owns its own jittered
+     * loop). Bails if `clear()` flips `isStreaming` mid-stream — see the
+     * note in `runStreamingBursty`.
      */
-    const runStreaming = async (chunksPerSecondTarget = 30) => {
-        if (isStreaming) return
-        scenario = 'stream-30tps'
-        resetStat()
-        source = ''
-        tokenCache.clearAllTokens()
-        await tick()
-
-        const chunks: string[] = []
-        const re = /\S+\s*/g
-        let match
-        while ((match = re.exec(STREAM_CORPUS)) !== null) chunks.push(match[0])
-
-        // Up-front pure-parse benchmark for percentiles independent of
-        // wall-clock pacing. Doesn't touch the live component.
-        const opts = { gfm: true, breaks: false, headerIds: true, headerPrefix: '' }
-        const bench = benchmarkAppendParse(chunks, opts)
-
-        // Real-time replay against the mounted component
+    const replayChunks = async (chunks: string[], chunksPerSecondTarget: number) => {
         const baseDelay = 1000 / chunksPerSecondTarget
         const renderDurations: number[] = []
         let i = 0
@@ -805,8 +802,6 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         const startWall = performance.now()
         await new Promise<void>((resolve) => {
             const step = async () => {
-                // Bail if `clear()` ran mid-stream — same race as the
-                // bursty variant. See note in `runStreamingBursty`.
                 if (!isStreaming || i >= chunks.length) {
                     resolve()
                     return
@@ -834,11 +829,18 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             clearTimeout(streamHandle)
             streamHandle = null
         }
+        return { renderDurations, wallMs }
+    }
 
+    /** Common stream-scenario stat fields from a replay + parse benchmark. */
+    const streamReplayStats = (
+        chunks: string[],
+        renderDurations: number[],
+        wallMs: number,
+        bench: ReturnType<typeof benchmarkAppendParse>
+    ) => {
         const renderTotal = renderDurations.reduce((s, d) => s + d, 0)
-        stat = {
-            ...stat,
-            srcKb: round(STREAM_CORPUS.length / 1024, 1),
+        return {
             streamChunks: chunks.length,
             streamTotalMs: round(renderTotal),
             streamAvgMs: round(renderTotal / chunks.length, 3),
@@ -848,6 +850,37 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
             parseChunkAvgMs: round(bench.totalParseMs / bench.chunkCount, 3),
             parseChunkP95Ms: round(bench.p95ParseMs, 3),
             parseChunkPeakMs: round(bench.peakParseMs, 3)
+        }
+    }
+
+    /**
+     * Real-time streaming scenario. Word-chunks the corpus, appends one
+     * chunk per tick at ~30 chunks/sec, and times each parse+render
+     * cycle. The live SvelteMarkdown component is mounted in streaming
+     * mode so the IncrementalParser is exercised. Rolling observers
+     * pick up longtasks/rAF/mutations during the run.
+     */
+    const runStreaming = async (chunksPerSecondTarget = 30) => {
+        if (isStreaming) return
+        scenario = 'stream-30tps'
+        resetStat()
+        source = ''
+        tokenCache.clearAllTokens()
+        await tick()
+
+        const chunks = wordChunks(STREAM_CORPUS)
+
+        // Up-front pure-parse benchmark for percentiles independent of
+        // wall-clock pacing. Doesn't touch the live component.
+        const opts = { gfm: true, breaks: false, headerIds: true, headerPrefix: '' }
+        const bench = benchmarkAppendParse(chunks, opts)
+
+        const { renderDurations, wallMs } = await replayChunks(chunks, chunksPerSecondTarget)
+
+        stat = {
+            ...stat,
+            srcKb: round(STREAM_CORPUS.length / 1024, 1),
+            ...streamReplayStats(chunks, renderDurations, wallMs, bench)
         }
         scenario = 'stream-30tps-done'
     }
@@ -875,10 +908,7 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         await tick()
 
         const corpus = generateStreamExtensions(12)
-        const chunks: string[] = []
-        const re = /\S+\s*/g
-        let match
-        while ((match = re.exec(corpus)) !== null) chunks.push(match[0])
+        const chunks = wordChunks(corpus)
 
         // Up-front pure-parse benchmark WITH the extensions registered, so the
         // IncrementalParser exercises the same tail-window decision the live
@@ -889,67 +919,24 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         )
         const bench = benchmarkAppendParse(chunks, extOpts)
         const growth = parseGrowthProfile(bench.parseDurationsMs)
-        // Tail-window engaged ⇒ per-chunk parse cost does not scale with
-        // document length. Ratio < 1.6 catches that directly. At the very
-        // small absolute times the engaged path produces (a tail re-lex of a
-        // few hundred bytes), timer noise can inflate the ratio, so also treat
-        // a flat last-third mean below FLAT_PARSE_FLOOR_MS as engaged — a full
-        // re-lex of this multi-KB corpus per chunk cannot stay that cheap.
-        const FLAT_PARSE_FLOOR_MS = 0.1
+        // Engagement is reported as fact from the parser (`usedTailWindow` per
+        // append), not inferred from timings. The first chunk always
+        // full-parses (empty prevSource), so "engaged" means the overwhelming
+        // majority of appends re-lexed only the tail. The growth ratio stays
+        // purely a performance metric alongside it.
         const tailWindow =
-            growth.ratio === 0
+            bench.chunkCount === 0
                 ? 'n/a'
-                : growth.ratio < 1.6 || growth.lastMs < FLAT_PARSE_FLOOR_MS
+                : bench.tailWindowChunks >= bench.chunkCount * 0.9
                   ? 'engaged'
                   : 'disabled'
 
-        // Real-time replay against the mounted (extension-enabled) component.
-        const baseDelay = 1000 / chunksPerSecondTarget
-        const renderDurations: number[] = []
-        let i = 0
-        isStreaming = true
-        const startWall = performance.now()
-        await new Promise<void>((resolve) => {
-            const step = async () => {
-                if (!isStreaming || i >= chunks.length) {
-                    resolve()
-                    return
-                }
-                const t0 = performance.now()
-                source += chunks[i]
-                i++
-                await tick()
-                if (!isStreaming) {
-                    resolve()
-                    return
-                }
-                renderDurations.push(performance.now() - t0)
-                streamHandle = setTimeout(() => {
-                    void step()
-                }, baseDelay)
-            }
-            void step()
-        })
-        const wallMs = performance.now() - startWall
-        isStreaming = false
-        if (streamHandle !== null) {
-            clearTimeout(streamHandle)
-            streamHandle = null
-        }
+        const { renderDurations, wallMs } = await replayChunks(chunks, chunksPerSecondTarget)
 
-        const renderTotal = renderDurations.reduce((s, d) => s + d, 0)
         stat = {
             ...stat,
             srcKb: round(corpus.length / 1024, 1),
-            streamChunks: chunks.length,
-            streamTotalMs: round(renderTotal),
-            streamAvgMs: round(renderTotal / chunks.length, 3),
-            streamP95Ms: round(percentile(renderDurations, 0.95), 3),
-            streamPeakMs: round(Math.max(...renderDurations), 3),
-            chunksPerSec: round((chunks.length / wallMs) * 1000, 1),
-            parseChunkAvgMs: round(bench.totalParseMs / bench.chunkCount, 3),
-            parseChunkP95Ms: round(bench.p95ParseMs, 3),
-            parseChunkPeakMs: round(bench.peakParseMs, 3),
+            ...streamReplayStats(chunks, renderDurations, wallMs, bench),
             extParseFirstMs: round(growth.firstMs, 4),
             extParseLastMs: round(growth.lastMs, 4),
             extGrowthRatio: round(growth.ratio, 2),
@@ -990,10 +977,7 @@ For more, see the [Svelte docs](https://svelte.dev/docs).
         // (occasionally up to 50) into chunks. Each chunk gets a
         // delay drawn from {short: [5,30], medium: [30,80], long: [80,200]}
         // weighted toward short (so the average is realistic).
-        const words: string[] = []
-        const re = /\S+\s*/g
-        let match
-        while ((match = re.exec(STREAM_CORPUS)) !== null) words.push(match[0])
+        const words = wordChunks(STREAM_CORPUS)
 
         const chunks: string[] = []
         const chunkDelays: number[] = []


### PR DESCRIPTION
## Summary

Registering **any** extension tokenizer used to disable the streaming tail-window, so the marketed LLM-streaming use cases (KaTeX math, alerts, Mermaid) silently re-lexed the entire accumulated document on every chunk — O(N²) over a stream. This PR keeps extension streams incremental and makes the cost visible:

1. **Bench coverage**: new `stream-extensions` scenario (KaTeX + alerts corpus, same cadence as `stream-30tps`) with an on-page diagnostic panel — per-chunk stats, first⅓→last⅓ growth ratio, and a tail-window engaged/disabled badge.
2. **Metadata prefix-skip decoupled from the tail-window**: `divergeOffset` is now also computed on the full-reparse path (guarded to `undefined` on unknown HTML source spans), so append-only updates skip prefix render-metadata work even when the tail-window is bypassed.
3. **`TAIL_WINDOW_SAFE` tokenizer markers**: marked's `use()` stores tokenizer *function references*, so the marker lives on the function. KaTeX, alert, and Mermaid opt in (block-anchored, stateless). Footnote (cross-block ref/def state) and all custom extensions keep the conservative full reparse.

**Measured** (guard re-ran the official bench): `stream-extensions` parse cost per chunk 0.036 ms with growth ratio **1.28× (tail-window engaged)** — on par with plain-markdown `stream-30tps` (0.036 ms). Executor baseline before the change: ~0.15 ms/chunk with growth ratio **2.5–3× (disabled)**, the O(N²) signature.

Executed by an Opus 4.8 agent from plan `003-extension-streaming-incremental` (bigger-faster-stronger batch) under guard supervision. Parity tests pin streamed tokens deep-equal to one-shot lexing, including chunks split mid-math and mid-alert.

## Changes

- ⚡ `src/lib/utils/incremental-parser.ts` — per-extension tail-window gating; full-reparse-path `divergeOffset` with unknown-span guard
- ⚡ `src/lib/types.ts` — `TAIL_WINDOW_SAFE` symbol + `markTailWindowSafe`/`isTailWindowSafe` helpers
- ⚡ `src/lib/extensions/{katex,alert,mermaid}/marked*.ts` — mark tokenizer functions tail-safe (footnote deliberately untouched)
- 🧪 `src/lib/utils/incremental-parser.test.ts` — 11 new tests: extension parity (3), divergeOffset semantics (2), tail-window engagement/safety matrix (6, incl. footnote and unmarked-custom staying on full reparse)
- 🧪 `src/routes/test/perf-bench/+page.svelte` + `scripts/perf-bench.mjs` — `stream-extensions` scenario + loud diagnostic panel (route: `/test/perf-bench`, button "Stream extensions")

## Verification

- `pnpm test` → 142 files / 930 tests, coverage gates hold; `pnpm check` → 0 errors; `trunk check` → no issues (13 files)
- `pnpm perf:bench` → exit 0; `stream-extensions` engaged with flat growth (guard-reproduced)
- Streaming DOM-identity canaries (`SvelteMarkdown.streaming-html.test.ts`) stay green — 25/25

## Commits

- [`c6c28bc`](https://github.com/humanspeak/svelte-markdown/commit/c6c28bc) perf(streaming): keep extension streams incremental via tail-safe markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
