### PR TITLE
fix(cache): hasTokens verifies source like getTokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,12 @@ tokenCache.deleteTokens(markdown, options)
 const myCache = new TokenCache({ maxSize: 100, ttl: 10 * 60 * 1000 })
 ```
 
+> **Note (v1.7.12+):** cache entries store the source string alongside its
+> tokens so a hit is verified against hash collisions — `getTokens`,
+> `setTokens`, and `hasTokens` are the supported token API. The raw
+> `get()`/`set()` methods inherited from `MemoryCache` now operate on the
+> wrapped `{ source, tokens }` entry shape, not bare token arrays.
+
 ### Smart Image Lazy Loading
 
 Images automatically lazy load using native `loading="lazy"` and IntersectionObserver prefetching, with a smooth fade-in animation and error state handling. To disable lazy loading, provide a custom Image renderer:

--- a/src/lib/utils/token-cache.test.ts
+++ b/src/lib/utils/token-cache.test.ts
@@ -501,5 +501,19 @@ describe('TokenCache', () => {
             // that a returned entry always matches the requested source.
             expect(cache.getTokens(COLLISION_A, options)).toBeUndefined()
         })
+
+        it('hasTokens agrees with getTokens for a colliding different source', () => {
+            const options: SvelteMarkdownOptions = {}
+            const tokensA: Token[] = [{ type: 'heading', raw: COLLISION_A, depth: 1, text: 'A' }]
+
+            cache.setTokens(COLLISION_A, options, tokensA)
+
+            // hasTokens must apply the same source verification as getTokens:
+            // reporting a hit that getTokens would refuse to serve is the
+            // inconsistency this test pins.
+            expect(cache.hasTokens(COLLISION_A, options)).toBe(true)
+            expect(cache.hasTokens(COLLISION_B, options)).toBe(false)
+            expect(cache.getTokens(COLLISION_B, options)).toBeUndefined()
+        })
     })
 })

--- a/src/lib/utils/token-cache.ts
+++ b/src/lib/utils/token-cache.ts
@@ -228,12 +228,16 @@ export class TokenCache extends MemoryCache<TokenCacheEntry> {
     }
 
     /**
-     * Checks if tokens are cached without retrieving them.
+     * Checks if tokens are cached for this exact source.
      * Useful for cache statistics or conditional logic.
+     *
+     * Applies the same source verification as {@link getTokens}: a hash
+     * collision with a different document reports `false`, so `hasTokens`
+     * can never claim a hit that `getTokens` would refuse to serve.
      *
      * @param source - Raw markdown string
      * @param options - Svelte markdown parser options
-     * @returns True if cached and not expired
+     * @returns True if this source's tokens are cached and not expired
      *
      * @example
      * ```typescript
@@ -243,8 +247,7 @@ export class TokenCache extends MemoryCache<TokenCacheEntry> {
      * ```
      */
     hasTokens(source: string, options: SvelteMarkdownOptions): boolean {
-        const key = getCacheKey(source, options)
-        return this.has(key)
+        return this.getTokens(source, options) !== undefined
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #358, prompted by a CodeRabbit finding on the #359 review. Two loose ends from the token-cache collision guard:

1. **`hasTokens` inconsistency**: it still checked only the hash key, so it could return `true` for a colliding different source that `getTokens` (correctly) refuses to serve. It now delegates to `getTokens`, applying the same source verification — the two methods can no longer disagree.
2. **Documentation of the entry-shape change**: since v1.7.12, `TokenCache` entries wrap tokens as `{ source, tokens }`. The raw `get()`/`set()` inherited from `MemoryCache` (public via the exported class) therefore operate on the wrapped shape. The README's caching section now states this and names `getTokens`/`setTokens`/`hasTokens` as the supported token API.

## Changes

- 🔒 `src/lib/utils/token-cache.ts` — `hasTokens` delegates to `getTokens` (same collision guard); JSDoc updated
- 🧪 `src/lib/utils/token-cache.test.ts` — regression test using the verified FNV-1a collision pair: `hasTokens` must agree with `getTokens`
- 📚 `README.md` — note on the v1.7.12 entry shape and supported cache surface

## Verification

- Red-first: the new test failed before the fix (`hasTokens` returned `true` for the colliding source)
- `pnpm test` → 142 files pass with coverage gates; `pnpm check` → 0 errors; `trunk check` → no new issues

## Commits

- fix(cache): hasTokens verifies source like getTokens; document entry shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
