### PR TITLE
feat(extensions): shiki syntax highlighting, streaming-compatible

### DIFF
--- a/.agents/.plans/bigger-faster-stronger/004-shiki-spike-report.md
+++ b/.agents/.plans/bigger-faster-stronger/004-shiki-spike-report.md
@@ -1,0 +1,260 @@
+# Plan 004 — Shiki syntax-highlighting extension: spike design report
+
+> **Status: spike complete, prototype working.** The renderer highlights code
+> synchronously, keeps `streaming` enabled (no async-extension warning), passes
+> DOM-parity and memoization tests, and stays out of the core bundle. It is
+> **not shipped**: the subpath is unexported, `package.json` `exports` and the
+> `extensions` barrel are untouched, and `shiki` is a `devDependency` only.
+> Shipping is the follow-up decision this report scopes.
+>
+> The one material caveat is **per-block highlight cost** with the synchronous
+> JS regex engine — see [Measured numbers](#measured-numbers) and
+> [STOP condition hit](#stop-condition-hit-frame-budget). It does not sink the
+> design (memoization contains it and there is a faster still-streaming-safe
+> engine), but it must be a conscious ship decision.
+
+## What was built
+
+`src/lib/extensions/shiki/`:
+
+- `createShikiHighlighter.ts` — wraps Shiki's **synchronous** core
+  (`createHighlighterCoreSync` from `shiki/core`) with the pure-JS regex engine
+  (`createJavaScriptRegexEngine` from `shiki/engine/javascript`). Consumer
+  supplies explicitly-imported `langs`/`themes`. Returns a tiny
+  `{ highlight(code, lang), hasLang(lang) }` facade. Unregistered/empty langs
+  and any per-block failure degrade to an **escaped** `<pre class="shiki-fallback">`
+  — never throws mid-stream. Also exports `escapeHtml`.
+- `ShikiCode.svelte` — a `code`-token renderer with the exact `Props` shape of
+  the built-in `Code.svelte` (`lang`, `text`), plus an optional `highlighter`
+  prop. `html` is `$derived` purely from `(text, lang, resolved)`, so unchanged
+  blocks are not re-highlighted. Renders via `{@html}`.
+- `shikiContext.ts` — highlighter injection channels: `SHIKI_CONTEXT_KEY`
+  (Svelte context) and a module singleton (`setShikiHighlighter` /
+  `getShikiHighlighter`).
+- `index.ts` — local barrel (deliberately **not** wired into the package
+  `extensions` barrel).
+
+Usage is the standard custom-renderers prop — no new component API:
+
+```svelte
+setShikiHighlighter(createShikiHighlighter({ langs: [js, ts], themes: [githubDark] }))
+<SvelteMarkdown {source} renderers={{ code: ShikiCode }} />
+```
+
+Because highlighting is a renderer concern only (no marked tokenizer, no
+`walkTokens`), the streaming tail-window logic in `incremental-parser.ts` is
+untouched and `SvelteMarkdown`'s `hasAsyncExtension` guard never trips.
+
+## Shiki API findings
+
+- **Installed version**: `shiki@4.3.1`. The synchronous core API the design
+  depends on **exists**: `createHighlighterCoreSync` is exported from
+  `shiki/core`. STOP condition ("no synchronous core API") **not** hit.
+- **Engine**: `createJavaScriptRegexEngine()` (`shiki/engine/javascript`) is a
+  fully synchronous regex engine — no WASM, no top-level `await`. This is the
+  piece that keeps `highlighter.codeToHtml` synchronous and therefore
+  streaming-safe.
+- **Langs/themes wiring**: consumer does explicit ESM imports, e.g.
+  `import js from 'shiki/langs/javascript.mjs'`,
+  `import githubDark from 'shiki/themes/github-dark.mjs'`, and passes them as
+  `{ langs, themes }`. Only what is imported is bundled. Language **aliases**
+  come for free — registering `javascript` also matches `js`/`cjs`/`mjs`
+  (`getLoadedLanguages()` includes them), so `hasLang('js')` is `true`.
+- **Type quirk**: Shiki's sync-mode option types demand already-resolved
+  registrations (`MaybeArray<LanguageRegistration>[]`), but the sync loader also
+  accepts the `{ default: … }` ESM module shape a consumer actually gets from
+  `import js from 'shiki/langs/*.mjs'` (verified at runtime). The wrapper keeps
+  the ergonomic `LanguageInput`/`ThemeInput` public types and bridges that quirk
+  with a single documented cast.
+- **SSR**: the sync core runs server-side with no special handling — the demo
+  route server-renders fully-highlighted `class="shiki"` markup (confirmed via a
+  server fetch, no client JS). No WASM means no SSR asset/loader concerns. This
+  is a real advantage of the JS-engine path over the WASM/oniguruma path.
+
+## Measured numbers
+
+Measured in this worktree (`shiki@4.3.1`, Node 24, `github-dark`, JS regex
+engine unless noted).
+
+### Bundle size added (1 theme + 2 langs)
+
+A minified bundle of `createHighlighterCoreSync` + JS engine + `javascript` +
+`typescript` langs + `github-dark` theme:
+
+| Metric   | Size         |
+| -------- | ------------ |
+| Minified | **516.2 KB** |
+| Gzipped  | **84.8 KB**  |
+
+This is dominated by the TextMate grammars (js/ts are large) and the JS regex
+engine. It is far larger than the core package's "~15KB" positioning — which is
+exactly why highlighting **must** be an opt-in, explicitly-imported subpath and
+must never touch the default `Code` renderer. The tree-shaking guard
+(`core component stays shiki-free`) enforces this: the core `SvelteMarkdown`
+bundle contains zero `shiki`/`@shikijs` modules.
+
+### Per-block highlight cost — JS regex engine (synchronous)
+
+One-time highlighter setup: **~16.6 ms**. Per `codeToHtml` (warm, avg):
+
+| Block size | ms/call | ms/line |
+| ---------- | ------- | ------- |
+| 10 lines   | ~16.9   | ~1.7    |
+| 30 lines   | ~38.4   | ~1.3    |
+| 60 lines   | ~97.9   | ~1.6    |
+| 100 lines  | ~121.8  | ~1.2    |
+| 200 lines  | ~137.3  | ~0.7    |
+
+Roughly linear at **~1.2–1.7 ms/line**. A ~100-line block (~122 ms) is ~7.6×
+one 16 ms frame. **A single non-trivial block exceeds the streaming frame
+budget when it is (re)highlighted.**
+
+### Per-block highlight cost — oniguruma WASM engine (comparison, not shipped)
+
+The WASM oniguruma engine requires an **async one-time WASM load** (~70 ms), but
+per-block `codeToHtml` stays **synchronous** afterward — so a "load WASM once at
+setup, highlight synchronously per block" shape is **still streaming-safe** (the
+async is in setup, not in a marked `walkTokens` extension). It is ~2.5× faster
+per block:
+
+| Block size | JS engine | oniguruma (sync after WASM load) |
+| ---------- | --------- | -------------------------------- |
+| 10 lines   | ~16.9 ms  | ~5.3 ms                          |
+| 30 lines   | ~38.4 ms  | ~14.2 ms                         |
+| 100 lines  | ~121.8 ms | ~48.6 ms                         |
+
+Still over the frame budget for large blocks, but materially cheaper. This is
+the single biggest lever for the ship decision (see open questions).
+
+### Streaming test outcome
+
+`ShikiCode.test.ts` (5 tests, all green):
+
+- **Streaming compatibility (load-bearing)**: `<SvelteMarkdown streaming>` with
+  `renderers={{ code: ShikiCode }}`, streamed word-by-word, produces **no**
+  async-extension console warning and DOM **identical** to the non-streaming
+  render (normalized). Proves `streaming` stays enabled and output is at parity.
+- **Memoization survives token churn (load-bearing)**: after a code fence
+  completes, streaming trailing prose does **not** re-invoke `highlight()` for
+  the unchanged block (spy on the highlighter; zero re-highlights of the final
+  code text). Confirms the `(text, lang)` `$derived` memo pays off because the
+  incremental parser preserves the completed block's component/token identity.
+- Component happy-path, unregistered-lang fallback, no-highlighter degradation,
+  and `<script>`-never-mounted.
+
+`createShikiHighlighter.test.ts` (10 tests, all green): happy path with token
+spans, alias resolution, unregistered fallback, empty lang, `<script>` escaped
+(shiki emits `&#x3C;`), and **adversarial-lang injection** — crafted info
+strings (`"><img src=x onerror=…>`, `'><svg onload=…>`, etc.) never appear
+verbatim, never form a raw `<img>/<svg>/<script>`, and surface only as an
+escaped `data-lang` attribute value.
+
+### Tree-shaking
+
+`pnpm test:tree-shaking` — all 6 cases pass, including the new
+`core component stays shiki-free` case asserting the core `SvelteMarkdown`
+bundle excludes `node_modules/shiki` and `node_modules/@shikijs`.
+
+## Security — the `{@html}` sink
+
+`ShikiCode` injects the highlighter's HTML string via `{@html}`, the same sink
+`KatexRenderer.svelte:40` and `MermaidRenderer.svelte:80` already use. The trust
+argument is the same **and** slightly stronger:
+
+- **Code text**: Shiki tokenizes and **escapes** the code it emits (it produces
+  `&#x3C;` for `<`), so user/agent code content is never live markup. The
+  unregistered-lang **fallback** independently HTML-escapes the code text.
+- **The `lang` (fenced info string) is untrusted** — in this package's headline
+  agent/LLM-streaming use case it is attacker-influenced. The fallback path
+  **escapes, never interpolates** `lang` (emitted only as an escaped `data-lang`
+  attribute); the registered path passes `lang` to Shiki as a lookup key, not
+  into markup. Covered by dedicated adversarial-injection tests.
+- Net: the `{@html}` sink only ever receives library-generated (Shiki) or
+  explicitly-escaped markup — same trust class as the existing KaTeX/Mermaid
+  renderers. **Recommendation**: document this explicitly on the ship docs page
+  (as KaTeX/Mermaid are), and keep the fallback's escape-only guarantee under
+  test so a future refactor can't silently start interpolating `lang`.
+
+## Ship checklist (for the follow-up plan)
+
+- [ ] `package.json`: move `shiki` from `devDependencies` to an **optional peer
+      dependency** — mirror KaTeX exactly: `peerDependencies.shiki` +
+      `peerDependenciesMeta.shiki.optional: true`.
+- [ ] `package.json` `exports`: add `./extensions/shiki` subpath (mirror
+      `./extensions/katex`).
+- [ ] `src/lib/extensions/index.ts`: export `ShikiCode`, `createShikiHighlighter`,
+      and the injection helpers from the barrel.
+- [ ] README.md + docs site: usage page (explicit lang/theme imports, injection
+      choice, the `{@html}`/escaping security note, the per-block cost caveat and
+      recommended block-size / engine guidance).
+- [ ] `docs/src/lib/compare-data.ts`: flip the three "no built-in code
+      highlighting" cons (lines ~128, ~481, ~639) and the Code Highlighting row
+      (~103–105) now that a first-party extension exists.
+- [ ] Decide the **injection API** to document as canonical (see open questions)
+      and trim the spike's other channels if desired.
+- [ ] Decide the **engine** (JS vs oniguruma-WASM) — see open questions.
+- [ ] Keep the tree-shaking `core component stays shiki-free` case.
+
+## Open questions
+
+1. **Highlighter injection — which one is canonical?** The spike ships three
+   (prop, context, singleton). The renderers-map only forwards `lang`/`text`, so
+   the prop is only reachable via a user wrapper. **Recommendation**: document
+   the **module singleton** (`setShikiHighlighter`) as the simple default and
+   **Svelte context** (`SHIKI_CONTEXT_KEY`) for apps needing per-subtree themes
+   (e.g. SSR request isolation, multiple themes on one page). Keep the prop as an
+   escape hatch.
+2. **Engine choice — JS regex vs oniguruma WASM.** The JS engine is
+   zero-WASM/SSR-trivial but ~2.5× slower per block; oniguruma is faster and
+   still streaming-safe (async load once, sync per block) but adds a WASM asset
+   and an async setup step. **Recommendation**: default to the **JS engine** for
+   SSR simplicity and document oniguruma as an opt-in for highlight-heavy,
+   client-rendered apps.
+3. **Frame budget for the actively-streaming block.** Memoization protects
+   _completed_ blocks, but the block currently being streamed is re-highlighted
+   on each chunk, and a large block blows the budget. **Options to evaluate at
+   ship time** (all renderer-level, none touch streaming internals): (a) render
+   a plain escaped `<pre>` while the fence is still open and highlight once on
+   completion (detectable because an open fence yields a growing `code` token);
+   (b) size/line threshold above which highlighting is deferred or skipped;
+   (c) oniguruma engine to cut the constant. Worker offload is explicitly out of
+   scope.
+4. **Dual light/dual-dark themes.** Shiki's `codeToHtml` supports a `themes`
+   (multi-theme) mode with CSS variables for automatic light/dark. Not spiked;
+   worth exposing so consumers get theme-aware output without re-highlighting.
+5. **Lazy language registration.** All langs are registered up front. Shiki
+   supports incremental `loadLanguage`, but that is async — incompatible with the
+   sync render path unless pre-registered. Likely stays "import what you need."
+6. **Bench corpus.** If Plan 003 landed, a code-heavy corpus in the
+   `stream-extensions` bench would quantify the streaming cost of the
+   actively-highlighting block — noted here, not done in this spike.
+
+## STOP condition hit: frame budget
+
+Per the plan's second STOP condition ("synchronous highlighting of a typical
+block costs enough to visibly blow the streaming frame budget — report numbers;
+a memoization-only mitigation is in scope"): **the numbers confirm the concern**
+(a ~100-line block ≈ 122 ms with the JS engine, ~7.6 frames). Per the plan this
+is a **report-and-continue**, not an abort: memoization (implemented) contains
+the cost for completed blocks, and the report documents the residual
+actively-streaming-block cost plus mitigations (open question 3) and the faster
+still-sync oniguruma alternative (open question 2). No worker offload was
+attempted (out of scope). No other STOP conditions were hit — the sync core API
+exists, and the streaming parity test passes without touching streaming
+internals.
+
+## Verification (all green in this worktree)
+
+| Gate                       | Result                                                      |
+| -------------------------- | ----------------------------------------------------------- |
+| `pnpm check`               | 0 errors (4 pre-existing warnings in unrelated files)       |
+| `pnpm test`                | 144 files, 958 tests pass; coverage 96.13/90.44/96.29/97.69 |
+| `pnpm test:tree-shaking`   | all 6 cases pass (incl. `core component stays shiki-free`)  |
+| `trunk fmt && trunk check` | no issues on the 10 changed files                           |
+| `pnpm perf:bench`          | completes; core scenarios unaffected                        |
+
+**Demo route for human inspection**: `src/routes/test/shiki-spike/+page.svelte`
+(`/test/shiki-spike`) — registered JS/TS/JSON blocks, unregistered-lang
+fallback, adversarial-lang case (with the escaped sink output shown), a
+sync-engaged / no-async-warning indicator, live per-block timing, and a live
+code-heavy streaming demo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,9 @@ src/
 │   │   └── html/             # HTML element renderers
 │   │       └── *.svelte      # Individual HTML tags (Div, Span, etc.)
 │   └── utils/                # Utility functions
-│       ├── markdown-parser.js
+│       ├── markdown-parser.ts
+│       ├── incremental-parser.ts # Streaming tail-window parser
+│       ├── sanitize.ts       # Default URL/attribute sanitizers
 │       ├── token-cache.ts    # LRU caching for parsed tokens
 │       ├── cache.ts          # Generic memory cache
 │       ├── rendererKeys.ts   # Canonical renderer key lists
@@ -140,7 +142,11 @@ buildUnsupportedRenderers() // Block all markdown renderers
 
 The following are explicitly out of scope:
 
-- Built-in HTML sanitization (provide hooks instead)
+- A bundled full DOM sanitizer (e.g. DOMPurify). The library ships
+  safe-by-default URL/attribute sanitization (`src/lib/utils/sanitize.ts`,
+  wired as prop defaults) — but full HTML sanitization of untrusted input
+  stays the consumer's responsibility, layered via the `sanitizeUrl` /
+  `sanitizeAttributes` hooks or an external sanitizer.
 - Remote fetching of markdown documents
 - WYSIWYG editor functionality
 
@@ -148,7 +154,7 @@ The following are explicitly out of scope:
 
 1. **`src/lib/index.ts`** - All public exports
 2. **`src/lib/SvelteMarkdown.svelte`** - Main component implementation
-3. **`src/lib/utils/markdown-parser.js`** - Token parsing logic
+3. **`src/lib/utils/markdown-parser.ts`** - Token parsing logic
 4. **`src/lib/renderers/`** - Individual renderer components
 5. **`README.md`** - Usage documentation
 
@@ -157,13 +163,18 @@ The following are explicitly out of scope:
 - Tests required for new features
 - Coverage must remain at 90%+
 - Pre-commit hooks will format code automatically
-- CI runs on Node 20, 22, and 24
+- CI runs on Node 22 and 24 (`engines`: node >=22)
 - Package published automatically on release via GitHub Actions
 - **README.md must be updated** when adding new features, props, or public API changes
 
 ## Security Considerations
 
-- No built-in HTML sanitization by default
-- XSS protection through secure parsing
-- Users should integrate their own sanitizer if needed
+- Safe-by-default sanitization ships enabled: `defaultSanitizeUrl` (protocol
+  allowlist blocking `javascript:`/`data:`/`vbscript:`) and
+  `defaultSanitizeAttributes` (strips `on*` handlers and `srcdoc`, sanitizes
+  URL attributes) are the default `sanitizeUrl`/`sanitizeAttributes` props —
+  see `src/lib/utils/sanitize.ts`
+- No bundled full DOM sanitizer — for untrusted input, layer DOMPurify (or
+  similar) on top; the defaults are XSS hardening, not complete sanitization
+- XSS protection through secure parsing (HTMLParser2)
 - Use `allowHtmlOnly`/`excludeHtmlOnly` to restrict HTML tags

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A powerful, customizable markdown renderer for Svelte with TypeScript support. B
 - 🎯 GitHub-style slug generation for headers
 - 🧪 Comprehensive test coverage (vitest and playwright)
 - 🧩 First-class marked extensions support via `extensions` prop (e.g., KaTeX math, alerts)
+- 🎨 Opt-in Shiki syntax highlighting — streaming-compatible, tree-shaken out of the core bundle
 - ⚡ Intelligent token caching (50-200x faster re-renders)
 - 📡 LLM streaming mode with incremental rendering (~1.6ms avg per update)
 - 🖼️ Smart image lazy loading with fade-in animation
@@ -601,6 +602,43 @@ Another claim[^note] that needs a source.
 ```
 
 `FootnoteRef` renders `<sup><a href="#fn-{id}">{id}</a></sup>` and `FootnoteSection` renders an `<ol>` with bidirectional links (ref to definition and back). You can also use snippet overrides for custom rendering.
+
+### Syntax Highlighting (Shiki)
+
+Unlike the marked extensions above, syntax highlighting is a **renderer-level override**: you replace the default `code` renderer with `ShikiCode`, so there is **no `extensions` prop entry** and **no marked tokenizer** involved. Because highlighting stays synchronous (Shiki's `createHighlighterCoreSync` + the pure-JS regex engine), the `code` renderer never trips the async-extension guard — **streaming stays fully enabled**.
+
+`shiki` is an optional peer dependency — install it yourself:
+
+```bash
+npm install shiki
+```
+
+Import only the languages and themes you need (each is a separate ESM module), build a highlighter, register it, then map `ShikiCode` to the `code` renderer:
+
+````svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+    import {
+        createShikiHighlighter,
+        ShikiCode,
+        setShikiHighlighter
+    } from '@humanspeak/svelte-markdown/extensions'
+    import js from 'shiki/langs/javascript.mjs'
+    import ts from 'shiki/langs/typescript.mjs'
+    import githubDark from 'shiki/themes/github-dark.mjs'
+
+    // Register once (module singleton). Every ShikiCode instance resolves it.
+    setShikiHighlighter(createShikiHighlighter({ langs: [js, ts], themes: [githubDark] }))
+
+    const source = '```ts\nconst answer: number = 42\n```'
+</script>
+
+<SvelteMarkdown {source} renderers={{ code: ShikiCode }} />
+````
+
+The highlighter is resolved in priority order: an explicit `highlighter` prop → a Svelte context set under `SHIKI_CONTEXT_KEY` (for per-subtree themes / SSR request isolation) → the module singleton from `setShikiHighlighter`. Unregistered or unknown languages, and any per-block failure, degrade to an **escaped** `<pre class="shiki-fallback">` rather than throwing mid-stream. Shiki escapes the code it emits and the fallback escapes its inputs, so the `{@html}` sink only ever receives library-generated or explicitly-escaped markup (the same trust model as `KatexRenderer` / `MermaidRenderer`).
+
+**Bundle guidance — this is opt-in for a reason.** A highlighter with the pure-JS engine plus two languages (js, ts) and one theme (github-dark) adds roughly **85 KB gzip** (~516 KB minified), dominated by the TextMate grammars and the regex engine. That cost lands **only** when you import and construct a highlighter — the core `SvelteMarkdown` bundle stays completely shiki-free (enforced by `scripts/tree-shaking.mjs`), and importing `ShikiCode` alone (without building a highlighter) pulls in nothing from Shiki. Import narrowly: every extra `shiki/langs/*` and `shiki/themes/*` you add is bundled. The JS engine keeps SSR trivial (no WASM); highlight-heavy client apps can opt into Shiki's faster oniguruma-WASM engine, which is still streaming-safe.
 
 ### How It Works
 

--- a/docs/src/lib/compare-data.ts
+++ b/docs/src/lib/compare-data.ts
@@ -23,6 +23,7 @@ const shared = {
         'LLM streaming with imperative writeChunk() / resetStream() API',
         '23 markdown renderers + 84 HTML tag renderers — every override is a Svelte snippet',
         'First-class extensions: KaTeX math, Mermaid diagrams, GitHub alerts, footnotes',
+        'Opt-in Shiki syntax highlighting (streaming-compatible, tree-shaken from core)',
         'Built-in XSS protection — protocol allowlist, event-handler stripping, attribute sanitization',
         'Allow/deny utilities (allowHtmlOnly, excludeRenderersOnly, etc.) for fine-grained control',
         'Drop-in component — works anywhere in your Svelte app'
@@ -101,7 +102,7 @@ export const competitors: Competitor[] = [
             },
             {
                 name: 'Code Highlighting',
-                us: 'Via marked extensions',
+                us: 'Built-in via opt-in Shiki extension',
                 them: 'Built-in (Shiki/Prism)'
             },
             { name: 'Remark/Rehype Plugins', us: false, them: true }
@@ -124,8 +125,7 @@ export const competitors: Competitor[] = [
         consUs: [
             ...shared.consUs,
             'Cannot embed Svelte components inside markdown content',
-            'No frontmatter support (parse separately if needed)',
-            'No built-in code syntax highlighting (use a marked extension)'
+            'No frontmatter support (parse separately if needed)'
         ],
         consThem: [
             'Cannot render dynamic/user-supplied markdown',
@@ -474,12 +474,7 @@ export const competitors: Competitor[] = [
             'Slash commands, toolbar, and more',
             'Headless — fully customizable appearance'
         ],
-        consUs: [
-            ...shared.consUs,
-            'No editing capabilities',
-            'No collaborative features',
-            'No built-in code syntax highlighting (use a marked extension)'
-        ],
+        consUs: [...shared.consUs, 'No editing capabilities', 'No collaborative features'],
         consThem: [
             'Heavy bundle for display-only use cases',
             'Svelte support is via adapter, not first-party',
@@ -605,7 +600,11 @@ export const competitors: Competitor[] = [
                 them: false,
                 note: 'Carta is an authoring editor with live preview, not a renderer for streaming agent output with nested HTML.'
             },
-            { name: 'Syntax Highlighting', us: 'Via marked extensions', them: 'Built-in plugin' },
+            {
+                name: 'Syntax Highlighting',
+                us: 'Opt-in Shiki extension',
+                them: 'Built-in plugin'
+            },
             {
                 name: 'Math (KaTeX)',
                 us: 'Built-in extension (markedKatex)',
@@ -632,12 +631,7 @@ export const competitors: Competitor[] = [
             'Plugin system for syntax highlighting, math, etc.',
             'Keyboard shortcuts and toolbar'
         ],
-        consUs: [
-            ...shared.consUs,
-            'No editing capabilities',
-            'No split-pane UI',
-            'No built-in code syntax highlighting (use a marked extension)'
-        ],
+        consUs: [...shared.consUs, 'No editing capabilities', 'No split-pane UI'],
         consThem: [
             'Bundled editor code even if you only need rendering',
             'Smaller community than established editors',
@@ -718,11 +712,7 @@ export const competitors: Competitor[] = [
             'XSS-safe by default',
             'Established community (~1,300 GitHub stars)'
         ],
-        consUs: [
-            ...shared.consUs,
-            'No editing capabilities',
-            'No built-in code syntax highlighting (use a marked extension)'
-        ],
+        consUs: [...shared.consUs, 'No editing capabilities'],
         consThem: [
             'Built on Svelte 3/4 — not updated for Svelte 5 runes',
             'Development has slowed significantly',

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -9,6 +9,7 @@ import {
     FileText,
     Filter,
     Gauge,
+    Highlighter,
     Link,
     List,
     Lock,
@@ -158,7 +159,12 @@ export const docsSections: NavSection[] = [
             { title: 'Token Caching', href: '/docs/advanced/token-caching', icon: Zap },
             { title: 'Tree Shaking', href: '/docs/advanced/tree-shaking', icon: Gauge },
             { title: 'Allow/Deny', href: '/docs/advanced/allow-deny', icon: Shield },
-            { title: 'Marked Extensions', href: '/docs/advanced/marked-extensions', icon: Puzzle }
+            { title: 'Marked Extensions', href: '/docs/advanced/marked-extensions', icon: Puzzle },
+            {
+                title: 'Syntax Highlighting',
+                href: '/docs/advanced/syntax-highlighting',
+                icon: Highlighter
+            }
         ]
     },
     {
@@ -200,6 +206,7 @@ export const docsSections: NavSection[] = [
             { title: 'Caching Performance', href: '/examples/caching-performance', icon: Gauge },
             { title: 'Marked Extensions', href: '/examples/marked-extensions', icon: Puzzle },
             { title: 'Mermaid Diagrams', href: '/examples/mermaid', icon: Workflow },
+            { title: 'Syntax Highlighting', href: '/examples/shiki', icon: Highlighter },
             { title: 'GitHub Alerts', href: '/examples/github-alerts', icon: TriangleAlert },
             { title: 'Footnotes', href: '/examples/footnotes', icon: Superscript },
             { title: 'Code Formatting', href: '/examples/code-formatting', icon: Code },

--- a/docs/src/lib/examples/shiki/demos/ComponentRendered.svelte
+++ b/docs/src/lib/examples/shiki/demos/ComponentRendered.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+    import type { RendererComponent, Renderers } from '@humanspeak/svelte-markdown'
+    import {
+        createShikiHighlighter,
+        ShikiCode,
+        SHIKI_CONTEXT_KEY
+    } from '@humanspeak/svelte-markdown/extensions'
+    import { DemoSplitV2 } from '@humanspeak/docs-kit'
+    import { setContext } from 'svelte'
+    import js from 'shiki/langs/javascript.mjs'
+    import json from 'shiki/langs/json.mjs'
+    import ts from 'shiki/langs/typescript.mjs'
+    import githubDark from 'shiki/themes/github-dark.mjs'
+
+    // Per-subtree injection via Svelte context — isolated from any other
+    // highlighter on the page (no global module-singleton cross-talk).
+    // ShikiCode reads this context at init and highlights synchronously.
+    setContext(
+        SHIKI_CONTEXT_KEY,
+        createShikiHighlighter({ langs: [js, ts, json], themes: [githubDark] })
+    )
+
+    // ShikiCode is a drop-in for the built-in `code` renderer (same lang/text
+    // props), so only fenced blocks are affected — inline `code` is untouched.
+    interface CodeRenderers extends Renderers {
+        code: RendererComponent
+    }
+    const renderers: Partial<CodeRenderers> = {
+        code: ShikiCode
+    }
+
+    const defaultMarkdown = `## Shiki Highlighting
+
+Fenced blocks render through Shiki synchronously — no async work, so
+**streaming stays enabled**.
+
+\`\`\`ts
+interface User {
+    id: number
+    name: string
+}
+
+const greet = (user: User): string => \`Hello, \${user.name}!\`
+\`\`\`
+
+\`\`\`json
+{ "langs": ["javascript", "typescript", "json"], "theme": "github-dark" }
+\`\`\`
+
+Inline \`code\` uses the codespan renderer and is left untouched.`
+
+    // Debounced live editor: `input` tracks the textarea verbatim, `source`
+    // is what SvelteMarkdown renders.
+    let input = $state(defaultMarkdown)
+    let source = $state(defaultMarkdown)
+    let debounceTimer = $state<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+    function handleInput(event: Event) {
+        const target = event.target as HTMLTextAreaElement
+        input = target.value
+        if (debounceTimer) clearTimeout(debounceTimer)
+        debounceTimer = setTimeout(() => {
+            source = input
+        }, 300)
+    }
+</script>
+
+<DemoSplitV2 leftLabel="EDITOR" leftTone="markdown" rightLabel="PREVIEW" rightTone="diagrams">
+    {#snippet left()}
+        <textarea
+            value={input}
+            oninput={handleInput}
+            class="md-editor"
+            spellcheck="false"
+            placeholder="Type markdown with ```ts / ```json code blocks..."></textarea>
+    {/snippet}
+    {#snippet right()}
+        <div class="md-preview prose prose-sm dark:prose-invert max-w-none">
+            <SvelteMarkdown {source} {renderers} />
+        </div>
+    {/snippet}
+</DemoSplitV2>
+
+<style>
+    .md-editor {
+        width: 100%;
+        height: 100%;
+        min-height: 360px;
+        resize: none;
+        border: 0;
+        outline: none;
+        background: transparent;
+        color: var(--brut-ink, var(--foreground, inherit));
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 12.5px;
+        line-height: 1.7;
+        padding: 0;
+    }
+    .md-preview {
+        font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+        color: var(--brut-ink-2, var(--muted-foreground, inherit));
+    }
+    .md-preview :global(h1),
+    .md-preview :global(h2),
+    .md-preview :global(h3),
+    .md-preview :global(h4) {
+        color: var(--brut-ink, var(--foreground, inherit));
+        letter-spacing: -0.02em;
+    }
+    /* Shiki emits <pre class="shiki"> with its own theme background. */
+    .md-preview :global(pre.shiki),
+    .md-preview :global(pre.shiki-fallback) {
+        padding: 12px;
+        border-radius: 6px;
+        overflow-x: auto;
+        font-size: 12px;
+        line-height: 1.6;
+    }
+    .md-preview :global(pre.shiki-fallback) {
+        background: var(--brut-bg-2, rgba(127, 127, 127, 0.08));
+        border: 1px solid var(--brut-rule, rgba(127, 127, 127, 0.18));
+    }
+    .md-preview :global(:not(pre) > code) {
+        background: var(--brut-bg-2, rgba(127, 127, 127, 0.08));
+        border: 1px solid var(--brut-rule, rgba(127, 127, 127, 0.18));
+        padding: 0 4px;
+        font-size: 12px;
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+    }
+</style>

--- a/docs/src/lib/examples/shiki/demos/FallbackRendered.svelte
+++ b/docs/src/lib/examples/shiki/demos/FallbackRendered.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+    import type { RendererComponent, Renderers } from '@humanspeak/svelte-markdown'
+    import {
+        createShikiHighlighter,
+        ShikiCode,
+        SHIKI_CONTEXT_KEY
+    } from '@humanspeak/svelte-markdown/extensions'
+    import { DemoSplitV2 } from '@humanspeak/docs-kit'
+    import { setContext } from 'svelte'
+    import ts from 'shiki/langs/typescript.mjs'
+    import githubDark from 'shiki/themes/github-dark.mjs'
+
+    // Only `typescript` is registered here — everything else degrades safely.
+    setContext(SHIKI_CONTEXT_KEY, createShikiHighlighter({ langs: [ts], themes: [githubDark] }))
+
+    interface CodeRenderers extends Renderers {
+        code: RendererComponent
+    }
+    const renderers: Partial<CodeRenderers> = {
+        code: ShikiCode
+    }
+
+    // `rust` is not registered, so it falls back to an escaped
+    // <pre class="shiki-fallback"> instead of throwing mid-stream. The
+    // untrusted lang string is only ever emitted as an escaped data-lang.
+    const source = `### Registered language (\`ts\`)
+
+\`\`\`ts
+const total: number = [1, 2, 3].reduce((a, b) => a + b, 0)
+\`\`\`
+
+### Unregistered language (\`rust\`) — safe escaped fallback
+
+\`\`\`rust
+fn main() {
+    let markup = "<b>bold</b> & <i>italic</i>";
+    println!("{markup}");
+}
+\`\`\``
+</script>
+
+<DemoSplitV2 leftLabel="SOURCE" leftTone="markdown" rightLabel="PREVIEW" rightTone="diagrams">
+    {#snippet left()}
+        <pre class="md-source">{source}</pre>
+    {/snippet}
+    {#snippet right()}
+        <div class="md-preview prose prose-sm dark:prose-invert max-w-none">
+            <SvelteMarkdown {source} {renderers} />
+        </div>
+    {/snippet}
+</DemoSplitV2>
+
+<style>
+    .md-source {
+        margin: 0;
+        white-space: pre-wrap;
+        color: var(--brut-ink, var(--foreground, inherit));
+        font-family: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 12.5px;
+        line-height: 1.7;
+    }
+    .md-preview {
+        font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+        color: var(--brut-ink-2, var(--muted-foreground, inherit));
+    }
+    .md-preview :global(h1),
+    .md-preview :global(h2),
+    .md-preview :global(h3),
+    .md-preview :global(h4) {
+        color: var(--brut-ink, var(--foreground, inherit));
+        letter-spacing: -0.02em;
+    }
+    .md-preview :global(pre.shiki),
+    .md-preview :global(pre.shiki-fallback) {
+        padding: 12px;
+        border-radius: 6px;
+        overflow-x: auto;
+        font-size: 12px;
+        line-height: 1.6;
+    }
+    .md-preview :global(pre.shiki-fallback) {
+        background: var(--brut-bg-2, rgba(127, 127, 127, 0.08));
+        border: 1px solid var(--brut-rule, rgba(127, 127, 127, 0.18));
+        color: var(--brut-ink, var(--foreground, inherit));
+    }
+</style>

--- a/docs/src/routes/docs/advanced/syntax-highlighting/+page.svx
+++ b/docs/src/routes/docs/advanced/syntax-highlighting/+page.svx
@@ -1,0 +1,147 @@
+---
+title: Syntax Highlighting
+description: Add opt-in Shiki syntax highlighting to @humanspeak/svelte-markdown with a streaming-compatible, synchronous code renderer that stays out of the core bundle.
+---
+
+<script>
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+    const seo = getSeoContext()
+    if (seo) {
+        seo.title = 'Syntax Highlighting (Shiki) | Svelte Markdown'
+        seo.description = 'Add opt-in Shiki syntax highlighting to @humanspeak/svelte-markdown with a streaming-compatible, synchronous code renderer that stays out of the core bundle.'
+        seo.ogTitle = 'Syntax Highlighting (Shiki)'
+        seo.ogTagline = 'Streaming-safe code highlighting, opt-in and tree-shaken.'
+        seo.ogFeatures = ['Shiki', 'Streaming-safe', 'Tree-shaken', 'SSR-friendly']
+        seo.ogSlug = 'docs-advanced-syntax-highlighting'
+    }
+</script>
+
+# Syntax Highlighting
+
+`@humanspeak/svelte-markdown` ships an **opt-in Shiki syntax-highlighting extension** from the `@humanspeak/svelte-markdown/extensions` subpath. It highlights fenced code blocks by replacing the default `code` renderer with `ShikiCode` — no marked tokenizer, no `extensions` prop entry, and (critically) **no async work on the render path**, so streaming stays enabled.
+
+## Why It's a Renderer, Not a Marked Extension
+
+KaTeX, Mermaid, alerts, and footnotes are [marked extensions](/docs/advanced/marked-extensions): they add custom token types via the `extensions` prop. Highlighting is different. A code fence is already a first-class `code` token, so there is nothing new to tokenize — the work is purely at render time. `ShikiCode` is therefore a **drop-in replacement for the built-in `code` renderer** with the same `Props` shape (`lang`, `text`):
+
+```svelte
+<SvelteMarkdown {source} renderers={{ code: ShikiCode }} />
+```
+
+This distinction matters for **streaming**. An async marked extension (one that returns a promise from `walkTokens`) forces `SvelteMarkdown` to disable streaming — the incremental parser can't reconcile a tail window against pending async work. `ShikiCode` stays **fully synchronous**: it wraps Shiki's `createHighlighterCoreSync` with the pure-JavaScript regex engine, so `codeToHtml` returns a string immediately with no WASM load and no top-level `await`. The `code` renderer never trips the `hasAsyncExtension` guard, and `streaming` is never silently turned off. (Contrast this with `MermaidRenderer`, which is intentionally async and browser-only.)
+
+## Install
+
+`shiki` is an optional peer dependency — install it yourself:
+
+```bash
+pnpm add shiki
+```
+
+## Wire It Up
+
+Import only the languages and themes you need — each is a separate ESM module, and **only what you import is bundled**. Build a highlighter, register it, then map `ShikiCode` to the `code` renderer:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+    import {
+        createShikiHighlighter,
+        ShikiCode,
+        setShikiHighlighter
+    } from '@humanspeak/svelte-markdown/extensions'
+    import js from 'shiki/langs/javascript.mjs'
+    import ts from 'shiki/langs/typescript.mjs'
+    import githubDark from 'shiki/themes/github-dark.mjs'
+
+    // Register once — every ShikiCode instance resolves this singleton.
+    setShikiHighlighter(
+        createShikiHighlighter({ langs: [js, ts], themes: [githubDark] })
+    )
+
+    const source = `
+\`\`\`ts
+const answer: number = 42
+console.log(answer)
+\`\`\`
+`
+</script>
+
+<SvelteMarkdown {source} renderers={{ code: ShikiCode }} />
+```
+
+Language **aliases** come for free — registering `javascript` also matches `js`, `cjs`, and `mjs`, so a ` ```js ` fence highlights without registering a separate language.
+
+### Choosing How to Inject the Highlighter
+
+`ShikiCode` resolves its highlighter in priority order:
+
+1. An explicit `highlighter` **prop** — only reachable if you wrap `ShikiCode` in your own component. Use it as an escape hatch.
+2. A Svelte **context** set under `SHIKI_CONTEXT_KEY` by an ancestor of `<SvelteMarkdown>`. Use this when you need per-subtree themes or SSR request isolation (multiple themes on one page, or a per-request highlighter on the server).
+3. The module **singleton** set via `setShikiHighlighter`. The simplest default for an app with a single global theme.
+
+```svelte
+<script lang="ts">
+    import { setContext } from 'svelte'
+    import { createShikiHighlighter, SHIKI_CONTEXT_KEY } from '@humanspeak/svelte-markdown/extensions'
+    import ts from 'shiki/langs/typescript.mjs'
+    import githubLight from 'shiki/themes/github-light.mjs'
+
+    setContext(
+        SHIKI_CONTEXT_KEY,
+        createShikiHighlighter({ langs: [ts], themes: [githubLight] })
+    )
+</script>
+```
+
+## Theme Selection
+
+Pass every theme you want available in `themes`, and pick the active one with `theme` (it must match one of the loaded theme names). When omitted, the first loaded theme is used:
+
+```ts
+createShikiHighlighter({
+    langs: [ts],
+    themes: [githubDark, githubLight],
+    theme: 'github-light'
+})
+```
+
+## Unregistered Languages and Failures
+
+Highlighting must never throw mid-stream — an exception on a partially-streamed fence would tear down the render. So for an **unregistered or empty** language, and for **any per-block highlighting failure**, `ShikiCode` degrades to an escaped fallback instead of throwing:
+
+```html
+<pre class="shiki-fallback" data-lang="rust"><code>fn main() {}</code></pre>
+```
+
+The code text is HTML-escaped and the (untrusted) `lang` is emitted **only** as an escaped `data-lang` attribute — never interpolated as raw markup. Style `.shiki-fallback` to match your registered-language blocks.
+
+## Security — the `{@html}` Sink
+
+`ShikiCode` injects the highlighter's HTML string via `{@html}`, the same sink `KatexRenderer` and `MermaidRenderer` already use. The trust model is the same, and slightly stronger:
+
+- **Code text** is tokenized and escaped by Shiki (it emits `&#x3C;` for `<`), so user- or agent-supplied code content is never live markup. The fallback path independently escapes the code text.
+- **The `lang` (fenced info string) is untrusted** — in this package's headline agent/LLM-streaming use case it is attacker-influenced. The registered path passes `lang` to Shiki only as a lookup key (never into markup); the fallback path **escapes, never interpolates** it.
+
+Net: the `{@html}` sink only ever receives Shiki-generated or explicitly-escaped markup — the same trust class as the existing KaTeX/Mermaid renderers. Highlighting does not replace HTML sanitization; keep your usual [security](/docs/advanced/security) posture for the rest of the document.
+
+## Bundle Size — Why It's Opt-in
+
+A highlighter with the pure-JS engine plus two languages (js, ts) and one theme (github-dark) adds roughly **85 KB gzip** (~516 KB minified), dominated by the TextMate grammars and the regex engine. That is far larger than the core package, which is exactly why highlighting is opt-in:
+
+- The cost lands **only** when you import and construct a highlighter with `createShikiHighlighter`. The core `SvelteMarkdown` bundle stays completely shiki-free — enforced by `scripts/tree-shaking.mjs`, and covered on the [Tree Shaking](/docs/advanced/tree-shaking) page.
+- Importing `ShikiCode` **without** building a highlighter pulls in nothing from Shiki (the renderer only depends on the escaped fallback).
+- Import narrowly: every extra `shiki/langs/*` and `shiki/themes/*` you add is bundled. Register only the languages your content actually uses.
+
+## JS Engine vs. Oniguruma
+
+The default pure-JavaScript regex engine has **no WASM**, which keeps SSR trivial (the sync core server-renders fully-highlighted markup with no asset or loader concerns) — the right default for most apps. Its tradeoff is per-block cost: highlighting is roughly linear at ~1.2–1.7 ms per line, so a large block being actively streamed can exceed a single frame. Completed blocks are memoized (`html` is `$derived` from `(text, lang)`), so they are not re-highlighted as later prose streams in. For highlight-heavy, client-rendered apps, Shiki's **oniguruma-WASM** engine is ~2.5× faster per block and is still streaming-safe (the WASM loads once at setup; per-block highlighting stays synchronous) — at the cost of shipping a WASM asset and an async setup step.
+
+## Related
+
+- [Marked Extensions](/docs/advanced/marked-extensions) -- KaTeX, Mermaid, alerts, and footnotes via the `extensions` prop
+- [LLM Streaming](/docs/advanced/llm-streaming) -- why synchronous rendering keeps streaming enabled
+- [Tree Shaking](/docs/advanced/tree-shaking) -- how the core bundle stays shiki-free
+- [Security](/docs/advanced/security) -- sanitization defaults and the `{@html}` trust model
+- [Shiki Interactive Demo](/examples/shiki) -- try live highlighting with fallback and streaming

--- a/docs/src/routes/examples/shiki/+page.svelte
+++ b/docs/src/routes/examples/shiki/+page.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        formatSheetLabel,
+        type ExampleSection
+    } from '@humanspeak/docs-kit'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import ComponentRendered from '$lib/examples/shiki/demos/ComponentRendered.svelte'
+    import FallbackRendered from '$lib/examples/shiki/demos/FallbackRendered.svelte'
+    import { Highlighter, Package, Shield, Terminal, Zap } from '@lucide/svelte'
+
+    const seo = getSeoContext()
+    if (seo) {
+        seo.title = 'Syntax Highlighting (Shiki) | Examples | Svelte Markdown'
+        seo.h1 = { title: 'Syntax Highlighting (Shiki)' }
+        seo.description =
+            'Highlight code blocks in @humanspeak/svelte-markdown with the opt-in Shiki extension — a synchronous, streaming-compatible ShikiCode renderer with a safe escaped fallback.'
+        seo.ogTitle = 'Syntax Highlighting (Shiki)'
+        seo.ogTagline = 'Streaming-safe code highlighting with a safe escaped fallback.'
+        seo.ogFeatures = ['Shiki', 'Streaming-safe', 'Escaped Fallback', 'Tree-shaken']
+        seo.ogSlug = 'examples-shiki'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-markdown/blob/main/docs/src/lib/examples/'
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'COMPONENT',
+            title: { prefix: 'shiki ', accent: 'renderer', end: '.' },
+            description:
+                'Map `ShikiCode` to the `code` renderer and inject a highlighter via Svelte context. Highlighting runs synchronously, so streaming stays enabled — edit the markdown live.',
+            snippet: componentSection,
+            codeSnippet: componentCode,
+            notes: componentNotes,
+            barCells: [{ k: 'override', v: 'component' }],
+            sourceUrl: `${SOURCE_URL}shiki/demos/ComponentRendered.svelte`
+        },
+        {
+            figId: 'FIG-002',
+            tag: 'FALLBACK',
+            title: { prefix: 'safe ', accent: 'fallback', end: '.' },
+            description:
+                'Unregistered languages (and any per-block failure) degrade to an escaped `<pre class="shiki-fallback">` instead of throwing mid-stream — the untrusted lang is only ever an escaped `data-lang`.',
+            snippet: fallbackSection,
+            codeSnippet: fallbackCode,
+            notes: fallbackNotes,
+            barCells: [{ k: 'lang', v: 'unregistered' }],
+            sourceUrl: `${SOURCE_URL}shiki/demos/FallbackRendered.svelte`
+        }
+    ]
+</script>
+
+{#snippet componentSection()}
+    <ComponentRendered />
+{/snippet}
+{#snippet componentNotes()}
+    <ul>
+        <li>
+            <Highlighter />
+            <span>
+                <code>ShikiCode</code> is a drop-in for the built-in <code>code</code> renderer
+                (same <code>lang</code> / <code>text</code> props) — only fenced blocks change.
+            </span>
+        </li>
+        <li>
+            <Zap />
+            <span>
+                Shiki's <code>createHighlighterCoreSync</code> + the JS regex engine highlight
+                synchronously, so the async-extension guard never trips and <code>streaming</code> stays
+                on.
+            </span>
+        </li>
+        <li>
+            <Package />
+            <span>
+                Import only the <code>shiki/langs/*</code> and <code>shiki/themes/*</code> you need —
+                everything else is tree-shaken out, and the core bundle stays shiki-free.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet componentCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'shiki/demos/ComponentRendered.svelte',
+                'component-rendered',
+                'ComponentRendered.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#snippet fallbackSection()}
+    <FallbackRendered />
+{/snippet}
+{#snippet fallbackNotes()}
+    <ul>
+        <li>
+            <Shield />
+            <span>
+                The fenced <code>lang</code> is untrusted (agent/LLM input) — the fallback
+                <strong>escapes, never interpolates</strong> it, emitting it only as an escaped
+                <code>data-lang</code>.
+            </span>
+        </li>
+        <li>
+            <Terminal />
+            <span>
+                Shiki escapes the code it emits and the fallback escapes too, so the
+                <code>{'{@html}'}</code> sink only ever receives library-generated or escaped markup.
+            </span>
+        </li>
+        <li>
+            <Highlighter />
+            <span>
+                Style <code>.shiki-fallback</code> to match your registered blocks — the content is
+                a plain escaped <code>&lt;pre&gt;&lt;code&gt;</code>.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet fallbackCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'shiki/demos/FallbackRendered.svelte',
+                'fallback-rendered',
+                'FallbackRendered.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
         "prettier-plugin-svelte": "^4.1.1",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "publint": "^0.3.21",
+        "shiki": "^4.3.1",
         "svelte": "^5.56.4",
         "svelte-check": "^4.7.1",
         "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
         "./extensions/mermaid": {
             "types": "./dist/extensions/mermaid/index.d.ts",
             "svelte": "./dist/extensions/mermaid/index.js"
+        },
+        "./extensions/shiki": {
+            "types": "./dist/extensions/shiki/index.d.ts",
+            "svelte": "./dist/extensions/shiki/index.js"
         }
     },
     "svelte": "./dist/index.js",
@@ -173,6 +177,7 @@
     "peerDependencies": {
         "katex": ">=0.16.0",
         "mermaid": ">=10.0.0",
+        "shiki": ">=4.0.0",
         "svelte": "^5.0.0"
     },
     "peerDependenciesMeta": {
@@ -180,6 +185,9 @@
             "optional": true
         },
         "mermaid": {
+            "optional": true
+        },
+        "shiki": {
             "optional": true
         }
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       publint:
         specifier: ^0.3.21
         version: 0.3.21
+      shiki:
+        specifier: ^4.3.1
+        version: 4.3.1
       svelte:
         specifier: ^5.56.4
         version: 5.56.4(@typescript-eslint/types@8.62.1)

--- a/scripts/tree-shaking.mjs
+++ b/scripts/tree-shaking.mjs
@@ -27,6 +27,18 @@ const cases = [
         expectAllMissing: ['node_modules/katex', 'node_modules/mermaid']
     },
     {
+        // SPIKE (plan 004): the default code renderer must never pull Shiki into
+        // the core bundle — highlighting is an opt-in, explicitly-imported
+        // extension, so the "lightweight" core positioning stays honest.
+        name: 'core component stays shiki-free',
+        source: `
+            import SvelteMarkdown from '@humanspeak/svelte-markdown/SvelteMarkdown'
+            console.log(SvelteMarkdown)
+        `,
+        expectInitialMissing: ['node_modules/shiki', 'node_modules/@shikijs'],
+        expectAllMissing: ['node_modules/shiki', 'node_modules/@shikijs']
+    },
+    {
         name: 'katex tokenizer only',
         source: `
             import { markedKatex } from '@humanspeak/svelte-markdown/extensions/katex'

--- a/scripts/tree-shaking.mjs
+++ b/scripts/tree-shaking.mjs
@@ -72,6 +72,43 @@ const cases = [
         `,
         expectInitialMissing: ['node_modules/mermaid'],
         expectDynamicPresent: ['node_modules/mermaid']
+    },
+    {
+        // Plan 004 ship: importing an unrelated extension subpath must not pull
+        // Shiki (or any @shikijs engine/grammar) into the bundle — highlighting
+        // is opt-in and only reachable via the shiki subpath.
+        name: 'other extension stays shiki-free',
+        source: `
+            import { markedKatex } from '@humanspeak/svelte-markdown/extensions/katex'
+            console.log(markedKatex().extensions?.length)
+        `,
+        expectInitialMissing: ['node_modules/shiki', 'node_modules/@shikijs'],
+        expectAllMissing: ['node_modules/shiki', 'node_modules/@shikijs']
+    },
+    {
+        // Plan 004 ship: the ShikiCode renderer on its own does NOT pull Shiki
+        // in — it only depends on the escaped fallback. Shiki is bundled solely
+        // when the consumer constructs a highlighter, keeping the renderer cheap.
+        name: 'shiki renderer stays shiki-free',
+        source: `
+            import { ShikiCode } from '@humanspeak/svelte-markdown/extensions/shiki'
+            console.log(ShikiCode)
+        `,
+        expectInitialMissing: ['node_modules/shiki', 'node_modules/@shikijs'],
+        expectAllMissing: ['node_modules/shiki', 'node_modules/@shikijs']
+    },
+    {
+        // Plan 004 ship: opting into the highlighter factory does pull Shiki's
+        // core (`@shikijs/*`, resolved via the `shiki/core` +
+        // `shiki/engine/javascript` subpaths) into the bundle — proving the
+        // opt-in path resolves and is intentionally bundled only when the
+        // consumer actually constructs a highlighter.
+        name: 'shiki highlighter factory',
+        source: `
+            import { createShikiHighlighter } from '@humanspeak/svelte-markdown/extensions/shiki'
+            console.log(createShikiHighlighter)
+        `,
+        expectInitialPresent: ['node_modules/@shikijs']
     }
 ]
 

--- a/src/lib/extensions/index.ts
+++ b/src/lib/extensions/index.ts
@@ -8,6 +8,7 @@
  * import { markedAlert, AlertRenderer } from '@humanspeak/svelte-markdown/extensions'
  * import { markedFootnote, FootnoteRef, FootnoteSection } from '@humanspeak/svelte-markdown/extensions'
  * import { markedKatex, KatexRenderer } from '@humanspeak/svelte-markdown/extensions'
+ * import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '@humanspeak/svelte-markdown/extensions'
  * ```
  *
  * @module @humanspeak/svelte-markdown/extensions
@@ -19,3 +20,12 @@ export { FootnoteRef, FootnoteSection, markedFootnote } from './footnote/index.j
 export { BLOCK_KATEX_TOKEN, INLINE_KATEX_TOKEN, KatexRenderer, markedKatex } from './katex/index.js'
 export type { MarkedKatexOptions } from './katex/index.js'
 export { MermaidRenderer, markedMermaid } from './mermaid/index.js'
+export {
+    SHIKI_CONTEXT_KEY,
+    ShikiCode,
+    createShikiHighlighter,
+    escapeHtml,
+    getShikiHighlighter,
+    setShikiHighlighter
+} from './shiki/index.js'
+export type { CreateShikiHighlighterOptions, ShikiHighlighter } from './shiki/index.js'

--- a/src/lib/extensions/shiki/ShikiCode.svelte
+++ b/src/lib/extensions/shiki/ShikiCode.svelte
@@ -1,0 +1,59 @@
+<!--
+@component
+SPIKE — a drop-in replacement for the default `code` renderer that renders
+fenced code blocks with Shiki syntax highlighting.
+
+Same `Props` shape as the built-in `Code.svelte` (`lang`, `text`) so it slots
+directly into the standard `renderers` prop with no new component API:
+
+```svelte
+<script>
+  import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '.../extensions/shiki'
+  import js from 'shiki/langs/javascript.mjs'
+  import githubDark from 'shiki/themes/github-dark.mjs'
+  setShikiHighlighter(createShikiHighlighter({ langs: [js], themes: [githubDark] }))
+</script>
+
+<SvelteMarkdown {source} renderers={{ code: ShikiCode }} />
+```
+
+The highlighter is resolved from (in priority order) an explicit `highlighter`
+prop, Svelte context under `SHIKI_CONTEXT_KEY`, then the module singleton.
+
+Highlighting is memoized: `html` is `$derived` purely from `(text, lang)` (and
+the resolved highlighter), so re-renders during streaming do NOT re-highlight a
+code block whose text has not changed. Shiki escapes the code text it emits, and
+the unregistered-language fallback escapes too, so the `{@html}` sink only ever
+receives library-generated / escaped markup — never raw user input.
+-->
+<script lang="ts">
+    import { getContext } from 'svelte'
+    import { escapeHtml, type ShikiHighlighter } from './createShikiHighlighter.js'
+    import { getShikiHighlighter, SHIKI_CONTEXT_KEY } from './shikiContext.js'
+
+    interface Props {
+        /** Language identifier from the code fence (e.g. `"js"`, `"typescript"`). Untrusted. */
+        lang: string
+        /** Raw text content of the code block. */
+        text: string
+        /** Optional explicit highlighter; overrides context and singleton. */
+        highlighter?: ShikiHighlighter
+    }
+
+    const { lang, text, highlighter }: Props = $props()
+
+    // Context is stable for the component's lifetime; read once at init.
+    const contextHighlighter = getContext<ShikiHighlighter | undefined>(SHIKI_CONTEXT_KEY)
+
+    const resolved = $derived(highlighter ?? contextHighlighter ?? getShikiHighlighter())
+
+    // Memoized by (text, lang, resolved): unchanged blocks are not re-highlighted.
+    const html = $derived(
+        resolved
+            ? resolved.highlight(text, lang)
+            : `<pre class="shiki-fallback"><code>${escapeHtml(text)}</code></pre>`
+    )
+</script>
+
+<!-- trunk-ignore(eslint/svelte/no-at-html-tags) -->
+{@html html}

--- a/src/lib/extensions/shiki/ShikiCode.test.ts
+++ b/src/lib/extensions/shiki/ShikiCode.test.ts
@@ -1,0 +1,190 @@
+/**
+ * SPIKE — component, streaming-compatibility, and memoization coverage for the
+ * Shiki `code` renderer.
+ *
+ * The load-bearing assertions here are:
+ *   1. streaming compatibility — mounting `<SvelteMarkdown streaming>` with the
+ *      shiki renderer emits NO async-extension console warning and produces DOM
+ *      identical to the non-streaming render (the renderer is synchronous, so
+ *      `hasAsyncExtension` never trips), and
+ *   2. memoization survives token churn — an unchanged code block is NOT
+ *      re-highlighted when prose appends after it during streaming.
+ *
+ * Streaming harness modeled on `SvelteMarkdown.streaming-html.test.ts`.
+ */
+
+import '@testing-library/jest-dom'
+import { act, render } from '@testing-library/svelte'
+import js from 'shiki/langs/javascript.mjs'
+import ts from 'shiki/langs/typescript.mjs'
+import githubDark from 'shiki/themes/github-dark.mjs'
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest'
+import SvelteMarkdown from '../../SvelteMarkdown.svelte'
+import { tokenCache } from '../../utils/token-cache.js'
+import { createShikiHighlighter, type ShikiHighlighter } from './createShikiHighlighter.js'
+import ShikiCode from './ShikiCode.svelte'
+import { setShikiHighlighter } from './shikiContext.js'
+
+/** A highlighter whose `highlight` is spied so tests can count invocations. */
+let highlightSpy: Mock<(code: string, lang: string) => string>
+let highlighter: ShikiHighlighter
+
+beforeEach(() => {
+    tokenCache.clearAllTokens()
+    const real = createShikiHighlighter({ langs: [js, ts], themes: [githubDark] })
+    highlightSpy = vi.fn((code: string, lang: string) => real.highlight(code, lang))
+    highlighter = { highlight: highlightSpy, hasLang: (lang: string) => real.hasLang(lang) }
+    setShikiHighlighter(highlighter)
+
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+        return setTimeout(() => cb(performance.now()), 16) as unknown as number
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
+})
+
+afterEach(() => {
+    setShikiHighlighter(undefined)
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+})
+
+const flushStreamingBatch = async () => {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(50)
+    })
+}
+
+const normalizeHtml = (html: string): string =>
+    html
+        .replace(/<!--[^>]*-->/g, '')
+        .replace(/ id="[^"]*"/g, '')
+        .replace(/>\s+</g, '><')
+        .replace(/\s+/g, ' ')
+        .trim()
+
+const CODE_DOC = `# Heading
+
+\`\`\`javascript
+const answer = 42
+function greet(name) {
+    return \`hello \${name}\`
+}
+\`\`\`
+
+Trailing prose paragraph.`
+
+const renderStatic = async (source: string) => {
+    const harness = render(SvelteMarkdown, {
+        props: { source, renderers: { code: ShikiCode } }
+    })
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(20)
+    })
+    return harness.container
+}
+
+const renderStreamedChunks = async (chunks: string[]) => {
+    const harness = render(SvelteMarkdown, {
+        props: { source: '', streaming: true, renderers: { code: ShikiCode } }
+    })
+    for (const chunk of chunks) {
+        await act(() => harness.component.writeChunk(chunk))
+        await flushStreamingBatch()
+    }
+    return harness.container
+}
+
+describe('ShikiCode component', () => {
+    test('renders highlighted output for a registered language', () => {
+        const { container } = render(ShikiCode, {
+            props: { lang: 'javascript', text: 'const x = 1', highlighter }
+        })
+        expect(container.innerHTML).toContain('shiki')
+        expect(container.querySelector('span')).not.toBeNull()
+        expect(highlightSpy).toHaveBeenCalledWith('const x = 1', 'javascript')
+    })
+
+    test('falls back to escaped text for an unregistered language without throwing', () => {
+        const { container } = render(ShikiCode, {
+            props: { lang: 'nope', text: 'a < b', highlighter }
+        })
+        expect(container.innerHTML).toContain('shiki-fallback')
+        expect(container.innerHTML).toContain('a &lt; b')
+    })
+
+    test('degrades to an escaped <pre> when no highlighter is available', () => {
+        // No prop, no context, and the singleton is cleared in afterEach — but
+        // clear it here too to be explicit about the "unconfigured" path.
+        setShikiHighlighter(undefined)
+        const { container } = render(ShikiCode, {
+            props: { lang: 'javascript', text: 'a < b & c' }
+        })
+        expect(container.innerHTML).toContain('shiki-fallback')
+        expect(container.innerHTML).toContain('a &lt; b &amp; c')
+        expect(container.querySelector('span')).toBeNull()
+    })
+
+    test('never mounts a <script> element from code content', () => {
+        const { container } = render(ShikiCode, {
+            props: { lang: 'javascript', text: '<script>alert(1)</script>', highlighter }
+        })
+        expect(container.querySelector('script')).toBeNull()
+    })
+})
+
+describe('ShikiCode streaming compatibility', () => {
+    test('emits no async-extension warning and matches non-streaming DOM', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        const chunks = CODE_DOC.match(/\S+\s*/g) ?? []
+        const streamed = await renderStreamedChunks(chunks)
+        const staticContainer = await renderStatic(CODE_DOC)
+
+        // The synchronous renderer must NOT trip the async-extension guard.
+        const asyncWarnings = warnSpy.mock.calls
+            .map((c) => String(c[0]))
+            .filter((m) => m.includes('async extension'))
+        expect(asyncWarnings).toEqual([])
+
+        // Streaming DOM must equal the single-shot render.
+        expect(normalizeHtml(streamed.innerHTML)).toBe(normalizeHtml(staticContainer.innerHTML))
+        // And it must actually be highlighted, not plain <pre>.
+        expect(streamed.innerHTML).toContain('shiki')
+
+        warnSpy.mockRestore()
+    })
+
+    test('does NOT re-highlight an unchanged code block as later prose streams in', async () => {
+        // Stream the complete code fence first...
+        const codePortion = `\`\`\`javascript
+const answer = 42
+function greet(name) {
+    return name
+}
+\`\`\`
+`
+        const harness = render(SvelteMarkdown, {
+            props: { source: '', streaming: true, renderers: { code: ShikiCode } }
+        })
+        await act(() => harness.component.writeChunk(codePortion))
+        await flushStreamingBatch()
+
+        // The block is now complete and highlighted.
+        expect(harness.container.innerHTML).toContain('shiki')
+        const finalCode = 'const answer = 42\nfunction greet(name) {\n    return name\n}'
+        expect(highlightSpy.mock.calls.some((c) => c[0] === finalCode)).toBe(true)
+
+        // From here on, only prose appends — the code block text is unchanged.
+        highlightSpy.mockClear()
+        const proseChunks = ['Some ', 'trailing ', 'prose ', 'that ', 'keeps ', 'coming.']
+        for (const chunk of proseChunks) {
+            await act(() => harness.component.writeChunk(chunk))
+            await flushStreamingBatch()
+        }
+
+        // The unchanged code block must NOT be re-highlighted on any prose append.
+        const rehighlights = highlightSpy.mock.calls.filter((c) => c[0] === finalCode)
+        expect(rehighlights).toEqual([])
+    })
+})

--- a/src/lib/extensions/shiki/createShikiHighlighter.test.ts
+++ b/src/lib/extensions/shiki/createShikiHighlighter.test.ts
@@ -1,0 +1,94 @@
+import js from 'shiki/langs/javascript.mjs'
+import ts from 'shiki/langs/typescript.mjs'
+import githubDark from 'shiki/themes/github-dark.mjs'
+import { describe, expect, it } from 'vitest'
+import {
+    createShikiHighlighter,
+    escapeHtml,
+    type ShikiHighlighter
+} from './createShikiHighlighter.js'
+
+const makeHighlighter = (): ShikiHighlighter =>
+    createShikiHighlighter({ langs: [js, ts], themes: [githubDark] })
+
+describe('escapeHtml', () => {
+    it('escapes the five HTML-significant characters', () => {
+        expect(escapeHtml(`<>&"'`)).toBe('&lt;&gt;&amp;&quot;&#39;')
+    })
+})
+
+describe('createShikiHighlighter', () => {
+    it('highlights a registered language synchronously with token spans', () => {
+        const hl = makeHighlighter()
+        const html = hl.highlight('const x = 1', 'javascript')
+        expect(html).toContain('<pre class="shiki')
+        expect(html).toContain('<span')
+        // Shiki inlines per-token colors from the theme.
+        expect(html).toMatch(/color:#[0-9a-fA-F]{3,6}/)
+    })
+
+    it('resolves language aliases (e.g. "js" -> javascript)', () => {
+        const hl = makeHighlighter()
+        expect(hl.hasLang('js')).toBe(true)
+        expect(hl.highlight('const x = 1', 'js')).toContain('shiki')
+    })
+
+    it('falls back to escaped plain text for an unregistered language (no throw)', () => {
+        const hl = makeHighlighter()
+        expect(hl.hasLang('brainfuck')).toBe(false)
+        const html = hl.highlight('a > b && c < d', 'brainfuck')
+        expect(html).toContain('shiki-fallback')
+        expect(html).toContain('a &gt; b &amp;&amp; c &lt; d')
+        // Original angle brackets from the code must not survive raw.
+        expect(html).not.toContain('a > b')
+    })
+
+    it('falls back for empty/missing lang', () => {
+        const hl = makeHighlighter()
+        expect(hl.highlight('plain', '')).toContain('shiki-fallback')
+    })
+
+    it('escapes code containing a <script> tag — never emits an executable element', () => {
+        const hl = makeHighlighter()
+        const payload = '<script>alert(1)</script>'
+        // Registered lang path (shiki escapes the code text it tokenizes)...
+        const highlighted = hl.highlight(payload, 'javascript')
+        expect(highlighted).not.toContain('<script>')
+        // Shiki escapes `<` as a hex entity (`&#x3C;`); accept any `<` entity form.
+        expect(highlighted).toMatch(/&(lt|#x3C|#60);/i)
+        // ...and the fallback path.
+        const fallback = hl.highlight(payload, 'not-a-lang')
+        expect(fallback).not.toContain('<script>')
+        expect(fallback).toContain('&lt;script&gt;')
+    })
+
+    describe('adversarial lang (injection, not just robustness)', () => {
+        // The fenced-code info string is untrusted, agent/LLM-streamed input.
+        const adversarialLangs = [
+            '"><img src=x onerror=alert(1)>',
+            'js"><script>alert(1)</script>',
+            `'><svg onload=alert(1)>`,
+            'javascript" onmouseover="alert(1)'
+        ]
+
+        for (const lang of adversarialLangs) {
+            it(`does not emit unescaped markup originating from lang: ${lang.slice(0, 20)}…`, () => {
+                const hl = makeHighlighter()
+                const html = hl.highlight('const x = 1', lang)
+                // Unregistered -> fallback path.
+                expect(html).toContain('shiki-fallback')
+                // No raw element from the lang survived — angle brackets are escaped,
+                // so no `<img>/<svg>/<script>` tag boundary can form.
+                expect(html).not.toContain('<img')
+                expect(html).not.toContain('<svg')
+                expect(html).not.toContain('<script')
+                // The untrusted lang never appears verbatim (its quotes/brackets
+                // would break out of the attribute if interpolated raw)...
+                expect(html).not.toContain(lang)
+                // ...it appears only as its fully-escaped data-lang value.
+                expect(html).toContain('data-lang="')
+                expect(html).toContain(escapeHtml(lang))
+            })
+        }
+    })
+})

--- a/src/lib/extensions/shiki/createShikiHighlighter.ts
+++ b/src/lib/extensions/shiki/createShikiHighlighter.ts
@@ -1,0 +1,128 @@
+/**
+ * SPIKE — streaming-compatible Shiki syntax highlighting.
+ *
+ * This module wraps Shiki's **synchronous** core highlighter
+ * ({@link createHighlighterCoreSync}) with the pure-JavaScript regex engine so
+ * that highlighting happens at render time with no WASM load and no top-level
+ * `await`. That is the property that keeps the streaming diff path intact: the
+ * `code` renderer stays synchronous, so `SvelteMarkdown`'s `hasAsyncExtension`
+ * guard never trips and `streaming` is never silently disabled.
+ *
+ * The consumer supplies explicitly-imported languages and themes, e.g.
+ *
+ * ```ts
+ * import js from 'shiki/langs/javascript.mjs'
+ * import ts from 'shiki/langs/typescript.mjs'
+ * import githubDark from 'shiki/themes/github-dark.mjs'
+ * import { createShikiHighlighter } from '.../extensions/shiki'
+ *
+ * const highlighter = createShikiHighlighter({ langs: [js, ts], themes: [githubDark] })
+ * ```
+ *
+ * Only the languages/themes you import are bundled — nothing is pulled in
+ * dynamically — which is what keeps the core package's "lightweight" bundle
+ * positioning honest (see `scripts/tree-shaking.mjs`).
+ *
+ * @module
+ */
+
+import {
+    createHighlighterCoreSync,
+    type LanguageInput,
+    type LanguageRegistration,
+    type MaybeArray,
+    type ThemeInput,
+    type ThemeRegistrationAny
+} from 'shiki/core'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+
+/**
+ * Escape the five HTML-significant characters so untrusted text can never break
+ * out of its element or attribute context. Used by the unregistered-language
+ * fallback, which must **escape, never interpolate** its inputs — the fenced
+ * code `lang` is untrusted (agent/LLM-streamed) input in this package's
+ * headline use case.
+ */
+export const escapeHtml = (value: string): string =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+
+/** A minimal, synchronous highlighter facade consumed by `ShikiCode.svelte`. */
+export interface ShikiHighlighter {
+    /**
+     * Highlight `code` for `lang`, returning an HTML string. For an
+     * unregistered (or empty) `lang`, returns an escaped `<pre><code>` fallback
+     * instead of throwing — critical mid-stream, where an exception would tear
+     * down the render.
+     */
+    highlight(_code: string, _lang: string): string
+    /** Whether `lang` (name or alias) is registered on the highlighter. */
+    hasLang(_lang: string): boolean
+}
+
+export interface CreateShikiHighlighterOptions {
+    /** Explicitly-imported Shiki languages (e.g. `import js from 'shiki/langs/javascript.mjs'`). */
+    langs: LanguageInput[]
+    /** Explicitly-imported Shiki themes (e.g. `import theme from 'shiki/themes/github-dark.mjs'`). */
+    themes: ThemeInput[]
+    /**
+     * Theme name to render with. Defaults to the first loaded theme. Must match
+     * one of the loaded `themes`.
+     */
+    theme?: string
+}
+
+/**
+ * Escaped, dependency-free fallback for unregistered languages. Deliberately
+ * does **not** interpolate `lang` as raw markup; when present it is emitted as
+ * an escaped `data-lang` attribute value only.
+ */
+const renderFallback = (code: string, lang: string): string => {
+    const langAttr = lang ? ` data-lang="${escapeHtml(lang)}"` : ''
+    return `<pre class="shiki-fallback"${langAttr}><code>${escapeHtml(code)}</code></pre>`
+}
+
+/**
+ * Build a synchronous {@link ShikiHighlighter} from explicit languages/themes.
+ *
+ * @throws If `createHighlighterCoreSync` itself fails (e.g. a malformed
+ *   language registration) — construction is a one-time setup concern, not a
+ *   per-block/mid-stream one, so it is allowed to surface.
+ */
+export const createShikiHighlighter = (
+    options: CreateShikiHighlighterOptions
+): ShikiHighlighter => {
+    const highlighter = createHighlighterCoreSync({
+        engine: createJavaScriptRegexEngine(),
+        // Shiki's sync-mode types demand already-resolved registrations, but its
+        // sync loader also accepts the `{ default: … }` ESM module shape the
+        // consumer gets from `import js from 'shiki/langs/javascript.mjs'`
+        // (verified at runtime). Keep the ergonomic `LanguageInput`/`ThemeInput`
+        // public API and bridge that known typing quirk here.
+        langs: options.langs as unknown as MaybeArray<LanguageRegistration>[],
+        themes: options.themes as unknown as MaybeArray<ThemeRegistrationAny>[]
+    })
+
+    const loadedLangs = new Set(highlighter.getLoadedLanguages())
+    const theme = options.theme ?? highlighter.getLoadedThemes()[0]
+
+    return {
+        hasLang: (lang: string): boolean => loadedLangs.has(lang),
+        highlight(code: string, lang: string): string {
+            if (!lang || !loadedLangs.has(lang)) {
+                return renderFallback(code, lang)
+            }
+            try {
+                return highlighter.codeToHtml(code, { lang, theme })
+            } catch {
+                // Defensive: any per-block failure degrades to escaped text
+                // rather than throwing mid-stream.
+                return renderFallback(code, lang)
+            }
+        }
+    }
+}

--- a/src/lib/extensions/shiki/index.ts
+++ b/src/lib/extensions/shiki/index.ts
@@ -1,0 +1,18 @@
+/**
+ * SPIKE — streaming-compatible Shiki syntax-highlighting extension.
+ *
+ * Intentionally NOT wired into the `extensions` barrel or the `package.json`
+ * `exports` map: shipping is a follow-up decision (see the design report at
+ * `.agents/.plans/bigger-faster-stronger/004-shiki-spike-report.md`).
+ *
+ * @module
+ */
+
+export {
+    createShikiHighlighter,
+    escapeHtml,
+    type CreateShikiHighlighterOptions,
+    type ShikiHighlighter
+} from './createShikiHighlighter.js'
+export { default as ShikiCode } from './ShikiCode.svelte'
+export { SHIKI_CONTEXT_KEY, getShikiHighlighter, setShikiHighlighter } from './shikiContext.js'

--- a/src/lib/extensions/shiki/shikiContext.ts
+++ b/src/lib/extensions/shiki/shikiContext.ts
@@ -1,0 +1,38 @@
+/**
+ * SPIKE — highlighter injection strategies for `ShikiCode.svelte`.
+ *
+ * The `code` renderer is instantiated deep inside `SvelteMarkdown` via the
+ * `renderers` prop, which only forwards token-derived props (`lang`, `text`).
+ * There is therefore no ergonomic way to thread a per-instance `highlighter`
+ * prop through the standard renderers map, so the spike offers two out-of-band
+ * channels and lets `ShikiCode` resolve in priority order:
+ *
+ * 1. an explicit `highlighter` prop (only reachable if the consumer wraps
+ *    `ShikiCode` in their own component),
+ * 2. Svelte {@link https://svelte.dev/docs/svelte#setcontext | context} set by
+ *    an ancestor of `<SvelteMarkdown>` under {@link SHIKI_CONTEXT_KEY},
+ * 3. a module-level singleton set via {@link setShikiHighlighter}.
+ *
+ * The report recommends one of these for the ship plan.
+ *
+ * @module
+ */
+
+import type { ShikiHighlighter } from './createShikiHighlighter.js'
+
+/** Context key an ancestor of `<SvelteMarkdown>` can set to inject a highlighter. */
+export const SHIKI_CONTEXT_KEY = Symbol('svelte-markdown:shiki-highlighter')
+
+let singleton: ShikiHighlighter | undefined
+
+/**
+ * Register a process/module-wide highlighter used by every `ShikiCode` that
+ * receives neither a prop nor a context highlighter. Convenient for apps with a
+ * single global theme; pass `undefined` to clear (used in tests).
+ */
+export const setShikiHighlighter = (highlighter: ShikiHighlighter | undefined): void => {
+    singleton = highlighter
+}
+
+/** Read the current module-level singleton highlighter, if any. */
+export const getShikiHighlighter = (): ShikiHighlighter | undefined => singleton

--- a/src/routes/test/shiki-spike/+page.svelte
+++ b/src/routes/test/shiki-spike/+page.svelte
@@ -1,0 +1,282 @@
+<!--
+SPIKE demo route (plan 004) — human-eyes verification of the Shiki
+syntax-highlighting renderer extension.
+
+Open at /test/shiki-spike. Renders, with loud labels:
+  - registered languages (JavaScript, TypeScript, JSON) highlighted,
+  - an unregistered language falling back to escaped plain text,
+  - an adversarial (injection-crafted) fenced-code info string,
+  - a live streaming demo of a code-heavy document,
+plus an on-page indicator that the synchronous highlighter engaged and NO
+async-extension console warning fired (which would mean streaming was disabled).
+
+This route is intentionally NOT part of the shipped package — it lives under
+src/routes for local inspection only.
+-->
+<script lang="ts">
+    import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
+    import {
+        createShikiHighlighter,
+        ShikiCode,
+        setShikiHighlighter,
+        type ShikiHighlighter
+    } from '$lib/extensions/shiki/index.js'
+    import type { StreamingChunk } from '$lib/types.js'
+    import js from 'shiki/langs/javascript.mjs'
+    import json from 'shiki/langs/json.mjs'
+    import ts from 'shiki/langs/typescript.mjs'
+    import githubDark from 'shiki/themes/github-dark.mjs'
+
+    // --- Sync highlighter setup (no WASM, no top-level await) --------------
+    const setupStart = typeof performance !== 'undefined' ? performance.now() : 0
+    const highlighter: ShikiHighlighter = createShikiHighlighter({
+        langs: [js, ts, json],
+        themes: [githubDark]
+    })
+    const setupMs =
+        typeof performance !== 'undefined' ? (performance.now() - setupStart).toFixed(1) : 'n/a'
+    // Register the module singleton so ShikiCode resolves it everywhere.
+    setShikiHighlighter(highlighter)
+
+    // --- Async-extension warning watchdog ----------------------------------
+    // A synchronous renderer must NOT trip SvelteMarkdown's async-extension
+    // guard. Capture any such warning so we can show a red/green indicator.
+    let asyncWarningSeen = $state(false)
+    let warningsCaptured = $state<string[]>([])
+    if (typeof window !== 'undefined') {
+        const originalWarn = console.warn
+        console.warn = (...args: unknown[]) => {
+            const msg = args.map(String).join(' ')
+            warningsCaptured = [...warningsCaptured, msg]
+            if (msg.includes('async extension')) asyncWarningSeen = true
+            originalWarn(...args)
+        }
+    }
+
+    // --- Per-block timing for a representative block -----------------------
+    const timedBlock = Array.from(
+        { length: 30 },
+        (_, i) => `const value${i} = compute(a, b) + transform(items.map((x) => x.id))`
+    ).join('\n')
+    let perBlockMs = $state('measuring…')
+    if (typeof window !== 'undefined') {
+        // warm + time
+        for (let i = 0; i < 3; i++) highlighter.highlight(timedBlock, 'javascript')
+        const s = performance.now()
+        const N = 20
+        for (let i = 0; i < N; i++) highlighter.highlight(timedBlock, 'javascript')
+        perBlockMs = ((performance.now() - s) / N).toFixed(1)
+    }
+
+    // --- Static highlighted cases ------------------------------------------
+    const JS_SOURCE = `\`\`\`javascript
+function greet(name) {
+    const message = \`Hello, \${name}!\`
+    return message.toUpperCase()
+}
+\`\`\``
+
+    const TS_SOURCE = `\`\`\`typescript
+interface User {
+    id: number
+    name: string
+}
+const admin: User = { id: 1, name: 'root' }
+\`\`\``
+
+    const JSON_SOURCE = `\`\`\`json
+{ "streaming": true, "highlighter": "shiki", "async": false }
+\`\`\``
+
+    const UNREGISTERED_SOURCE = `\`\`\`rust
+fn main() { let x = a < b && c > d; println!("{}", x); }
+\`\`\``
+
+    // Adversarial fenced-code info string (untrusted LLM/agent input).
+    const ADVERSARIAL_LANG = '"><img src=x onerror=alert(1)>'
+    const ADVERSARIAL_CODE = 'const totallyFine = 1'
+
+    // --- Streaming demo ----------------------------------------------------
+    interface Handle {
+        writeChunk: (_chunk: StreamingChunk) => void
+        resetStream: (_next?: string) => void
+    }
+    let streamHandle = $state<Handle | undefined>()
+
+    const STREAM_DOC = `# Streaming a code-heavy document
+
+Prose arrives first, then a fenced block streams in token by token.
+
+\`\`\`typescript
+export async function loadUser(id: number): Promise<User> {
+    const res = await fetch(\`/api/users/\${id}\`)
+    if (!res.ok) throw new Error('not found')
+    return (await res.json()) as User
+}
+\`\`\`
+
+More prose appended **after** the code block — the completed block above
+must not re-highlight as these words stream in.`
+
+    let streaming = $state(false)
+    const startStream = async () => {
+        if (!streamHandle) return
+        streaming = true
+        streamHandle.resetStream()
+        const chunks = STREAM_DOC.match(/\S+\s*/g) ?? []
+        for (const chunk of chunks) {
+            streamHandle.writeChunk(chunk)
+            await new Promise((r) => setTimeout(r, 40))
+        }
+        streaming = false
+    }
+</script>
+
+<div class="page" data-testid="shiki-spike">
+    <h1>Shiki syntax-highlighting spike</h1>
+
+    <section class="status">
+        <div class="chip {asyncWarningSeen ? 'bad' : 'good'}" data-testid="async-indicator">
+            {asyncWarningSeen
+                ? '✗ async-extension warning fired — streaming DISABLED'
+                : '✓ Sync highlighter engaged — no async-extension warning (streaming stays ON)'}
+        </div>
+        <ul class="metrics">
+            <li>Highlighter setup (one-time, sync): <strong>{setupMs} ms</strong></li>
+            <li>Per-block highlight (~30 lines JS): <strong>{perBlockMs} ms</strong></li>
+            <li>Console warnings captured: <strong>{warningsCaptured.length}</strong></li>
+        </ul>
+    </section>
+
+    <section>
+        <h2 class="label">Case 1 — JavaScript (registered)</h2>
+        <div class="demo">
+            <SvelteMarkdown source={JS_SOURCE} renderers={{ code: ShikiCode }} />
+        </div>
+    </section>
+
+    <section>
+        <h2 class="label">Case 2 — TypeScript (registered)</h2>
+        <div class="demo">
+            <SvelteMarkdown source={TS_SOURCE} renderers={{ code: ShikiCode }} />
+        </div>
+    </section>
+
+    <section>
+        <h2 class="label">Case 3 — JSON (registered)</h2>
+        <div class="demo">
+            <SvelteMarkdown source={JSON_SOURCE} renderers={{ code: ShikiCode }} />
+        </div>
+    </section>
+
+    <section>
+        <h2 class="label">Case 4 — Unregistered language (rust) → escaped fallback</h2>
+        <p class="note">Should render as plain escaped text (no colors, no crash).</p>
+        <div class="demo">
+            <SvelteMarkdown source={UNREGISTERED_SOURCE} renderers={{ code: ShikiCode }} />
+        </div>
+    </section>
+
+    <section>
+        <h2 class="label">Case 5 — Adversarial lang (injection attempt)</h2>
+        <p class="note">
+            Info string: <code>{ADVERSARIAL_LANG}</code> — must NOT produce an
+            <code>&lt;img&gt;</code> or fire <code>onerror</code>. Rendered via ShikiCode directly
+            with the crafted lang.
+        </p>
+        <div class="demo" data-testid="adversarial-demo">
+            <ShikiCode lang={ADVERSARIAL_LANG} text={ADVERSARIAL_CODE} {highlighter} />
+        </div>
+        <p class="note">Escaped HTML the sink received:</p>
+        <pre class="raw">{highlighter.highlight(ADVERSARIAL_CODE, ADVERSARIAL_LANG)}</pre>
+    </section>
+
+    <section>
+        <h2 class="label">Case 6 — Live streaming demo (code-heavy)</h2>
+        <button onclick={startStream} disabled={streaming}>
+            {streaming ? 'Streaming…' : 'Start streaming'}
+        </button>
+        <div class="demo" data-testid="stream-demo">
+            <SvelteMarkdown
+                bind:this={streamHandle}
+                source=""
+                streaming
+                renderers={{ code: ShikiCode }}
+            />
+        </div>
+    </section>
+</div>
+
+<style>
+    .page {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+        font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
+    }
+    h1 {
+        font-size: 1.8rem;
+    }
+    .label {
+        font-size: 1.15rem;
+        margin-top: 2rem;
+        padding: 0.4rem 0.6rem;
+        background: #1e293b;
+        color: #fff;
+        border-radius: 6px;
+    }
+    .note {
+        color: #475569;
+        font-size: 0.9rem;
+    }
+    .demo {
+        border: 2px dashed #cbd5e1;
+        border-radius: 8px;
+        padding: 0.75rem;
+        margin: 0.5rem 0;
+        overflow-x: auto;
+    }
+    .status {
+        margin: 1rem 0 2rem;
+    }
+    .chip {
+        display: inline-block;
+        padding: 0.6rem 1rem;
+        border-radius: 8px;
+        font-weight: 600;
+        color: #fff;
+    }
+    .chip.good {
+        background: #16a34a;
+    }
+    .chip.bad {
+        background: #dc2626;
+    }
+    .metrics {
+        margin-top: 0.75rem;
+        line-height: 1.7;
+    }
+    .raw {
+        background: #f1f5f9;
+        padding: 0.5rem;
+        border-radius: 6px;
+        font-size: 0.8rem;
+        white-space: pre-wrap;
+        word-break: break-all;
+    }
+    button {
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
+        border: 1px solid #334155;
+        background: #334155;
+        color: #fff;
+        cursor: pointer;
+    }
+    button:disabled {
+        opacity: 0.6;
+        cursor: default;
+    }
+</style>


### PR DESCRIPTION
## Summary

First-class **Shiki syntax highlighting** for streaming AI output — the feature this repo's own comparison pages conceded to every competitor. Built in two verified phases: a spike proving the design premise (commit `fb9d268`, guard-PASSed), then the ship wiring + full docs treatment (`99464d6`).

The design that makes it work: highlighting lives entirely at the **renderer level** — no marked tokenizer, no walkTokens — using Shiki's synchronous core (`createHighlighterCoreSync` + JS regex engine, no WASM). So `streaming` stays enabled, the incremental tail-window is untouched, and the parser never knows highlighting exists.

## What ships

- **`@humanspeak/svelte-markdown/extensions/shiki`** subpath + barrel exports: `createShikiHighlighter`, `ShikiCode`, context/singleton injection, types
- **`shiki >=4.0.0` as optional peer dependency** (mirrors katex/mermaid); core bundle stays shiki-free — gated by 3 new tree-shaking cases (9 total)
- **README**: Syntax Highlighting section with honest bundle guidance (opt-in ~85 KB gzip for JS engine + 2 langs + 1 theme)
- **Docs site**: first-class page at `/docs/advanced/syntax-highlighting`, live example at `/examples/shiki` (editor demo + fallback demo), nav entries, and every "no built-in syntax highlighting" con on the comparison pages flipped to the opt-in Shiki pro (competitor descriptions left accurate)

## Safety & performance (guard re-verified)

- **Streaming parity**: no async-extension warning; DOM matches non-streaming render
- **Injection-safe**: untrusted `lang` values (fenced-code info strings) only reach the `{@html}` sink escaped — the fallback escapes, never interpolates
- **Memoized**: unchanged code blocks are never re-highlighted mid-stream (spy-verified)
- Per-block cost ~1.2–1.7 ms/line on the JS engine; oniguruma-WASM documented as a ~2.5× option in the docs page
- Design report with full numbers: `.agents/.plans/bigger-faster-stronger/004-shiki-spike-report.md`

## Verify

- Library demo: `pnpm dev` → `/test/shiki-spike`
- Docs: `pnpm --filter docs dev` → `/docs/advanced/syntax-highlighting` and `/examples/shiki`

## Gates

`pnpm test` 144 files / 958 tests + coverage; `pnpm check` 0 errors; `pnpm test:tree-shaking` 9/9; `pnpm build` publint "All good!"; `pnpm --filter docs build` + `check` clean; trunk clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
