### PR TITLE
docs: reconcile CLAUDE.md with shipped sanitizer defaults and CI matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,9 @@ src/
 │   │   └── html/             # HTML element renderers
 │   │       └── *.svelte      # Individual HTML tags (Div, Span, etc.)
 │   └── utils/                # Utility functions
-│       ├── markdown-parser.js
+│       ├── markdown-parser.ts
+│       ├── incremental-parser.ts # Streaming tail-window parser
+│       ├── sanitize.ts       # Default URL/attribute sanitizers
 │       ├── token-cache.ts    # LRU caching for parsed tokens
 │       ├── cache.ts          # Generic memory cache
 │       ├── rendererKeys.ts   # Canonical renderer key lists
@@ -140,7 +142,11 @@ buildUnsupportedRenderers() // Block all markdown renderers
 
 The following are explicitly out of scope:
 
-- Built-in HTML sanitization (provide hooks instead)
+- A bundled full DOM sanitizer (e.g. DOMPurify). The library ships
+  safe-by-default URL/attribute sanitization (`src/lib/utils/sanitize.ts`,
+  wired as prop defaults) — but full HTML sanitization of untrusted input
+  stays the consumer's responsibility, layered via the `sanitizeUrl` /
+  `sanitizeAttributes` hooks or an external sanitizer.
 - Remote fetching of markdown documents
 - WYSIWYG editor functionality
 
@@ -148,7 +154,7 @@ The following are explicitly out of scope:
 
 1. **`src/lib/index.ts`** - All public exports
 2. **`src/lib/SvelteMarkdown.svelte`** - Main component implementation
-3. **`src/lib/utils/markdown-parser.js`** - Token parsing logic
+3. **`src/lib/utils/markdown-parser.ts`** - Token parsing logic
 4. **`src/lib/renderers/`** - Individual renderer components
 5. **`README.md`** - Usage documentation
 
@@ -157,13 +163,18 @@ The following are explicitly out of scope:
 - Tests required for new features
 - Coverage must remain at 90%+
 - Pre-commit hooks will format code automatically
-- CI runs on Node 20, 22, and 24
+- CI runs on Node 22 and 24 (`engines`: node >=22)
 - Package published automatically on release via GitHub Actions
 - **README.md must be updated** when adding new features, props, or public API changes
 
 ## Security Considerations
 
-- No built-in HTML sanitization by default
-- XSS protection through secure parsing
-- Users should integrate their own sanitizer if needed
+- Safe-by-default sanitization ships enabled: `defaultSanitizeUrl` (protocol
+  allowlist blocking `javascript:`/`data:`/`vbscript:`) and
+  `defaultSanitizeAttributes` (strips `on*` handlers and `srcdoc`, sanitizes
+  URL attributes) are the default `sanitizeUrl`/`sanitizeAttributes` props —
+  see `src/lib/utils/sanitize.ts`
+- No bundled full DOM sanitizer — for untrusted input, layer DOMPurify (or
+  similar) on top; the defaults are XSS hardening, not complete sanitization
+- XSS protection through secure parsing (HTMLParser2)
 - Use `allowHtmlOnly`/`excludeHtmlOnly` to restrict HTML tags


### PR DESCRIPTION
## Summary

Fixes the CLAUDE.md drift flagged by the bigger-faster-stronger audit (findings DEBT-01/DX-01). The agent-facing decision doc contradicted shipped behavior in a security-relevant way: it told agents "no built-in HTML sanitization" while `sanitize.ts` defaults are wired as prop defaults and the package markets "XSS-safe defaults" — an agent trusting the doc could remove the defaults as an out-of-scope "non-goal" or re-implement what already exists.

## Changes

- 📚 **Non-Goals**: the genuine non-goal is now stated precisely — no *bundled full DOM sanitizer* (DOMPurify-class); the shipped URL/attribute sanitization defaults are acknowledged with pointers to the `sanitizeUrl`/`sanitizeAttributes` hooks
- 📚 **Security Considerations**: describes what actually ships (`defaultSanitizeUrl` protocol allowlist, `defaultSanitizeAttributes` stripping `on*`/`srcdoc`) and the honest boundary (XSS hardening, not complete sanitization)
- 📚 **CI claim**: Node 20/22/24 → Node 22 and 24 (verified against both workflows; `engines: node >=22`)
- 📚 **File references**: `markdown-parser.js` → `markdown-parser.ts` (both occurrences); structure tree gains `sanitize.ts` and `incremental-parser.ts`

Docs-site updates (e.g. flipping the "no built-in syntax highlighting" cons in compare-data) deliberately wait on the shiki spike ship decision (#361).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
