### PR TITLE
test(redraw): pin Parser-count and DOM-identity across streaming flushes

### DIFF
--- a/.agents/.plans/redraw-hardening/001-redraw-regression-harness.guard-report.md
+++ b/.agents/.plans/redraw-hardening/001-redraw-regression-harness.guard-report.md
@@ -1,0 +1,33 @@
+# Guard report — 001 redraw-regression-harness
+
+**Recommendation: PASS** — all done criteria reproduced green by guard; the harness asserts exactly the bounds the plan specified, with no source files touched.
+**Reviewed at** fd3f8a5 · 2026-07-13 14:59 · **Plan planned at** eed2e08
+**Integrated** — PR <https://github.com/humanspeak/svelte-markdown/pull/365> opened via the `pr` skill for the reviewed snapshot commit
+
+## Done criteria
+
+| Criterion                                                        | Result | Evidence                                                                                                                                      |
+| ---------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm check` exits 0                                             | met    | guard-run: `COMPLETED 1042 FILES 0 ERRORS 4 WARNINGS` (warnings pre-existing), exit 0                                                         |
+| `pnpm test` exits 0 with thresholds; new test file exists+passes | met    | guard-run: exit 0, coverage 96.13% Stmts / 90.44% Branch / 96.29% Funcs / 97.69% Lines; targeted run of the new file: 5/5 passed              |
+| Delta assertions exact/bounded as specified — not loosened       | met    | `redraw-regression.test.ts:88` `toBe(0)` for in-place growth; lines 110-111 and 164-165 `>=1 && <=3` for new blocks; observed `// current: 1` |
+| `git status` shows no modified files outside the in-scope list   | met    | diff `0506f2d...fd3f8a5` touches only the new test file and the README status row; `Parser.svelte`/`SvelteMarkdown.svelte`/utils untouched    |
+| README status row for 001 updated                                | met    | `.agents/.plans/redraw-hardening/README.md` row 001 → DONE                                                                                    |
+
+## Spirit
+
+The plan's purpose was to turn the dev-only `__svmParserCount` instrumentation into permanent CI tripwires so the library's entire anti-redraw stack — source-offset stable keys, streaming prefix reuse, inline fast paths — stops being unguarded, specifically as the safety net for plan 011's high-risk refactor. The delivered harness does exactly that: five tests covering counter liveness (calibration first, the plan's red-equivalent), zero-Parser in-place tail growth, O(1) new-block cost with the observed baseline documented in-line, and DOM node identity across both streaming flushes and non-streaming source replacement. Every assertion is a delta from a snapshot (correct for the cumulative counter) and every bound is the plan's own — a whole-document redraw regression would now fail this file loudly rather than hiding in noisy wall-clock timings. Intent fully delivered.
+
+## Scope & conduct
+
+- In-scope only? Yes — one new file `src/lib/SvelteMarkdown.redraw-regression.test.ts` plus the README status row. No source, bench-page, or Playwright changes.
+- STOP conditions respected? Yes — none triggered: counter was live in Step 1, in-place delta was 0, identity assertions held, `writeChunk` existed. The executor also self-corrected a briefly-drafted `eslint-disable` comment (forbidden by CLAUDE.md) before finishing; the final file contains none.
+- Plan amendments during execution: none.
+- Accepted in-spirit deviations: Step 3 runs as a separate test with a fresh render rather than continuing Step 2's stream (equivalent tripwire; the plan's Test plan enumerates them as separate items); the unused `readParserByType` helper was dropped once the calibration log was removed.
+
+## Residual risk / follow-ups
+
+- The tree moved from `eed2e08` (planned-at) to `0506f2d` (v1.8.0) between planning and execution; the scoped drift check on the three watched files was empty, so the plan's counter semantics remained exact.
+- These tests are the tripwire for plan 011: 011 must land with this file green and unmodified — enforce that in 011's review.
+- The `[1, 3]` band and `// current: 1` baseline are deliberate; any future PR that changes these numbers must justify the new baseline in-line (plan's maintenance note).
+- The counter is DEV-only; production builds compile it out, so this harness is unit-level only. An E2E variant was deliberately deferred by the plan.

--- a/.agents/.plans/redraw-hardening/001-redraw-regression-harness.guard.md
+++ b/.agents/.plans/redraw-hardening/001-redraw-regression-harness.guard.md
@@ -1,0 +1,12 @@
+# Guard log — 001 redraw-regression-harness
+
+## Checkpoint 1 — 2026-07-13 14:59 — ON TRACK
+
+fd3f8a5 · final close-out — full review of the executor's complete run (dispatched by operator, Opus 4.8, isolated worktree)
+
+- Pre-dispatch drift check clean: `git diff --stat eed2e08..HEAD -- src/lib/Parser.svelte src/lib/SvelteMarkdown.svelte src/lib/SvelteMarkdown.stream-id.test.ts` empty despite main moving to v1.8.0 since planning.
+- Contribution diff is exactly the in-scope list: new `src/lib/SvelteMarkdown.redraw-regression.test.ts` (167 lines, 5 tests) plus README row 001 → DONE. Zero source files touched; no plan-file or guard-file edits.
+- Assertions read in full and match the plan without loosening: in-place tail growth delta asserted `toBe(0)` (line 88); new-block delta asserted `>=1 && <=3` with observed value recorded as `// current: 1` (lines 105-111); DOM identity via `toBe(h1)` / `toBe(firstP)` after two flushes (lines 137-138); non-streaming rerender preserves prefix identity with bounded delta (lines 160-165). Calibration test proves the DEV counter is live (line 68-69). All deltas measured from snapshots, never absolutes, per the counter's cumulative semantics.
+- Done criteria reproduced by guard: targeted file 5/5 passed; `pnpm check` exit 0 (0 errors); `pnpm test` exit 0 (coverage 96.13/90.44/96.29/97.69, thresholds met); calibration `console.info` absent (0 console statements in file).
+- Minor in-spirit deviations, judged acceptable: Step 3's new-block tripwire is a separate test with a fresh render rather than literally continuing Step 2's stream (the plan's own Test plan lists them as separate coverage items; the tripwire is equivalent); an unused `readParserByType` helper from the Step 1 scaffold was dropped after the calibration log was removed (would have been an unused-var lint error).
+- Action: PASS at final; PR opened via the `pr` skill (URL in close-out report). Reported to operator.

--- a/.agents/.plans/redraw-hardening/README.md
+++ b/.agents/.plans/redraw-hardening/README.md
@@ -14,7 +14,7 @@ conditions, and update your row when done.
 
 | Plan | Title                                                                  | Priority | Effort | Risk | Depends on             | Status |
 | ---- | ---------------------------------------------------------------------- | -------- | ------ | ---- | ---------------------- | ------ |
-| 001  | Redraw regression harness (Parser-count + DOM-identity tripwires)      | P1       | S–M    | LOW  | —                      | TODO   |
+| 001  | Redraw regression harness (Parser-count + DOM-identity tripwires)      | P1       | S–M    | LOW  | —                      | DONE   |
 | 002  | Stream resets replace the token array instead of mutating `length`     | P3       | S      | LOW  | —                      | TODO   |
 | 011  | Unify streaming token-reuse identity + generic child walk (#331, #333) | P2       | L      | HIGH | 001 (soft), 002 (soft) | TODO   |
 

--- a/src/lib/SvelteMarkdown.redraw-regression.test.ts
+++ b/src/lib/SvelteMarkdown.redraw-regression.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Redraw-regression harness.
+ *
+ * This library's streaming render path leans on a stack of anti-redraw
+ * machinery: source-offset stable keys on every `{#each}` block, streaming
+ * prefix reuse by object identity, recursive tail-token reuse, and inline
+ * fast paths that skip Parser instantiation for text/space/default-HTML
+ * tokens. None of that was guarded by an automated test — only a manual
+ * bench page read the dev-only instantiation counter (`window.__svmParserCount`).
+ *
+ * These tests convert that counter into permanent CI tripwires plus DOM
+ * node-identity assertions, so a keying/reuse regression fails loudly instead
+ * of only showing up as a wall-clock slowdown (which `performance.test.ts` is
+ * far too noisy to catch).
+ *
+ * The counter is DEV-only (`import.meta.env.DEV`) and cumulative across every
+ * test in the file, so every assertion is a DELTA from a snapshot taken right
+ * before the action under test — never an absolute count.
+ */
+
+import '@testing-library/jest-dom'
+import { act, render, screen } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import SvelteMarkdown from './SvelteMarkdown.svelte'
+import { tokenCache } from './utils/token-cache.js'
+
+beforeEach(() => {
+    tokenCache.clearAllTokens()
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+        return setTimeout(() => cb(performance.now()), 16) as unknown as number
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+})
+
+const flushStreamingBatch = async () => {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(50)
+    })
+}
+
+interface SVMWindow extends Window {
+    __svmParserCount?: number
+    __svmParserByType?: Record<string, number>
+}
+const readParserCount = () => (window as SVMWindow).__svmParserCount ?? 0
+
+describe('redraw regression harness', () => {
+    test('calibration: the DEV Parser counter is live under Vitest', async () => {
+        const before = readParserCount()
+        const { component, container } = render(SvelteMarkdown, {
+            props: { source: '', streaming: true }
+        })
+        await act(() => component.writeChunk('# Title\n\nFirst paragraph.\n\nSecond para'))
+        await flushStreamingBatch()
+
+        expect(container.querySelectorAll('h1')).toHaveLength(1)
+        expect(container.querySelectorAll('p')).toHaveLength(2)
+
+        // Counter must have advanced past the pre-render snapshot: this proves
+        // the `import.meta.env.DEV` guard in Parser.svelte is active here.
+        expect(readParserCount()).toBeGreaterThan(before)
+        expect(readParserCount()).toBeGreaterThan(0)
+    })
+
+    test('growing the tail block in place spawns zero new Parsers', async () => {
+        const { component, container } = render(SvelteMarkdown, {
+            props: { source: '', streaming: true }
+        })
+        await act(() => component.writeChunk('# Title\n\nFirst paragraph.\n\nSecond para'))
+        await flushStreamingBatch()
+        expect(container.querySelectorAll('p')).toHaveLength(2)
+
+        // The appended text extends the still-open second paragraph. Its token
+        // is replaced but its source-offset key is stable, so the keyed each
+        // block updates in place — no token remounts, no new Parser instances.
+        const before = readParserCount()
+        await act(() => component.writeChunk(' grows in place with more text'))
+        await flushStreamingBatch()
+
+        expect(screen.getByText(/grows in place/)).toBeInTheDocument()
+        expect(readParserCount() - before).toBe(0)
+    })
+
+    test('appending a new block costs O(1) Parsers, not O(document)', async () => {
+        const { component, container } = render(SvelteMarkdown, {
+            props: { source: '', streaming: true }
+        })
+        await act(() => component.writeChunk('# Title\n\nFirst paragraph.\n\nSecond para'))
+        await flushStreamingBatch()
+        expect(container.querySelectorAll('p')).toHaveLength(2)
+
+        const before = readParserCount()
+        await act(() => component.writeChunk('\n\nThird paragraph.\n\n'))
+        await flushStreamingBatch()
+
+        expect(container.querySelectorAll('p')).toHaveLength(3)
+
+        // current: 1 — one new Parser for the appended paragraph token; its
+        // leaf text child is inlined (issue #286), so it costs nothing. The
+        // [1, 3] band leaves headroom for benign structural churn while still
+        // catching a whole-document redraw, which would be >= the block count.
+        const delta = readParserCount() - before
+        expect(delta).toBeGreaterThanOrEqual(1)
+        expect(delta).toBeLessThanOrEqual(3)
+    })
+
+    test('DOM node identity survives streaming flushes', async () => {
+        const { component, container } = render(SvelteMarkdown, {
+            props: { source: '', streaming: true }
+        })
+        await act(() => component.writeChunk('# Title\n\nFirst paragraph.\n\nSecond para'))
+        await flushStreamingBatch()
+
+        const h1 = container.querySelector('h1')
+        const firstP = container.querySelectorAll('p')[0]
+        expect(h1).not.toBeNull()
+        expect(firstP).not.toBeUndefined()
+
+        // In-place growth of the open tail block.
+        await act(() => component.writeChunk(' grows in place with more text'))
+        await flushStreamingBatch()
+
+        // A brand-new appended block.
+        await act(() => component.writeChunk('\n\nThird paragraph.\n\n'))
+        await flushStreamingBatch()
+
+        // The unchanged prefix — the heading and the first paragraph — keeps
+        // its source-offset keys through both flushes, so Svelte must update
+        // those keyed blocks in place rather than recreate their DOM nodes.
+        expect(container.querySelector('h1')).toBe(h1)
+        expect(container.querySelectorAll('p')[0]).toBe(firstP)
+    })
+
+    test('non-streaming source replacement preserves prefix DOM with bounded delta', async () => {
+        const { container, rerender } = render(SvelteMarkdown, {
+            props: { source: '# Title\n\nPara one.\n\nPara two.' }
+        })
+
+        const h1 = container.querySelector('h1')
+        const firstP = container.querySelectorAll('p')[0]
+        expect(h1).not.toBeNull()
+        expect(firstP).not.toBeUndefined()
+
+        const before = readParserCount()
+        await act(() => rerender({ source: '# Title\n\nPara one.\n\nPara two.\n\nPara three.' }))
+
+        expect(container.querySelectorAll('p')).toHaveLength(3)
+
+        // A full re-parse produces all-new token objects, but the source-offset
+        // keys of the unchanged prefix are identical, so its keyed blocks (and
+        // therefore DOM nodes and Parser instances) stay alive. Only the newly
+        // appended block should instantiate — a small constant, never O(blocks).
+        expect(container.querySelector('h1')).toBe(h1)
+        expect(container.querySelectorAll('p')[0]).toBe(firstP)
+
+        const delta = readParserCount() - before
+        expect(delta).toBeGreaterThanOrEqual(1)
+        expect(delta).toBeLessThanOrEqual(3)
+    })
+})


### PR DESCRIPTION
## Summary

Converts the dev-only Parser instantiation counter (`window.__svmParserCount`) into permanent CI tripwires guarding the library's anti-redraw machinery — source-offset stable keys, streaming prefix reuse, and inline fast paths — none of which had automated coverage (only a manual bench page and noisy wall-clock timings). History shows keying regressions are subtle (#291, #328, #339); this harness makes them fail loudly and is the prerequisite safety net for the upcoming plan-011 token-reuse refactor.

Executed from plan 001 of the redraw-hardening batch (`.agents/.plans/redraw-hardening/001-redraw-regression-harness.md`); guard-verified — see the accompanying guard report on this branch.

## Changes

- 🧪 New `src/lib/SvelteMarkdown.redraw-regression.test.ts` (5 tests, no source changes):
    - calibration — the DEV counter is live under Vitest JSDOM
    - in-place tail growth spawns exactly **0** new Parsers
    - a new appended block costs O(1) Parsers (observed 1, bounded [1, 3])
    - h1/first-p DOM node identity survives streaming flushes
    - non-streaming source replacement preserves prefix DOM with bounded delta

## Commits

- [`fd3f8a5`](https://github.com/humanspeak/svelte-markdown/commit/fd3f8a53055e2c73af5764ceb378bae985dc326e) test(redraw): pin Parser-count and DOM-identity across streaming flushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
