### PR TITLE
chore(plans): re-baseline plan 011 after 001/002 landed

### DIFF
--- a/.agents/.plans/redraw-hardening/011-unify-token-reuse-identity.guard.md
+++ b/.agents/.plans/redraw-hardening/011-unify-token-reuse-identity.guard.md
@@ -1,0 +1,12 @@
+# Guard log — 011 unify-token-reuse-identity
+
+## Checkpoint 1 — 2026-07-13 16:14 — PLAN AMENDED
+
+pre-execution · baseline amendment before dispatch; no executor work exists yet
+
+- Trigger: 011's drift check (`eed2e08..HEAD` over the three in-scope source files) fires on `src/lib/SvelteMarkdown.svelte` — 10 changed lines, all from this batch's own landed work (plan 002's three reset-site swaps via PR #364 plus two operator-approved invariant comments). `incremental-parser.ts` and `streaming-token-reuse.ts` are byte-identical since `eed2e08` (guard-verified with `git diff --stat`).
+- Classification: plan defect, not executor drift — the plan itself anticipated this ordering ("Land 002 first too"), so the stale baseline is expected reality the plan must re-stamp, and there is no executor whose work could be at fault.
+- Operator approval: explicit ("Yes amend it"), 2026-07-13.
+- Amendment (all in `011-unify-token-reuse-identity.md`): drift-check and STOP-condition baseline `eed2e08` → `e8940c5`; `Planned at` re-stamped; the `SvelteMarkdown.svelte:184-186` assignment refs updated to `:188-190` (guard verified the excerpt content still matches live code at the new lines); revision note added under the executor-instructions block, including a pointer to the new replace-never-shrink invariant at the `streamTokens` declaration. Batch README dependency note updated to record the re-baseline.
+- Standard resisted: no done criterion, scope boundary, or STOP condition was weakened — only the baseline SHA and line references moved to match merged, guard-verified work.
+- Action: amendment committed on `plans/011-rebaseline` for PR to main (skip-publish); 011 must not be dispatched until it merges, so the executor reads the amended plan.

--- a/.agents/.plans/redraw-hardening/011-unify-token-reuse-identity.md
+++ b/.agents/.plans/redraw-hardening/011-unify-token-reuse-identity.md
@@ -6,8 +6,19 @@
 > `.agents/.plans/redraw-hardening/README.md` when done.
 >
 > **Drift check (run first)**:
-> `git diff --stat eed2e08..HEAD -- src/lib/utils/incremental-parser.ts src/lib/utils/streaming-token-reuse.ts src/lib/SvelteMarkdown.svelte`
+> `git diff --stat e8940c5..HEAD -- src/lib/utils/incremental-parser.ts src/lib/utils/streaming-token-reuse.ts src/lib/SvelteMarkdown.svelte`
 > On any change, compare "Current state" excerpts to live code; mismatch ⇒ STOP.
+>
+> Revision 2026-07-13 (guard, operator-approved): re-baselined the drift check
+> from `eed2e08` to `e8940c5` after plans 001/002 of this batch landed on main
+> (PRs #365/#364). Guard verified all "Current state" excerpts against
+> `e8940c5`: `incremental-parser.ts` and `streaming-token-reuse.ts` are
+> byte-identical since `eed2e08`; in `SvelteMarkdown.svelte` only plan 002's
+> reset-site swaps and two invariant comments landed, shifting the streaming
+> assignment excerpt from lines 184-186 to 188-190 (refs updated below).
+> Note for the executor: the reset sites now use `streamTokens = []` — your
+> collapsed assignment must follow the same replace-never-shrink invariant
+> documented at the `streamTokens` declaration (`SvelteMarkdown.svelte:133`).
 >
 > **Carried over 2026-07-13**: this plan was authored in the (now closed)
 > `streaming-component-hardening` batch at `939f154` and never executed. It was
@@ -29,7 +40,7 @@
   003/005/007 prerequisites from the source batch all landed already.)
 - **Category**: tech-debt (structural correctness hardening)
 - **Planned at**: commit `939f154`, 2026-07-07; refreshed against `eed2e08`,
-  2026-07-13
+  2026-07-13; re-baselined against `e8940c5` (post-001/002), 2026-07-13
 - **Absorbs GitHub issues**: #331 (single identity rule) and #333 (generic child
   walk). Close both when this lands.
 
@@ -98,7 +109,7 @@ unchanged.
 
 Reuse module, `src/lib/utils/streaming-token-reuse.ts:13-35` (`hasSameStableNodeIdentity`)
 and `:80-107` (`reuseStableNode` with the enumerated `tokens`/`items`/`header`/
-`rows` walk). The module is consumed at `src/lib/SvelteMarkdown.svelte:184-186`:
+`rows` walk). The module is consumed at `src/lib/SvelteMarkdown.svelte:188-190`:
 
 ```ts
 streamTokens = canReuse ? reuseStableStreamingTokens(streamTokens, newTokens, divergeAt) : newTokens
@@ -135,7 +146,7 @@ identity rule is correct on its own.
   and delete it, or reduce it to a single shared identity predicate the parser
   imports. Generic child walk (all array-of-nodes own-properties) replaces the
   enumerated keys.
-- `src/lib/SvelteMarkdown.svelte` — collapse the `canReuse` branch at 184-186.
+- `src/lib/SvelteMarkdown.svelte` — collapse the `canReuse` branch at 188-190.
 - Test files: recreate `streaming-reuse-repro.test.ts`; update
   `streaming-token-reuse.test.ts` and `incremental-parser.test.ts` to match the
   new surface.
@@ -204,7 +215,7 @@ merge use — that is the "one rule" requirement. Do not yet move it into
 
 Make `update()` return `tokens` that are **already the reused array** (splice the
 stable prefix from `prevTokens`, deep-merge the boundary token via the shared
-predicate/walk). Then change `SvelteMarkdown.svelte:184-186` to
+predicate/walk). Then change `SvelteMarkdown.svelte:188-190` to
 `streamTokens = newTokens` unconditionally. Remove `reuseStableStreamingTokens`,
 `divergeAt`, and `canReuse` from the public surface **only after** all callers are
 migrated. Preserve `divergeOffset` and `streamRenderMetadataStartIndex/Offset`
@@ -254,7 +265,7 @@ ALL must hold:
 
 ## STOP conditions
 
-- Any in-scope file drifted from the excerpts since eed2e08.
+- Any in-scope file drifted from the excerpts since e8940c5.
 - Plan 001's redraw-regression tests fail or need their delta baselines
   changed to pass — that means this refactor altered render identity; report
   the failing assertion and the `__svmParserByType` breakdown.

--- a/.agents/.plans/redraw-hardening/README.md
+++ b/.agents/.plans/redraw-hardening/README.md
@@ -31,9 +31,10 @@ REJECTED (one-line rationale).
 - **011 keeps its original number**: it was authored in the (now closed)
   `.agents/.plans-closed/streaming-component-hardening/` batch as plan 011,
   was never executed, and was carried over here on 2026-07-13 with refreshed
-  line references and drift baseline (`eed2e08`). The number is preserved for
-  traceability with GitHub issues #331/#333 and the source batch's guard
-  reports.
+  line references and drift baseline (`eed2e08`); after 001/002 landed it was
+  re-baselined to `e8940c5` (guard amendment, operator-approved, 2026-07-13).
+  The number is preserved for traceability with GitHub issues #331/#333 and
+  the source batch's guard reports.
 
 ## Findings considered and rejected
 


### PR DESCRIPTION
## Summary

Guard amendment (operator-approved) re-baselining plan 011 of the redraw-hardening batch before its executor is dispatched. Plans 001 (#365) and 002 (#364) landed on main, so 011's drift check against `eed2e08` now fires on `SvelteMarkdown.svelte` — entirely our own merged work. Guard verified every "Current state" excerpt against `e8940c5`: the two parser/reuse files are byte-identical since planning; only the component's line numbers shifted (+4) from plan 002's comments. No done criterion, scope boundary, or STOP condition was weakened.

## Changes

- 📚 Plan 011: drift-check + STOP baseline `eed2e08` → `e8940c5`; assignment refs `:184-186` → `:188-190`; dated revision note with executor guidance on the replace-never-shrink invariant
- 📚 Batch README: dependency note records the re-baseline
- 📚 New guard log for 011 with the PLAN AMENDED entry

## Commits

- [`bd617a7`](https://github.com/humanspeak/svelte-markdown/commit/bd617a7c4b2076afeffb77dd994feebcda3f2539) chore(plans): re-baseline plan 011 to e8940c5 after 001/002 landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
