### PR TITLE
test(streaming): extract shared rAF/fake-timer test harness

### DIFF
--- a/src/lib/SvelteMarkdown.issue-328.test.ts
+++ b/src/lib/SvelteMarkdown.issue-328.test.ts
@@ -11,36 +11,18 @@
 import '@testing-library/jest-dom'
 import { act, render } from '@testing-library/svelte'
 import Slugger from 'github-slugger'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import SvelteMarkdown from './SvelteMarkdown.svelte'
 import StableHeading from './test/issues/issue-328/StableHeading.svelte'
 import TrackedListItem from './test/issues/issue-328/TrackedListItem.svelte'
 import TrackedParagraph from './test/issues/issue-328/TrackedParagraph.svelte'
+import { flushStreamingBatch, useStreamingTestHarness } from './test/streaming/harness.js'
 import type { SvelteMarkdownProps } from './types.js'
 import type { Renderers, Token } from './utils/markdown-parser.js'
-import { tokenCache } from './utils/token-cache.js'
 
 type TestListItemToken = Token & { text?: string }
 
-beforeEach(() => {
-    tokenCache.clearAllTokens()
-    vi.useFakeTimers()
-    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-        return setTimeout(() => callback(performance.now()), 16) as unknown as number
-    })
-    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
-})
-
-afterEach(() => {
-    vi.unstubAllGlobals()
-    vi.useRealTimers()
-})
-
-const flushStreamingBatch = async () => {
-    await act(async () => {
-        await vi.advanceTimersByTimeAsync(50)
-    })
-}
+useStreamingTestHarness()
 
 const headingIds = (container: HTMLElement) =>
     Array.from(container.querySelectorAll('h1,h2,h3,h4,h5,h6'), (heading) => heading.id)

--- a/src/lib/SvelteMarkdown.redraw-regression.test.ts
+++ b/src/lib/SvelteMarkdown.redraw-regression.test.ts
@@ -20,30 +20,11 @@
 
 import '@testing-library/jest-dom'
 import { act, render, screen } from '@testing-library/svelte'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import SvelteMarkdown from './SvelteMarkdown.svelte'
-import { tokenCache } from './utils/token-cache.js'
+import { flushStreamingBatch, useStreamingTestHarness } from './test/streaming/harness.js'
 
-beforeEach(() => {
-    tokenCache.clearAllTokens()
-    vi.useFakeTimers()
-    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-        return setTimeout(() => cb(performance.now()), 16) as unknown as number
-    })
-    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
-})
-
-afterEach(() => {
-    vi.unstubAllGlobals()
-    vi.useRealTimers()
-    vi.restoreAllMocks()
-})
-
-const flushStreamingBatch = async () => {
-    await act(async () => {
-        await vi.advanceTimersByTimeAsync(50)
-    })
-}
+useStreamingTestHarness()
 
 interface SVMWindow extends Window {
     __svmParserCount?: number

--- a/src/lib/SvelteMarkdown.stream-id.test.ts
+++ b/src/lib/SvelteMarkdown.stream-id.test.ts
@@ -19,34 +19,12 @@
 
 import '@testing-library/jest-dom'
 import { act, render } from '@testing-library/svelte'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import SvelteMarkdown from './SvelteMarkdown.svelte'
+import { flushStreamingBatch, useStreamingTestHarness } from './test/streaming/harness.js'
 import StreamIdRaceHarness from './test/streaming/StreamIdRaceHarness.svelte'
-import { tokenCache } from './utils/token-cache.js'
 
-beforeEach(() => {
-    tokenCache.clearAllTokens()
-    vi.useFakeTimers()
-    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-        return setTimeout(() => cb(performance.now()), 16) as unknown as number
-    })
-    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
-})
-
-afterEach(() => {
-    vi.unstubAllGlobals()
-    vi.useRealTimers()
-    // A failing assertion skips a test's own `mockRestore()`, and `vi.spyOn`
-    // on an already-spied method hands back the existing mock — call history
-    // included. Restore here so one failure can't cascade into the next test.
-    vi.restoreAllMocks()
-})
-
-const flushStreamingBatch = async () => {
-    await act(async () => {
-        await vi.advanceTimersByTimeAsync(50)
-    })
-}
+useStreamingTestHarness()
 
 describe('streamId prop', () => {
     describe('append mode', () => {

--- a/src/lib/SvelteMarkdown.stream-reset.test.ts
+++ b/src/lib/SvelteMarkdown.stream-reset.test.ts
@@ -15,30 +15,11 @@
 
 import '@testing-library/jest-dom'
 import { act, render } from '@testing-library/svelte'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import SvelteMarkdown from './SvelteMarkdown.svelte'
-import { tokenCache } from './utils/token-cache.js'
+import { flushStreamingBatch, useStreamingTestHarness } from './test/streaming/harness.js'
 
-beforeEach(() => {
-    tokenCache.clearAllTokens()
-    vi.useFakeTimers()
-    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-        return setTimeout(() => cb(performance.now()), 16) as unknown as number
-    })
-    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
-})
-
-afterEach(() => {
-    vi.unstubAllGlobals()
-    vi.useRealTimers()
-    vi.restoreAllMocks()
-})
-
-const flushStreamingBatch = async () => {
-    await act(async () => {
-        await vi.advanceTimersByTimeAsync(50)
-    })
-}
+useStreamingTestHarness()
 
 const MULTI_BLOCK = '# Title\n\nOne.\n\nTwo.'
 

--- a/src/lib/SvelteMarkdown.streaming-html.test.ts
+++ b/src/lib/SvelteMarkdown.streaming-html.test.ts
@@ -18,29 +18,11 @@
 
 import '@testing-library/jest-dom'
 import { act, render } from '@testing-library/svelte'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import SvelteMarkdown from './SvelteMarkdown.svelte'
-import { tokenCache } from './utils/token-cache.js'
+import { flushStreamingBatch, useStreamingTestHarness } from './test/streaming/harness.js'
 
-beforeEach(() => {
-    tokenCache.clearAllTokens()
-    vi.useFakeTimers()
-    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-        return setTimeout(() => cb(performance.now()), 16) as unknown as number
-    })
-    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
-})
-
-afterEach(() => {
-    vi.unstubAllGlobals()
-    vi.useRealTimers()
-})
-
-const flushStreamingBatch = async () => {
-    await act(async () => {
-        await vi.advanceTimersByTimeAsync(50)
-    })
-}
+useStreamingTestHarness()
 
 const NESTED = `<div style="background: #1e293b">
 <strong>Verdict:</strong> ship it

--- a/src/lib/test/streaming/harness.ts
+++ b/src/lib/test/streaming/harness.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared harness for streaming component suites.
+ *
+ * The component batches streaming flushes behind requestAnimationFrame, so
+ * deterministic tests need fake timers plus an rAF stub on a 16ms setTimeout
+ * cadence; `flushStreamingBatch()` then drains one batch window with a single
+ * 50ms advance. Five suites share this exact timing — it lives here so the
+ * cadence and the batch window can never drift apart between copies.
+ */
+
+import { act } from '@testing-library/svelte'
+import { afterEach, beforeEach, vi } from 'vitest'
+import { tokenCache } from '../../utils/token-cache.js'
+
+/**
+ * Registers the beforeEach/afterEach pair for a streaming suite: clears the
+ * token cache, installs fake timers and the rAF/cAF stubs, and tears them
+ * down again. Call once at the top level of the test file.
+ */
+export const useStreamingTestHarness = (): void => {
+    beforeEach(() => {
+        tokenCache.clearAllTokens()
+        vi.useFakeTimers()
+        vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+            return setTimeout(() => cb(performance.now()), 16) as unknown as number
+        })
+        vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        vi.useRealTimers()
+        // A failing assertion skips a test's own `mockRestore()`, and `vi.spyOn`
+        // on an already-spied method hands back the existing mock — call history
+        // included. Restore here so one failure can't cascade into the next test.
+        vi.restoreAllMocks()
+    })
+}
+
+/** Drains one rAF-batched streaming flush window. */
+export const flushStreamingBatch = async (): Promise<void> => {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(50)
+    })
+}


### PR DESCRIPTION
## Summary

Extracts the streaming-test harness that five suites had copy-pasted verbatim — the 16ms rAF/cAF stubs, fake-timer lifecycle, token-cache clear, and the `flushStreamingBatch()` 50ms batch-window drain — into a single shared module, `src/lib/test/streaming/harness.ts`. Any future change to the streaming batch timing now happens in one place instead of five that could silently drift apart. Net −51 lines.

This closes out the reuse observation from the /simplify pass on #364. Behavior is intentionally unified upward: the two suites that lacked the anti-cascade `vi.restoreAllMocks()` teardown (`streaming-html`, `issue-328`) now get it; `SvelteMarkdown.test.ts` uses a different minimal setup and is deliberately untouched.

## Changes

- 🧪 New `src/lib/test/streaming/harness.ts`: `useStreamingTestHarness()` (registers the beforeEach/afterEach pair) and the shared `flushStreamingBatch()`
- 🔧 `stream-id`, `streaming-html`, `issue-328`, `redraw-regression`, `stream-reset` suites: local copies replaced with the shared harness; unused `vi`/`tokenCache` imports pruned

Verified: the five suites pass (73 tests), `pnpm check` clean, full `pnpm test` green with coverage unchanged (96.13% / 90.44% / 96.29% / 97.69%).

## Commits

- [`fb09382`](https://github.com/humanspeak/svelte-markdown/commit/fb09382dba927e8bcb9706b358017ed40c01b15f) test(streaming): extract shared rAF/fake-timer harness across five suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
