### PR TITLE
fix(extensions): drop shiki from the extensions barrel

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ Import only the languages and themes you need (each is a separate ESM module), b
         createShikiHighlighter,
         ShikiCode,
         setShikiHighlighter
-    } from '@humanspeak/svelte-markdown/extensions'
+    } from '@humanspeak/svelte-markdown/extensions/shiki'
     import js from 'shiki/langs/javascript.mjs'
     import ts from 'shiki/langs/typescript.mjs'
     import githubDark from 'shiki/themes/github-dark.mjs'

--- a/docs/src/lib/examples/shiki/demos/ComponentRendered.svelte
+++ b/docs/src/lib/examples/shiki/demos/ComponentRendered.svelte
@@ -5,7 +5,7 @@
         createShikiHighlighter,
         ShikiCode,
         SHIKI_CONTEXT_KEY
-    } from '@humanspeak/svelte-markdown/extensions'
+    } from '@humanspeak/svelte-markdown/extensions/shiki'
     import { DemoSplitV2 } from '@humanspeak/docs-kit'
     import { setContext } from 'svelte'
     import js from 'shiki/langs/javascript.mjs'

--- a/docs/src/lib/examples/shiki/demos/FallbackRendered.svelte
+++ b/docs/src/lib/examples/shiki/demos/FallbackRendered.svelte
@@ -5,7 +5,7 @@
         createShikiHighlighter,
         ShikiCode,
         SHIKI_CONTEXT_KEY
-    } from '@humanspeak/svelte-markdown/extensions'
+    } from '@humanspeak/svelte-markdown/extensions/shiki'
     import { DemoSplitV2 } from '@humanspeak/docs-kit'
     import { setContext } from 'svelte'
     import ts from 'shiki/langs/typescript.mjs'

--- a/docs/src/routes/docs/advanced/syntax-highlighting/+page.svx
+++ b/docs/src/routes/docs/advanced/syntax-highlighting/+page.svx
@@ -19,7 +19,7 @@ description: Add opt-in Shiki syntax highlighting to @humanspeak/svelte-markdown
 
 # Syntax Highlighting
 
-`@humanspeak/svelte-markdown` ships an **opt-in Shiki syntax-highlighting extension** from the `@humanspeak/svelte-markdown/extensions` subpath. It highlights fenced code blocks by replacing the default `code` renderer with `ShikiCode` — no marked tokenizer, no `extensions` prop entry, and (critically) **no async work on the render path**, so streaming stays enabled.
+`@humanspeak/svelte-markdown` ships an **opt-in Shiki syntax-highlighting extension** from the dedicated `@humanspeak/svelte-markdown/extensions/shiki` subpath (deliberately not re-exported from the `extensions` barrel, so consumers who skip highlighting never need `shiki` installed). It highlights fenced code blocks by replacing the default `code` renderer with `ShikiCode` — no marked tokenizer, no `extensions` prop entry, and (critically) **no async work on the render path**, so streaming stays enabled.
 
 ## Why It's a Renderer, Not a Marked Extension
 
@@ -50,7 +50,7 @@ Import only the languages and themes you need — each is a separate ESM module,
         createShikiHighlighter,
         ShikiCode,
         setShikiHighlighter
-    } from '@humanspeak/svelte-markdown/extensions'
+    } from '@humanspeak/svelte-markdown/extensions/shiki'
     import js from 'shiki/langs/javascript.mjs'
     import ts from 'shiki/langs/typescript.mjs'
     import githubDark from 'shiki/themes/github-dark.mjs'
@@ -84,7 +84,7 @@ Language **aliases** come for free — registering `javascript` also matches `js
 ```svelte
 <script lang="ts">
     import { setContext } from 'svelte'
-    import { createShikiHighlighter, SHIKI_CONTEXT_KEY } from '@humanspeak/svelte-markdown/extensions'
+    import { createShikiHighlighter, SHIKI_CONTEXT_KEY } from '@humanspeak/svelte-markdown/extensions/shiki'
     import ts from 'shiki/langs/typescript.mjs'
     import githubLight from 'shiki/themes/github-light.mjs'
 

--- a/scripts/tree-shaking.mjs
+++ b/scripts/tree-shaking.mjs
@@ -86,6 +86,21 @@ const cases = [
         expectAllMissing: ['node_modules/shiki', 'node_modules/@shikijs']
     },
     {
+        // Shiki must never be reachable from the extensions barrel — its
+        // implementation statically imports `shiki/core` from plain JS, so a
+        // barrel re-export forces every barrel consumer to have the optional
+        // `shiki` peer installed just to resolve modules (shipped broken in
+        // v1.8.0). Bundle-level check; the source-graph invariant lives in
+        // `src/lib/extensions/barrel-optional-deps.test.ts`.
+        name: 'extensions barrel stays shiki-free',
+        source: `
+            import { markedAlert } from '@humanspeak/svelte-markdown/extensions'
+            console.log(markedAlert().extensions?.length)
+        `,
+        expectInitialMissing: ['node_modules/shiki', 'node_modules/@shikijs'],
+        expectAllMissing: ['node_modules/shiki', 'node_modules/@shikijs']
+    },
+    {
         // Plan 004 ship: the ShikiCode renderer on its own does NOT pull Shiki
         // in — it only depends on the escaped fallback. Shiki is bundled solely
         // when the consumer constructs a highlighter, keeping the renderer cheap.

--- a/src/lib/extensions/barrel-optional-deps.test.ts
+++ b/src/lib/extensions/barrel-optional-deps.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression guard for the `extensions` barrel's optional-dependency invariant.
+ *
+ * `shiki` is an optional peer dependency, but its implementation statically
+ * imports `shiki/core` from plain JS (`shiki/createShikiHighlighter.ts`).
+ * Bundlers eagerly resolve the plain-JS module graph of the barrel the moment a
+ * consumer imports anything from it (e.g. Vite's dependency optimizer), so a
+ * barrel re-export of shiki hard-breaks every consumer without `shiki`
+ * installed — even ones that never use highlighting. That regression shipped in
+ * v1.8.0 and was only caught in the field: `scripts/tree-shaking.mjs` verifies
+ * final-bundle contents via subpath imports, not barrel-graph resolution.
+ *
+ * `.svelte` files are exempt: they are compiled per-file and are not part of
+ * the eagerly-scanned plain-JS graph, which is why `KatexRenderer.svelte`'s
+ * static `katex` import only affects consumers who opt into that renderer.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const BARREL = resolve(__dirname, 'index.ts')
+
+/** Module specifiers of every static `import`/`export ... from` in a source file. */
+const importSpecifiers = (source: string): string[] =>
+    [...source.matchAll(/(?:^|\n)\s*(?:import|export)\s[^'"]*?from\s+['"]([^'"]+)['"]/g)].map(
+        (match) => match[1]
+    )
+
+/** Map a relative `./foo.js` specifier back to its `.ts` source file. */
+const toSourcePath = (fromFile: string, specifier: string): string =>
+    resolve(dirname(fromFile), specifier.replace(/\.js$/, '.ts'))
+
+/**
+ * Collect the transitive plain-TS module graph reachable from `entry`,
+ * skipping `.svelte` files (see module doc) and bare (package) specifiers.
+ */
+const collectPlainModuleGraph = (entry: string): Map<string, string[]> => {
+    const graph = new Map<string, string[]>()
+    const queue = [entry]
+    while (queue.length > 0) {
+        const file = queue.pop() as string
+        if (graph.has(file)) continue
+        const specifiers = importSpecifiers(readFileSync(file, 'utf-8'))
+        graph.set(file, specifiers)
+        for (const specifier of specifiers) {
+            if (!specifier.startsWith('.') || specifier.endsWith('.svelte')) continue
+            queue.push(toSourcePath(file, specifier))
+        }
+    }
+    return graph
+}
+
+describe('extensions barrel optional-dependency invariant', () => {
+    it('never reaches a shiki import through its plain-JS module graph', () => {
+        const offenders = [...collectPlainModuleGraph(BARREL)]
+            .filter(([, specifiers]) =>
+                specifiers.some((s) => s === 'shiki' || s.startsWith('shiki/'))
+            )
+            .map(([file]) => file)
+        expect(offenders).toEqual([])
+    })
+
+    it('does not re-export the shiki subpath', () => {
+        const barrelImports = importSpecifiers(readFileSync(BARREL, 'utf-8'))
+        expect(barrelImports.filter((s) => s.includes('shiki'))).toEqual([])
+    })
+})

--- a/src/lib/extensions/index.ts
+++ b/src/lib/extensions/index.ts
@@ -8,8 +8,13 @@
  * import { markedAlert, AlertRenderer } from '@humanspeak/svelte-markdown/extensions'
  * import { markedFootnote, FootnoteRef, FootnoteSection } from '@humanspeak/svelte-markdown/extensions'
  * import { markedKatex, KatexRenderer } from '@humanspeak/svelte-markdown/extensions'
- * import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '@humanspeak/svelte-markdown/extensions'
  * ```
+ *
+ * Shiki is deliberately NOT re-exported here — import it from the dedicated
+ * `@humanspeak/svelte-markdown/extensions/shiki` subpath instead. Its
+ * implementation statically imports `shiki/core` from plain JS, so exporting it
+ * from this barrel forces every barrel consumer's bundler to resolve `shiki`
+ * (an optional peer dependency) even when they never use highlighting.
  *
  * @module @humanspeak/svelte-markdown/extensions
  */
@@ -20,12 +25,3 @@ export { FootnoteRef, FootnoteSection, markedFootnote } from './footnote/index.j
 export { BLOCK_KATEX_TOKEN, INLINE_KATEX_TOKEN, KatexRenderer, markedKatex } from './katex/index.js'
 export type { MarkedKatexOptions } from './katex/index.js'
 export { MermaidRenderer, markedMermaid } from './mermaid/index.js'
-export {
-    SHIKI_CONTEXT_KEY,
-    ShikiCode,
-    createShikiHighlighter,
-    escapeHtml,
-    getShikiHighlighter,
-    setShikiHighlighter
-} from './shiki/index.js'
-export type { CreateShikiHighlighterOptions, ShikiHighlighter } from './shiki/index.js'

--- a/src/lib/extensions/shiki/index.ts
+++ b/src/lib/extensions/shiki/index.ts
@@ -1,9 +1,12 @@
 /**
- * SPIKE — streaming-compatible Shiki syntax-highlighting extension.
+ * Streaming-compatible Shiki syntax-highlighting extension.
  *
- * Intentionally NOT wired into the `extensions` barrel or the `package.json`
- * `exports` map: shipping is a follow-up decision (see the design report at
- * `.agents/.plans/bigger-faster-stronger/004-shiki-spike-report.md`).
+ * Shipped ONLY via the `@humanspeak/svelte-markdown/extensions/shiki` subpath —
+ * intentionally NOT re-exported from the `extensions` barrel.
+ * `createShikiHighlighter.js` statically imports `shiki/core` from plain JS, so
+ * a barrel re-export would force every barrel consumer's bundler to resolve
+ * `shiki` (an optional peer dependency) even when they never use highlighting
+ * (guarded by `barrel-optional-deps.test.ts`).
  *
  * @module
  */


### PR DESCRIPTION
## Summary

v1.8.0 (#361) re-exported the shiki extension from the `/extensions` barrel, which hard-breaks every consumer who imports **anything** from the barrel without `shiki` installed — Vite fails with `Could not resolve "shiki/core" imported by "@humanspeak/svelte-markdown"` even though `shiki` is an optional peer dependency and the consumer never opted into highlighting. The root cause: `createShikiHighlighter.ts` statically imports `shiki/core` from plain JS, so bundlers eagerly resolve it as part of the barrel's module graph (unlike KaTeX, whose static import lives inside a `.svelte` file and only resolves once the renderer is actually used).

This restores the shiki spike's original, documented invariant — shiki ships **only** via the dedicated `@humanspeak/svelte-markdown/extensions/shiki` subpath and is deliberately not re-exported from the barrel — and adds two regression guards so it cannot silently ship again. CI missed the original regression because `tree-shaking.mjs` only verified final-bundle contents via subpath imports; the failure mode is dev-time module *resolution* of the barrel.

> **Note for shiki users on v1.8.0–v1.8.3:** change your import from `.../extensions` to `.../extensions/shiki` — a one-line change. All other barrel exports are untouched.

## Changes

- 🐛 `src/lib/extensions/index.ts` — remove all shiki re-exports from the barrel; doc comment records the invariant and points to the subpath
- 🧪 `src/lib/extensions/barrel-optional-deps.test.ts` (new) — walks the barrel's transitive plain-TS module graph and fails on any `shiki` import
- 🧪 `scripts/tree-shaking.mjs` — new "extensions barrel stays shiki-free" scenario (all 10 scenarios pass)
- 📚 `src/lib/extensions/shiki/index.ts` — replace the stale SPIKE header with the shipped-via-subpath-only invariant
- 📚 Docs demos (`ComponentRendered`/`FallbackRendered`), the syntax-highlighting page, and the README example now import from `/extensions/shiki`

## Verification

- 973/973 unit tests pass (148 files, including the new guard)
- `pnpm package` + publint clean; built `dist/extensions/index.js` contains no shiki imports
- `pnpm test:tree-shaking` — 10/10 scenarios pass
- `pnpm check` — 0 errors; `trunk check` — no issues

## Commits

- [`d20b6a5`](https://github.com/humanspeak/svelte-markdown/commit/d20b6a5b369a49fa65ed7410cbdfaa9fb5243a18) fix(extensions): drop shiki from the extensions barrel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
