### PR TITLE
build(docs): bump docs-kit to 2026.7.6

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.16",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.7.6",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.17.0",
         "marked-code-format": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.6.16
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.7.13(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@internationalized/date@3.12.2)(@lucide/svelte@1.23.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)))(mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(shiki@4.3.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))
+        specifier: github:humanspeak/docs-kit#2026.7.6
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.7.13(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@internationalized/date@3.12.2)(@lucide/svelte@1.23.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)))(mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(shiki@4.3.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -688,8 +688,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc':
+    resolution: {gitHosted: true, integrity: sha512-Xxt3dmuuwbejKVBjEzE09d2Zgnzc5c4FqgVkPN+Yix0mbgEVe+YWYpxwX6yIACQS/w5oCper3W7sD/UQFv3c+w==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4340,7 +4340,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.7.13(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@internationalized/date@3.12.2)(@lucide/svelte@1.23.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)))(mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(shiki@4.3.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.7.13(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@internationalized/date@3.12.2)(@lucide/svelte@1.23.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)))(mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(shiki@4.3.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))':
     dependencies:
       '@humanspeak/svelte-motion': 0.7.13(svelte@5.56.4(@typescript-eslint/types@8.62.1))
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.4(@typescript-eslint/types@8.62.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,8 @@ packages:
     - docs
 
 allowBuilds:
+    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc': true
     '@humanspeak/docs-kit': true
-    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e': true
     esbuild: true
     sharp: true
     workerd: true


### PR DESCRIPTION
Bumps `@humanspeak/docs-kit` from the previous pinned tag to `2026.7.6` and refreshes the `allowBuilds` resolved-commit key in `pnpm-workspace.yaml` (pnpm 11.9 matches git-hosted deps by `name@resolved-url`, so the key must embed the commit the new tag resolves to). Lockfile re-resolved.

Mirrors the setup already on `svelte-motion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)