### PR TITLE
build(docs): bump docs-kit to 2026.8.1

### DIFF
--- a/.competitive-intel/config.json
+++ b/.competitive-intel/config.json
@@ -5,6 +5,12 @@
     "self_npm": "@humanspeak/svelte-markdown",
     "self_repo": "humanspeak/svelte-markdown",
 
+    "github_handle": "jaysin586",
+    "repo_triage": {
+        "enabled": true,
+        "_comment": "Surfaces open PRs/issues NOT opened by github_handle, and threads where someone replied after your last comment. Uses self_repo. 'since' each run = previous last_run. Set GITHUB_TOKEN in the scheduled env to raise rate limits."
+    },
+
     "self_features": [
         "Marked-based parsing",
         "Secure HTML parsing via HTMLParser2 + XSS-safe defaults (protocol allowlist, on* handler stripping)",
@@ -51,6 +57,17 @@
         "download_tolerance": 0.3,
         "_comment": "compare-data.ts drives the /compare 'vs' pages (12 competitors incl. editors/parsers/preprocessors beyond the renderer watchlist). Validator checks svelte_peer for framework claims, hardcoded download figures, and them: feature cells on version bumps."
     },
+    "benchmarks": [
+        {
+            "page": "vs-svelte-streamdown",
+            "script": "scripts/stream-compare-bench.mjs",
+            "command": "pnpm build && pnpm preview  (then, in another shell) pnpm perf:stream-compare",
+            "measures": "streaming perf claims on the page: 'Nx faster under burst backpressure', DOM-footprint element counts, p95/throughput",
+            "compares": { "svelte-streamdown": "devDependency" },
+            "measured_against": { "svelte-streamdown": "3.1.2" },
+            "_comment": "Perf numbers are only valid for the pinned devDep version. When svelte-streamdown publishes past measured_against, flag the page and prompt a human to bump the devDep + re-run the script. Do NOT auto-run in the nightly job."
+        }
+    ],
 
     "slack_channel": "C0BP5BF1UTX",
     "_slack_channel_comment": "#claude-reports in human-speak.slack.com (public, home workspace). Confirmed auto-send works 2026-08-10. NOTE: sends only work while the humanspeak workspace is the connected Slack — the integration is single-workspace, and from another org this same channel is a Slack Connect channel that blocks bot sends (draft-only)."

--- a/.competitive-intel/state.json
+++ b/.competitive-intel/state.json
@@ -1,82 +1,134 @@
 {
     "project": "@humanspeak/svelte-markdown",
-    "last_run": "2026-08-10",
-    "run_type": "baseline",
+    "last_run": "2026-08-11",
+    "run_type": "delta",
     "snapshot": {
-        "fetched_at": "2026-08-10T17:04:58Z",
+        "fetched_at": "2026-08-11T07:00:27Z",
         "project": "@humanspeak/svelte-markdown",
         "self": {
             "npm": "@humanspeak/svelte-markdown",
             "repo": "humanspeak/svelte-markdown",
-            "latest_version": "1.8.5",
-            "last_publish": "2026-07-23",
+            "latest_version": "1.8.6",
+            "last_publish": "2026-08-10",
             "first_publish": "2024-10-30",
             "weekly_downloads": 45099,
+            "peer_deps": {
+                "katex": ">=0.16.0",
+                "mermaid": ">=10.0.0",
+                "shiki": ">=4.0.0",
+                "svelte": "^5.0.0"
+            },
+            "svelte_peer": "^5.0.0",
             "error": null,
-            "stars": 129,
+            "stars": 130,
             "archived": false,
             "pushed_at": "2026-08-10",
-            "last_release": "2026-07-23",
+            "last_release": "2026-08-10",
             "recent_releases": [
                 {
+                    "version": "v1.8.6",
+                    "date": "2026-08-10",
+                    "notes": "Changes in this Release\ndocs(compare): add Streamdown and refresh competitors\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/376)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.6"
+                },
+                {
                     "version": "v1.8.5",
-                    "date": "2026-07-23"
+                    "date": "2026-07-23",
+                    "notes": "Changes in this Release\nbuild(docs): bump docs-kit to 2026.7.6\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/370)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.5"
                 },
                 {
                     "version": "v1.8.4",
-                    "date": "2026-07-14"
+                    "date": "2026-07-14",
+                    "notes": "> [!IMPORTANT]\n> **This release fixes v1.8.0–v1.8.3**, which are deprecated on npm: those versions broke module resolution (`Could not resolve \"shiki/core\"`) for anyone importing from `@humanspeak/svelte-markdown/extensions` without the optional `shiki` peer dependency installed.\n>\n> **If you use the shiki extension**, update your import — everything else is unchanged:\n>\n> ```diff\n> - import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '@humanspeak/svelte-markdown/extensions'\n> + import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '@humanspeak/svelte-markd",
+                    "notes_truncated": true,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4"
                 },
                 {
                     "version": "v1.8.3",
-                    "date": "2026-07-14"
+                    "date": "2026-07-14",
+                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm — use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
+                    "notes_truncated": true,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.3"
                 },
                 {
                     "version": "v1.8.2",
-                    "date": "2026-07-13"
+                    "date": "2026-07-13",
+                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm — use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
+                    "notes_truncated": true,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.2"
                 },
                 {
                     "version": "v1.8.1",
-                    "date": "2026-07-13"
+                    "date": "2026-07-13",
+                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm — use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
+                    "notes_truncated": true,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.1"
                 },
                 {
                     "version": "v1.8.0",
-                    "date": "2026-07-13"
+                    "date": "2026-07-13",
+                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm — use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
+                    "notes_truncated": true,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.0"
                 },
                 {
                     "version": "v1.7.14",
-                    "date": "2026-07-13"
+                    "date": "2026-07-13",
+                    "notes": "Changes in this Release\nfix(cache): hasTokens verifies source like getTokens\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/360)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.14"
                 },
                 {
                     "version": "v1.7.13",
-                    "date": "2026-07-13"
+                    "date": "2026-07-13",
+                    "notes": "Changes in this Release\nperf(streaming): keep extension streams incremental via tail-safe markers\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/359)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.13"
                 },
                 {
                     "version": "v1.7.12",
-                    "date": "2026-07-13"
+                    "date": "2026-07-13",
+                    "notes": "Changes in this Release\nfix(cache): verify source on token-cache hit to guard hash collisions\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/358)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.12"
                 },
                 {
                     "version": "v1.7.11",
-                    "date": "2026-07-13"
+                    "date": "2026-07-13",
+                    "notes": "Changes in this Release\nfix(html): stop attribute values truncating at embedded quotes\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/357)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.11"
                 },
                 {
                     "version": "v1.7.10",
-                    "date": "2026-07-09"
+                    "date": "2026-07-09",
+                    "notes": "Changes in this Release\nchore(test): gate coverage, declare engines, cover rAF fallback\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/353)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.10"
                 },
                 {
                     "version": "v1.7.9",
-                    "date": "2026-07-09"
+                    "date": "2026-07-09",
+                    "notes": "Changes in this Release\nchore(lint): lint test files and enable type-aware promise rules\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/352)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.9"
                 },
                 {
                     "version": "v1.7.8",
-                    "date": "2026-07-09"
+                    "date": "2026-07-09",
+                    "notes": "Changes in this Release\nrefactor(cleanup): drop dead legacy HTML functions and bench module\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/351)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.8"
                 },
                 {
                     "version": "v1.7.7",
-                    "date": "2026-07-09"
-                },
-                {
-                    "version": "v1.7.6",
-                    "date": "2026-07-09"
+                    "date": "2026-07-09",
+                    "notes": "Changes in this Release\nfeat(streaming): add streamId prop to reset state between streams\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/350)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.7"
                 }
             ]
         },
@@ -88,6 +140,10 @@
                 "last_publish": "2023-12-25",
                 "first_publish": "2020-04-21",
                 "weekly_downloads": 44707,
+                "peer_deps": {
+                    "svelte": "^4.0.0"
+                },
+                "svelte_peer": "^4.0.0",
                 "error": null,
                 "stars": 389,
                 "archived": false,
@@ -102,6 +158,10 @@
                 "last_publish": "2025-08-09",
                 "first_publish": "2022-04-09",
                 "weekly_downloads": 58302,
+                "peer_deps": {
+                    "svelte": "^5.1.3"
+                },
+                "svelte_peer": "^5.1.3",
                 "error": null,
                 "stars": 351,
                 "archived": false,
@@ -118,6 +178,10 @@
                 "last_publish": "2026-07-01",
                 "first_publish": "2025-09-08",
                 "weekly_downloads": 22209,
+                "peer_deps": {
+                    "svelte": "^5.0.0"
+                },
+                "svelte_peer": "^5.0.0",
                 "error": null,
                 "stars": 102,
                 "archived": false,
@@ -126,26 +190,46 @@
                 "recent_releases": [
                     {
                         "version": "3.1.2",
-                        "date": "2026-07-01"
+                        "date": "2026-07-01",
+                        "notes": "### 🔒 Security\n- Bumped `mermaid` to `^11.15.0`, clearing 4 moderate advisories flagged by `pnpm audit` (#32, thanks @polvallverdu).\n\n### 🐛 Bug Fixes\n- List no longer absorbs a following paragraph after a blank line (#34, thanks @snayerman).\n- Inline citations with no matching source now render as plain text instead of vanishing (#31).",
+                        "notes_truncated": false,
+                        "url": "https://github.com/beynar/svelte-streamdown/releases/tag/3.1.2"
                     },
                     {
                         "version": "3.1.1",
-                        "date": "2026-07-01"
+                        "date": "2026-07-01",
+                        "notes": "### 🐛 Bug Fixes\n- Removed the doubled bottom border on the final table row (#23, thanks @ieedan).",
+                        "notes_truncated": false,
+                        "url": "https://github.com/beynar/svelte-streamdown/releases/tag/3.1.1"
                     },
                     {
                         "version": "3.1.0",
-                        "date": "2026-06-10"
+                        "date": "2026-06-10",
+                        "notes": "### ✨ Features\n\n- **`allowedLinkPrefixes` / `allowedImagePrefixes` now support protocol-only prefixes** ([#27](https://github.com/beynar/svelte-streamdown/issues/27)). Use `'https://'` to allow all HTTPS links while still blocking insecure `http://`, or `'mailto:'` / `'tel:'` for those protocols. The `'*'` wildcard continues to allow only `http`/`https`.\n  ```svelte\n  <Streamdown {content} allowedLinkPrefixes={['https://', 'mailto:']} />\n  ```\n- **Disable Mermaid mouse-wheel zoom** ([#29](https://github.com/beynar/svelte-streamdown/issues/29)). `controls.mermaid` now accepts an object `{ enabl",
+                        "notes_truncated": true,
+                        "url": "https://github.com/beynar/svelte-streamdown/releases/tag/3.1.0"
                     }
                 ]
             },
             {
                 "npm": "@comark/svelte",
-                "repo": "",
+                "repo": null,
                 "latest_version": "0.6.2",
                 "last_publish": "2026-08-07",
                 "first_publish": "2026-03-23",
                 "weekly_downloads": 5326,
+                "peer_deps": {
+                    "beautiful-mermaid": "^1.1.3",
+                    "katex": "^0.17.0",
+                    "shiki": "^4.3.1",
+                    "svelte": "^5.0.0"
+                },
+                "svelte_peer": "^5.0.0",
                 "error": null,
+                "stars": null,
+                "archived": null,
+                "pushed_at": null,
+                "last_release": null,
                 "recent_releases": []
             }
         ]
@@ -155,19 +239,36 @@
             "gap": "remark/rehype plugin-ecosystem compatibility",
             "held_by": "svelte-exmarkdown",
             "why": "lets users drop in any remark/rehype plugin; we ship a curated closed set of Marked extensions",
-            "worth_doing": "undecided \u2014 evaluate a plugin escape hatch"
+            "worth_doing": "undecided — evaluate a plugin escape hatch"
         },
         {
-            "gap": "reactivity-driven incremental streaming",
+            "gap": "streaming presentation layer (reveal animations, citation UI, MDX-style components)",
             "held_by": "svelte-streamdown",
-            "why": "fine-grained reactivity instead of token cache for long AI streams",
-            "worth_doing": "benchmark head-to-head to confirm our token-cache approach still wins"
+            "why": "batteries-included AI chat UIs get these in-box; our position is deliberately lower-level/unstyled",
+            "worth_doing": "watch-not-build unless users ask; perf gap resolved 2026-08-10 (benchmark: 2-4x faster under burst, tied frame-paced)"
         },
         {
             "gap": "first-party interactive mermaid parity claim",
             "held_by": "@comark/svelte",
             "why": "beautiful-mermaid shipped in-box",
-            "worth_doing": "low \u2014 we already ship a mermaid extension"
+            "worth_doing": "low — we already ship a mermaid extension"
+        }
+    ],
+    "compare_validation": {
+        "svelte-streamdown": {
+            "validated_against_version": "3.1.2",
+            "validated_on": "2026-08-11"
+        },
+        "svelte-exmarkdown": {
+            "validated_against_version": "5.0.2",
+            "validated_on": "2026-08-11"
+        }
+    },
+    "watch_candidates": [
+        {
+            "npm": "markstream-svelte",
+            "first_seen": "2026-08-11",
+            "note": "Svelte binding of cross-framework Markstream streaming renderer; 0.0.6 @ 325 wkly DL, but family has traction (markstream-core 14.6k, markstream-vue 28.1k wkly). Promote to watchlist if it keeps shipping."
         }
     ]
 }

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,6 +4,7 @@ static/twitter-default.png
 static/docs/
 static/examples.md
 static/examples/
+static/compare/
 static/llms*.txt
 src/lib/sitemap-manifest.json
 src/lib/demo-manifest.json

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.7.6",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.8.1",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.18.2",
         "marked-code-format": "^1.1.6",

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -12,13 +12,13 @@ import { sveltekit } from '@sveltejs/kit/vite'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 
-import { competitors } from './src/lib/compare-data'
+import { competitors, ours } from './src/lib/compare-data'
 import { docsConfig } from './src/lib/docs-config'
 
 const indexNowKey = '71d77690-dc98-4385-ac10-569e4ec5c303'
 
 export default defineConfig({
-    // Three docs-kit plugins run on `buildStart` and rewatch via Vite's
+    // The docs-kit plugins run on `buildStart` and rewatch via Vite's
     // own file watcher — no chokidar process, no package.json scripts to
     // maintain.
     //   * `demoManifestPlugin`     scans `src/lib/examples/<...>/demos/*.svelte`
@@ -37,10 +37,6 @@ export default defineConfig({
     //     plus `src/lib/examples/**/demos/*.svelte`, then emits
     //     `static/examples.md` and `static/examples/<slug>.md` with the
     //     live example prose, notes, and fenced Svelte demo source.
-    //   * `llmsFullPlugin`         concatenates every per-page mirror into
-    //     `static/llms-full.txt`, served at /llms-full.txt — the surface
-    //     agentic LLMs (Claude Code, Cursor) reach for when they want the
-    //     whole library in a single context window.
     //   * `llmsPlugin`             emits `static/llms.txt` — the compact
     //     discovery index per the llmstxt.org convention. The `prepend` +
     //     `append` slots inline our hand-curated positioning content
@@ -49,7 +45,12 @@ export default defineConfig({
     //     features, use cases; `static/llms-append.md`: external links)
     //     while the canonical-URL block and `## Documentation` link
     //     table auto-sync from the sitemap manifest so new doc pages
-    //     show up without a manual edit.
+    //     show up without a manual edit. It also emits Markdown mirrors
+    //     for the comparison index and every competitor page.
+    //   * `llmsFullPlugin`         concatenates every docs and comparison
+    //     mirror into `static/llms-full.txt`, served at /llms-full.txt —
+    //     the surface agentic LLMs (Claude Code, Cursor) reach for when
+    //     they want the whole library in a single context window.
     plugins: [
         sitemapManifestPlugin({
             blogDir: false,
@@ -68,17 +69,18 @@ export default defineConfig({
             siteUrl: 'https://markdown.svelte.page',
             sourceBaseUrl: 'https://github.com/humanspeak/svelte-markdown/blob/main/docs'
         }),
-        llmsFullPlugin({
-            siteUrl: 'https://markdown.svelte.page',
-            pkgName: '@humanspeak/svelte-markdown'
-        }),
         llmsPlugin({
             siteUrl: 'https://markdown.svelte.page',
             pkgName: 'Svelte Markdown',
             description:
                 'A powerful, customizable markdown and HTML renderer for Svelte 5 — built for rendering streaming AI agent output from Claude Code, ChatGPT, and agentic workflows. Built on Marked and HTMLParser2 with 24 markdown renderers, 83 HTML tag renderers, LRU token caching, allow/deny filtering, and XSS-safe defaults.',
             prepend: 'static/llms-prepend.md',
-            append: 'static/llms-append.md'
+            append: 'static/llms-append.md',
+            comparisons: { ours, competitors }
+        }),
+        llmsFullPlugin({
+            siteUrl: 'https://markdown.svelte.page',
+            pkgName: '@humanspeak/svelte-markdown'
         }),
         // Renders `static/og-default.png` + per-page social cards from
         // satori templates. `apply: 'build'` — dev skips it, so iterating

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.7.6
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))
+        specifier: github:humanspeak/docs-kit#2026.8.1
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -675,8 +675,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc':
-    resolution: {gitHosted: true, integrity: sha512-Xxt3dmuuwbejKVBjEzE09d2Zgnzc5c4FqgVkPN+Yix0mbgEVe+YWYpxwX6yIACQS/w5oCper3W7sD/UQFv3c+w==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4413,7 +4413,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
     dependencies:
       '@humanspeak/svelte-motion': 0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.8(@typescript-eslint/types@8.66.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
     - docs
 
 allowBuilds:
-    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc': true
+    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8': true
     '@humanspeak/docs-kit': true
     esbuild: true
     sharp: true


### PR DESCRIPTION
## Summary

Updates the documentation site to docs-kit 2026.8.1 and adopts its comparison Markdown mirror support. Comparison pages are now discoverable through both `llms.txt` and the complete `llms-full.txt` bundle, while the competitive-intelligence configuration and latest tracking snapshot are brought up to date.

## Changes

- 📦 Bump `@humanspeak/docs-kit` from 2026.7.6 to 2026.8.1 and update its lockfile/build allowlist pin.
- ✨ Generate Markdown mirrors from the existing comparison dataset.
- 🔧 Run the compact LLM index before the full bundle so generated comparison mirrors are included in the same build.
- 📚 Ignore the generated `static/compare/` output.
- 🔎 Enable repository triage and record the streaming benchmark in competitive-intel configuration.
- 🔄 Refresh competitive package, release, validation, feature-gap, and watch-candidate state from the latest delta run.
- 🧪 Verified with Trunk formatting/linting, root and docs Svelte checks, and a full production docs build.

## Commits

- [`e2f1853`](https://github.com/humanspeak/svelte-markdown/commit/e2f18536e585d9d576d09ecab13bf6db664ba7f2) build(docs): bump docs-kit to 2026.8.1
- [`ae8fe33`](https://github.com/humanspeak/svelte-markdown/commit/ae8fe33bc9e5f48e334658182c49b78536f0ced1) chore(competitive-intel): update tracking state
