### PR TITLE
docs(blog): add Svelte markdown guides

### DIFF
--- a/.competitive-intel/.gitignore
+++ b/.competitive-intel/.gitignore
@@ -1,0 +1,4 @@
+# Local-only artifacts for the competitive-intel-digest skill.
+# config.json and state.json ARE tracked (they're the scaffolding); these are not.
+gsc/
+reports/

--- a/.competitive-intel/config.json
+++ b/.competitive-intel/config.json
@@ -52,6 +52,14 @@
         }
     ],
 
+    "seo": {
+        "enabled": true,
+        "docs_domain": "markdown.svelte.page",
+        "gsc_dir": ".competitive-intel/gsc",
+        "gsc_staleness_days": 14,
+        "_comment": "Cross-references the local GSC export (dropped in gsc_dir, gitignored) with Ahrefs to produce keyword/blog/site-fix recommendations. Nudges for a fresh export past gsc_staleness_days."
+    },
+
     "compare_data_paths": ["docs/src/lib/compare-data.ts"],
     "page_validation": {
         "download_tolerance": 0.3,

--- a/.competitive-intel/state.json
+++ b/.competitive-intel/state.json
@@ -3,7 +3,7 @@
     "last_run": "2026-08-18",
     "run_type": "delta",
     "snapshot": {
-        "fetched_at": "2026-08-18T07:00:27Z",
+        "fetched_at": "2026-08-18T11:00:33Z",
         "project": "@humanspeak/svelte-markdown",
         "self": {
             "npm": "@humanspeak/svelte-markdown",
@@ -132,6 +132,7 @@
                 }
             ]
         },
+        "upstream": [],
         "competitors": [
             {
                 "npm": "svelte-markdown",
@@ -275,5 +276,210 @@
             "first_seen": "2026-08-18",
             "note": "Surfaced in discovery; 0.4.0 last published 2026-01-12, ~30 wkly DL. Too small/stale to track \u2014 recorded to avoid re-surfacing it each week."
         }
-    ]
+    ],
+    "seo": {
+        "export_date": "2026-08-18",
+        "striking_distance": [
+            {
+                "query": "svelte markdown",
+                "impressions": 272.0,
+                "position": 11.03
+            },
+            {
+                "query": "\"milkdown\" \"javascript:\" xss",
+                "impressions": 230.0,
+                "position": 7.11
+            },
+            {
+                "query": "tiptap markdown",
+                "impressions": 212.0,
+                "position": 19.46
+            },
+            {
+                "query": "tiptap svelte",
+                "impressions": 197.0,
+                "position": 17.46
+            },
+            {
+                "query": "@humanspeak/svelte-markdown",
+                "impressions": 98.0,
+                "position": 4.71
+            },
+            {
+                "query": "svelte markdown renderer",
+                "impressions": 85.0,
+                "position": 5.74
+            },
+            {
+                "query": "svelte-markdown",
+                "impressions": 62.0,
+                "position": 9.39
+            },
+            {
+                "query": "svelte-exmarkdown",
+                "impressions": 51.0,
+                "position": 10.86
+            },
+            {
+                "query": "svelte marked",
+                "impressions": 42.0,
+                "position": 8.88
+            },
+            {
+                "query": "svelte markdown editor",
+                "impressions": 37.0,
+                "position": 11.08
+            },
+            {
+                "query": "markdown playground",
+                "impressions": 35.0,
+                "position": 12.51
+            },
+            {
+                "query": "svelte render markdown",
+                "impressions": 34.0,
+                "position": 6.15
+            },
+            {
+                "query": "svelte tiptap",
+                "impressions": 30.0,
+                "position": 17.7
+            },
+            {
+                "query": "markdown svelte",
+                "impressions": 29.0,
+                "position": 6.72
+            },
+            {
+                "query": "svelte custom renderer",
+                "impressions": 26.0,
+                "position": 7.5
+            },
+            {
+                "query": "\"alerttriangle\" \"lucide-svelte\"",
+                "impressions": 26.0,
+                "position": 7.81
+            },
+            {
+                "query": "svelte-markdown npm package",
+                "impressions": 26.0,
+                "position": 9.81
+            },
+            {
+                "query": "site:svelte.page",
+                "impressions": 24.0,
+                "position": 18.21
+            },
+            {
+                "query": "svelte-markdown npm",
+                "impressions": 21.0,
+                "position": 8.81
+            },
+            {
+                "query": "marked svelte",
+                "impressions": 20.0,
+                "position": 13.7
+            }
+        ],
+        "underperforming_pages": [
+            {
+                "page": "https://markdown.svelte.page/compare/vs-milkdown",
+                "impressions": 797.0,
+                "position": 9.87,
+                "ctr": 0.63
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-tiptap",
+                "impressions": 639.0,
+                "position": 18.19,
+                "ctr": 0.16
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-bytemd",
+                "impressions": 375.0,
+                "position": 9.56,
+                "ctr": 0.27
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-carta",
+                "impressions": 359.0,
+                "position": 10.99,
+                "ctr": 0.84
+            },
+            {
+                "page": "https://markdown.svelte.page/docs/getting-started",
+                "impressions": 255.0,
+                "position": 13.91,
+                "ctr": 1.96
+            },
+            {
+                "page": "https://markdown.svelte.page/docs/advanced/marked-extensions",
+                "impressions": 237.0,
+                "position": 9.23,
+                "ctr": 0.84
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-mdsvex",
+                "impressions": 233.0,
+                "position": 14.3,
+                "ctr": 0.43
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-marked",
+                "impressions": 231.0,
+                "position": 14.66,
+                "ctr": 0.87
+            },
+            {
+                "page": "https://markdown.svelte.page/docs/advanced/syntax-highlighting",
+                "impressions": 222.0,
+                "position": 22.73,
+                "ctr": 0.9
+            },
+            {
+                "page": "https://markdown.svelte.page/compare",
+                "impressions": 163.0,
+                "position": 14.67,
+                "ctr": 0.61
+            },
+            {
+                "page": "https://markdown.svelte.page/docs/api/svelte-markdown",
+                "impressions": 142.0,
+                "position": 27.06,
+                "ctr": 1.41
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-unified-remark",
+                "impressions": 120.0,
+                "position": 17.39,
+                "ctr": 0.0
+            },
+            {
+                "page": "https://markdown.svelte.page/examples",
+                "impressions": 119.0,
+                "position": 15.23,
+                "ctr": 0.0
+            },
+            {
+                "page": "https://markdown.svelte.page/examples/github-alerts",
+                "impressions": 115.0,
+                "position": 23.84,
+                "ctr": 0.0
+            },
+            {
+                "page": "https://markdown.svelte.page/examples/llm-streaming",
+                "impressions": 110.0,
+                "position": 24.09,
+                "ctr": 0.0
+            }
+        ],
+        "recommendations_open": [
+            "rewrite vs-tiptap title/meta (639 impr, pos 18, 0.16% CTR \u2014 intent/title problem)",
+            "write dedicated markdown-XSS/security page (markdown xss KD4; milkdown-xss cluster 230 impr pos 7)",
+            "dedicated hub page for 'svelte markdown' head term (pos 11 via homepage)",
+            "dedicated 'marked in Svelte' page (rank pos 8-13 with no target URL)",
+            "fix structured-data validation errors on 11 pages",
+            "wire up IndexNow (38 eligible pages)"
+        ]
+    }
 }

--- a/.competitive-intel/state.json
+++ b/.competitive-intel/state.json
@@ -1,9 +1,9 @@
 {
     "project": "@humanspeak/svelte-markdown",
-    "last_run": "2026-08-11",
+    "last_run": "2026-08-18",
     "run_type": "delta",
     "snapshot": {
-        "fetched_at": "2026-08-11T07:00:27Z",
+        "fetched_at": "2026-08-18T07:00:27Z",
         "project": "@humanspeak/svelte-markdown",
         "self": {
             "npm": "@humanspeak/svelte-markdown",
@@ -11,7 +11,7 @@
             "latest_version": "1.8.6",
             "last_publish": "2026-08-10",
             "first_publish": "2024-10-30",
-            "weekly_downloads": 45099,
+            "weekly_downloads": 28501,
             "peer_deps": {
                 "katex": ">=0.16.0",
                 "mermaid": ">=10.0.0",
@@ -20,9 +20,9 @@
             },
             "svelte_peer": "^5.0.0",
             "error": null,
-            "stars": 130,
+            "stars": 131,
             "archived": false,
-            "pushed_at": "2026-08-10",
+            "pushed_at": "2026-08-12",
             "last_release": "2026-08-10",
             "recent_releases": [
                 {
@@ -42,35 +42,35 @@
                 {
                     "version": "v1.8.4",
                     "date": "2026-07-14",
-                    "notes": "> [!IMPORTANT]\n> **This release fixes v1.8.0–v1.8.3**, which are deprecated on npm: those versions broke module resolution (`Could not resolve \"shiki/core\"`) for anyone importing from `@humanspeak/svelte-markdown/extensions` without the optional `shiki` peer dependency installed.\n>\n> **If you use the shiki extension**, update your import — everything else is unchanged:\n>\n> ```diff\n> - import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '@humanspeak/svelte-markdown/extensions'\n> + import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '@humanspeak/svelte-markd",
+                    "notes": "> [!IMPORTANT]\n> **This release fixes v1.8.0\u2013v1.8.3**, which are deprecated on npm: those versions broke module resolution (`Could not resolve \"shiki/core\"`) for anyone importing from `@humanspeak/svelte-markdown/extensions` without the optional `shiki` peer dependency installed.\n>\n> **If you use the shiki extension**, update your import \u2014 everything else is unchanged:\n>\n> ```diff\n> - import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '@humanspeak/svelte-markdown/extensions'\n> + import { createShikiHighlighter, ShikiCode, setShikiHighlighter } from '@humanspeak/svelte-markd",
                     "notes_truncated": true,
                     "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4"
                 },
                 {
                     "version": "v1.8.3",
                     "date": "2026-07-14",
-                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm — use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
+                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm \u2014 use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
                     "notes_truncated": true,
                     "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.3"
                 },
                 {
                     "version": "v1.8.2",
                     "date": "2026-07-13",
-                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm — use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
+                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm \u2014 use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
                     "notes_truncated": true,
                     "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.2"
                 },
                 {
                     "version": "v1.8.1",
                     "date": "2026-07-13",
-                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm — use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
+                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm \u2014 use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
                     "notes_truncated": true,
                     "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.1"
                 },
                 {
                     "version": "v1.8.0",
                     "date": "2026-07-13",
-                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm — use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
+                    "notes": "> [!CAUTION]\n> **This release is broken and deprecated on npm \u2014 use [v1.8.4](https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.4) or later.**\n>\n> Importing **anything** from `@humanspeak/svelte-markdown/extensions` (even just `markedAlert`) fails with `Could not resolve \"shiki/core\"` unless the optional `shiki` peer dependency is installed. The barrel mistakenly re-exported the shiki extension, whose static `shiki/core` import forces bundlers to resolve shiki for every barrel consumer. Fixed in v1.8.4 ([#369](https://github.com/humanspeak/svelte-markdown/pull/369)).\n>\n> **If you ",
                     "notes_truncated": true,
                     "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.0"
                 },
@@ -139,7 +139,7 @@
                 "latest_version": "0.4.1",
                 "last_publish": "2023-12-25",
                 "first_publish": "2020-04-21",
-                "weekly_downloads": 44707,
+                "weekly_downloads": 41546,
                 "peer_deps": {
                     "svelte": "^4.0.0"
                 },
@@ -157,15 +157,15 @@
                 "latest_version": "5.0.2",
                 "last_publish": "2025-08-09",
                 "first_publish": "2022-04-09",
-                "weekly_downloads": 58302,
+                "weekly_downloads": 34876,
                 "peer_deps": {
                     "svelte": "^5.1.3"
                 },
                 "svelte_peer": "^5.1.3",
                 "error": null,
-                "stars": 351,
+                "stars": 353,
                 "archived": false,
-                "pushed_at": "2026-08-10",
+                "pushed_at": "2026-08-15",
                 "last_release": "2025-08-09",
                 "recent_releases": []
             }
@@ -177,13 +177,13 @@
                 "latest_version": "3.1.2",
                 "last_publish": "2026-07-01",
                 "first_publish": "2025-09-08",
-                "weekly_downloads": 22209,
+                "weekly_downloads": 23128,
                 "peer_deps": {
                     "svelte": "^5.0.0"
                 },
                 "svelte_peer": "^5.0.0",
                 "error": null,
-                "stars": 102,
+                "stars": 103,
                 "archived": false,
                 "pushed_at": "2026-07-01",
                 "last_release": "2026-07-01",
@@ -191,21 +191,21 @@
                     {
                         "version": "3.1.2",
                         "date": "2026-07-01",
-                        "notes": "### 🔒 Security\n- Bumped `mermaid` to `^11.15.0`, clearing 4 moderate advisories flagged by `pnpm audit` (#32, thanks @polvallverdu).\n\n### 🐛 Bug Fixes\n- List no longer absorbs a following paragraph after a blank line (#34, thanks @snayerman).\n- Inline citations with no matching source now render as plain text instead of vanishing (#31).",
+                        "notes": "### \ud83d\udd12 Security\n- Bumped `mermaid` to `^11.15.0`, clearing 4 moderate advisories flagged by `pnpm audit` (#32, thanks @polvallverdu).\n\n### \ud83d\udc1b Bug Fixes\n- List no longer absorbs a following paragraph after a blank line (#34, thanks @snayerman).\n- Inline citations with no matching source now render as plain text instead of vanishing (#31).",
                         "notes_truncated": false,
                         "url": "https://github.com/beynar/svelte-streamdown/releases/tag/3.1.2"
                     },
                     {
                         "version": "3.1.1",
                         "date": "2026-07-01",
-                        "notes": "### 🐛 Bug Fixes\n- Removed the doubled bottom border on the final table row (#23, thanks @ieedan).",
+                        "notes": "### \ud83d\udc1b Bug Fixes\n- Removed the doubled bottom border on the final table row (#23, thanks @ieedan).",
                         "notes_truncated": false,
                         "url": "https://github.com/beynar/svelte-streamdown/releases/tag/3.1.1"
                     },
                     {
                         "version": "3.1.0",
                         "date": "2026-06-10",
-                        "notes": "### ✨ Features\n\n- **`allowedLinkPrefixes` / `allowedImagePrefixes` now support protocol-only prefixes** ([#27](https://github.com/beynar/svelte-streamdown/issues/27)). Use `'https://'` to allow all HTTPS links while still blocking insecure `http://`, or `'mailto:'` / `'tel:'` for those protocols. The `'*'` wildcard continues to allow only `http`/`https`.\n  ```svelte\n  <Streamdown {content} allowedLinkPrefixes={['https://', 'mailto:']} />\n  ```\n- **Disable Mermaid mouse-wheel zoom** ([#29](https://github.com/beynar/svelte-streamdown/issues/29)). `controls.mermaid` now accepts an object `{ enabl",
+                        "notes": "### \u2728 Features\n\n- **`allowedLinkPrefixes` / `allowedImagePrefixes` now support protocol-only prefixes** ([#27](https://github.com/beynar/svelte-streamdown/issues/27)). Use `'https://'` to allow all HTTPS links while still blocking insecure `http://`, or `'mailto:'` / `'tel:'` for those protocols. The `'*'` wildcard continues to allow only `http`/`https`.\n  ```svelte\n  <Streamdown {content} allowedLinkPrefixes={['https://', 'mailto:']} />\n  ```\n- **Disable Mermaid mouse-wheel zoom** ([#29](https://github.com/beynar/svelte-streamdown/issues/29)). `controls.mermaid` now accepts an object `{ enabl",
                         "notes_truncated": true,
                         "url": "https://github.com/beynar/svelte-streamdown/releases/tag/3.1.0"
                     }
@@ -217,7 +217,7 @@
                 "latest_version": "0.6.2",
                 "last_publish": "2026-08-07",
                 "first_publish": "2026-03-23",
-                "weekly_downloads": 5326,
+                "weekly_downloads": 2344,
                 "peer_deps": {
                     "beautiful-mermaid": "^1.1.3",
                     "katex": "^0.17.0",
@@ -239,7 +239,7 @@
             "gap": "remark/rehype plugin-ecosystem compatibility",
             "held_by": "svelte-exmarkdown",
             "why": "lets users drop in any remark/rehype plugin; we ship a curated closed set of Marked extensions",
-            "worth_doing": "undecided — evaluate a plugin escape hatch"
+            "worth_doing": "undecided \u2014 evaluate a plugin escape hatch"
         },
         {
             "gap": "streaming presentation layer (reveal animations, citation UI, MDX-style components)",
@@ -251,24 +251,29 @@
             "gap": "first-party interactive mermaid parity claim",
             "held_by": "@comark/svelte",
             "why": "beautiful-mermaid shipped in-box",
-            "worth_doing": "low — we already ship a mermaid extension"
+            "worth_doing": "low \u2014 we already ship a mermaid extension"
         }
     ],
     "compare_validation": {
         "svelte-streamdown": {
             "validated_against_version": "3.1.2",
-            "validated_on": "2026-08-11"
+            "validated_on": "2026-08-18"
         },
         "svelte-exmarkdown": {
             "validated_against_version": "5.0.2",
-            "validated_on": "2026-08-11"
+            "validated_on": "2026-08-18"
         }
     },
     "watch_candidates": [
         {
             "npm": "markstream-svelte",
             "first_seen": "2026-08-11",
-            "note": "Svelte binding of cross-framework Markstream streaming renderer; 0.0.6 @ 325 wkly DL, but family has traction (markstream-core 14.6k, markstream-vue 28.1k wkly). Promote to watchlist if it keeps shipping."
+            "note": "Svelte binding of cross-framework Markstream renderer; 0.0.7 (2026-08-14) @ 327 wkly DL \u2014 still shipping but traction flat week over week. Promote only if downloads start climbing."
+        },
+        {
+            "npm": "@markdown-ui/svelte",
+            "first_seen": "2026-08-18",
+            "note": "Surfaced in discovery; 0.4.0 last published 2026-01-12, ~30 wkly DL. Too small/stale to track \u2014 recorded to avoid re-surfacing it each week."
         }
     ]
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.8.2",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.8.4",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.18.2",
         "marked-code-format": "^1.1.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.8.1",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.8.2",
         "@humanspeak/svelte-markdown": "workspace:*",
         "katex": "^0.18.2",
         "marked-code-format": "^1.1.6",
@@ -28,7 +28,7 @@
         "@cloudflare/workers-types": "^5.20260808.1",
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
-        "@humanspeak/svelte-motion": "^0.8.2",
+        "@humanspeak/svelte-motion": "^0.9.2",
         "@icons-pack/svelte-simple-icons": "^7.2.0",
         "@lucide/svelte": "^1.30.0",
         "@sveltejs/adapter-cloudflare": "^7.2.9",

--- a/docs/src/lib/compare-data.ts
+++ b/docs/src/lib/compare-data.ts
@@ -209,6 +209,7 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-mdsvex',
         name: 'MDsveX',
+        seoTitle: 'MDsveX vs Svelte Markdown: Build-Time or Runtime?',
         tagline: 'Build-Time Preprocessor vs Runtime Component',
         description:
             'Compare MDsveX and @humanspeak/svelte-markdown: build-time .svx preprocessing versus runtime Svelte 5 markdown rendering, caching, and HTML control.',
@@ -320,9 +321,10 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-tiptap',
         name: 'Tiptap',
-        tagline: 'Heavyweight Editor vs Lightweight Renderer',
+        seoTitle: 'Tiptap vs Svelte Markdown: Editor or Renderer?',
+        tagline: 'Do you need to edit markdown, or just render it?',
         description:
-            'Compare Tiptap and @humanspeak/svelte-markdown: a ProseMirror rich text editor versus a focused Svelte 5 markdown renderer for display-only content.',
+            'Tiptap is a ProseMirror rich-text editor; Svelte Markdown is a zero-config Svelte 5 renderer for read-only markdown. Editing vs rendering — which do you need?',
         website: 'https://tiptap.dev',
         github: 'https://github.com/ueberdosis/tiptap',
         npm: '@tiptap/core',
@@ -398,6 +400,7 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-markdown-it',
         name: 'markdown-it',
+        seoTitle: 'markdown-it vs Svelte Markdown: Parser or Component?',
         tagline: 'Raw Parser vs Svelte Component',
         description:
             'Compare markdown-it and @humanspeak/svelte-markdown: raw HTML string parsing versus typed Svelte 5 renderers with caching, snippets, and HTML control.',
@@ -496,6 +499,7 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-marked',
         name: 'marked',
+        seoTitle: 'marked vs Svelte Markdown: Parser or Svelte Component?',
         tagline: 'The Engine Under Our Hood',
         description:
             'Compare marked and @humanspeak/svelte-markdown: direct markdown parsing versus a Svelte 5 component layer with renderers, caching, and safety controls.',
@@ -591,6 +595,7 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-milkdown',
         name: 'Milkdown',
+        seoTitle: 'Milkdown vs Svelte Markdown: Editor or Renderer?',
         tagline: 'Plugin-Driven Editor vs Focused Renderer',
         description:
             'Compare Milkdown and @humanspeak/svelte-markdown: a ProseMirror markdown editor versus a lightweight Svelte 5 component for rendering markdown content.',
@@ -754,6 +759,7 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-carta',
         name: 'Carta',
+        seoTitle: 'Carta vs Svelte Markdown: Editor or Renderer?',
         tagline: 'Editor + Viewer vs Pure Renderer',
         description:
             'Compare Carta and @humanspeak/svelte-markdown: a Svelte markdown editor and viewer versus a focused Svelte 5 renderer with caching and HTML filtering.',
@@ -839,6 +845,7 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-bytemd',
         name: 'ByteMD',
+        seoTitle: 'ByteMD vs Svelte Markdown: Editor or Renderer?',
         tagline: 'Full Editor vs Pure Renderer',
         description:
             'Compare ByteMD and @humanspeak/svelte-markdown: a hackable markdown editor from ByteDance versus a focused Svelte 5 renderer for app content.',
@@ -924,6 +931,7 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-unified-remark',
         name: 'unified / remark',
+        seoTitle: 'unified/remark vs Svelte Markdown: Pipeline or Component?',
         tagline: 'AST Pipeline vs Component Renderer',
         description:
             'Compare unified/remark and @humanspeak/svelte-markdown: AST content pipelines versus a direct marked-based Svelte 5 renderer with practical defaults.',
@@ -1011,6 +1019,7 @@ export const competitors: Competitor[] = [
     {
         slug: 'vs-prosemirror',
         name: 'ProseMirror',
+        seoTitle: 'ProseMirror vs Svelte Markdown: Editor or Renderer?',
         tagline: 'Editor Toolkit vs Ready-Made Renderer',
         description:
             'Compare ProseMirror and @humanspeak/svelte-markdown: low-level editor framework assembly versus a ready-to-use Svelte 5 markdown renderer for apps.',

--- a/docs/src/routes/blog/preventing-markdown-xss-in-svelte/+page.svx
+++ b/docs/src/routes/blog/preventing-markdown-xss-in-svelte/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Preventing Markdown XSS in Svelte
-date: 2026-08-18
+date: '2026-08-18T12:00:00-04:00'
 description: 'How markdown becomes an XSS vector in Svelte — javascript: URLs, on* handlers, data: URIs — and how to render user or AI markdown safely by default.'
 tags:
     - security
@@ -18,7 +18,7 @@ readingTime: 8
     const post: BlogPostMeta = {
         slug: 'preventing-markdown-xss-in-svelte',
         title: 'Preventing Markdown XSS in Svelte',
-        date: '2026-08-18',
+        date: '2026-08-18T12:00:00-04:00',
         description:
             'How markdown becomes an XSS vector in Svelte — javascript: URLs, on* handlers, data: URIs — and how to render user or AI markdown safely by default.',
         tags: ['security', 'xss', 'markdown', 'svelte-5'],

--- a/docs/src/routes/blog/preventing-markdown-xss-in-svelte/+page.svx
+++ b/docs/src/routes/blog/preventing-markdown-xss-in-svelte/+page.svx
@@ -39,6 +39,10 @@ This is the smallest payload that demonstrates the problem:
 [Review the report](javascript:stealCookies())
 ```
 
+That is the easy-to-miss distinction: a markdown-native link can carry `javascript:` without
+containing an HTML tag at all. Sanitizing only the raw HTML-looking parts of a markdown string
+does not close the XSS boundary.
+
 It reads like an ordinary markdown link. A few neighboring variants are just as important:
 
 ```md
@@ -113,7 +117,18 @@ These defaults are XSS hardening. They are not a complete DOM sanitizer, and the
 
 That distinction matters. Inline styles are not comprehensively sanitized. Less-common URL containers such as `srcset` may need an application-specific rule. An iframe with a permitted HTTPS URL can still load a site you would rather not embed. HTML and browser behavior are broad enough that fully untrusted raw HTML deserves a dedicated sanitizer and a narrowly defined policy.
 
-For that case, combine the built-in markdown URL checks with DOMPurify or an equivalent sanitizer. The [security guide](/docs/advanced/security) covers the hooks and the defense-in-depth pattern. Sanitizing only the HTML-looking parts of a markdown string is not sufficient: a markdown-native link can carry `javascript:` without containing an HTML tag at all.
+For that case, combine the built-in markdown URL checks with DOMPurify or an equivalent sanitizer. The [security guide](/docs/advanced/security) covers the hooks and the defense-in-depth pattern.
+
+## How to render markdown safely: a review checklist
+
+When rendering untrusted markdown, verify all four layers:
+
+- **Protocol allowlist:** reject dangerous link and image protocols, including `javascript:`, `data:`, and `vbscript:`.
+- **Attribute policy:** strip `on*` handlers and `srcdoc` before they reach a renderer.
+- **HTML policy:** block iframe, form, embed, and other tags your product does not need.
+- **Layered sanitizer:** pass fully untrusted raw HTML through a maintained DOM sanitizer configured with your application's allowlist.
+
+Run those checks against real payloads, not just configuration. At minimum, test a `javascript:` link, a `data:` image, an `onerror` handler, and an iframe with `srcdoc`.
 
 ## Tighten the allowed HTML surface
 
@@ -167,16 +182,7 @@ The same approach works with `sanitizeAttributes` when your policy depends on th
 
 Markdown libraries make different trust assumptions. Some expose an allow-all URL prefix as their default; others return an HTML string and leave the entire policy to you. That can be reasonable for trusted documents and surprising for comments or chat.
 
-Before choosing a renderer, test its current defaults with a `javascript:` link, a `data:` image, an `onerror` handler, and an iframe with `srcdoc`. Do not infer the answer from the word “markdown.” If you are comparing editor-oriented tools, our [Milkdown comparison](/compare/vs-milkdown) is one useful starting point, but the renderer's own security documentation should be the final authority.
-
-## A short review checklist
-
-When rendering untrusted markdown, verify all four layers:
-
-- **Protocol allowlist:** dangerous link and image protocols are rejected.
-- **Attribute policy:** `on*` handlers and `srcdoc` are stripped.
-- **HTML policy:** iframe, form, embed, and other unnecessary tags are blocked.
-- **Layered sanitizer:** fully untrusted raw HTML passes through a maintained DOM sanitizer with your application's allowlist.
+Before choosing a renderer, test its current defaults rather than inferring the answer from the word “markdown.” If you are comparing editor-oriented tools, our [Milkdown comparison](/compare/vs-milkdown) is one useful starting point, but the renderer's own security documentation should be the final authority.
 
 Safe rendering is easier to maintain when the baseline is already present. Install the package with `pnpm add @humanspeak/svelte-markdown`, then follow the [getting-started guide](/docs/getting-started) to render untrusted markdown in one component.
 

--- a/docs/src/routes/blog/preventing-markdown-xss-in-svelte/+page.svx
+++ b/docs/src/routes/blog/preventing-markdown-xss-in-svelte/+page.svx
@@ -1,0 +1,183 @@
+---
+title: Preventing Markdown XSS in Svelte
+date: 2026-08-18
+description: 'How markdown becomes an XSS vector in Svelte — javascript: URLs, on* handlers, data: URIs — and how to render user or AI markdown safely by default.'
+tags:
+    - security
+    - xss
+    - markdown
+    - svelte-5
+author: Jason Kummerl
+readingTime: 8
+---
+
+<script lang="ts">
+    import { BlogPostV2, type BlogPostMeta } from '@humanspeak/docs-kit/blog'
+    import { docsConfig } from '$lib/docs-config'
+
+    const post: BlogPostMeta = {
+        slug: 'preventing-markdown-xss-in-svelte',
+        title: 'Preventing Markdown XSS in Svelte',
+        date: '2026-08-18',
+        description:
+            'How markdown becomes an XSS vector in Svelte — javascript: URLs, on* handlers, data: URIs — and how to render user or AI markdown safely by default.',
+        tags: ['security', 'xss', 'markdown', 'svelte-5'],
+        author: 'Jason Kummerl',
+        readingTime: 8
+    }
+</script>
+
+<BlogPostV2 {post} config={docsConfig}>
+
+Markdown has a reassuringly small vocabulary. Headings, emphasis, lists, links: none of it looks much like executable code. That makes it easy to treat a markdown string as harmless text.
+
+The browser does not see it that way. Once markdown becomes HTML, a link is an `href`, an image is a `src`, and any raw HTML in the source becomes part of the page. If one of those values came from a user, a CMS, or an LLM, your markdown renderer may also be an XSS boundary.
+
+This is the smallest payload that demonstrates the problem:
+
+```md
+[Review the report](javascript:stealCookies())
+```
+
+It reads like an ordinary markdown link. A few neighboring variants are just as important:
+
+```md
+![preview](data:text/html,<script>alert(1)</script>)
+[open](vbscript:msgbox(1))
+
+<img src=x onerror="stealCookies()">
+<a href="/account" onclick="stealCookies()">Account</a>
+<iframe srcdoc="<script>stealCookies()</script>"></iframe>
+```
+
+Not every browser executes every historical payload, but that is the wrong standard for a security policy. The policy should reject dangerous protocols and executable attributes before the browser has a chance to interpret them.
+
+## Why this comes up more often now
+
+Markdown used to be mostly authored content: README files, documentation, and blog posts committed alongside code. Today we also render comments, support tickets, chat messages, CMS fields, and model output. The person rendering the markdown frequently does not control the string.
+
+LLM output deserves the same treatment as user input. The model does not need to be malicious. It can repeat markup from retrieved content, follow an injected instruction, or produce a link it was given elsewhere. The trust boundary is the input, not the apparent intent of its author.
+
+For the broader HTML-output case, see [Rendering Agent HTML Safely](/blog/rendering-agent-html-safely). Here we are concentrating on the quieter markdown-specific problem: URLs and attributes that look inert in source form.
+
+## The familiar Svelte one-liner is not a sanitizer
+
+A common implementation parses markdown into an HTML string, then asks Svelte to insert it:
+
+```svelte
+<script lang="ts">
+    import { marked } from 'marked'
+
+    const source = '[Review the report](javascript:stealCookies())'
+    const html = marked.parse(source)
+</script>
+
+{@html html}
+```
+
+`{@html}` means exactly what it says: insert this HTML. Svelte does not sanitize the string, validate its URLs, or remove event handlers. That is useful when the HTML is trusted, but it is a dangerous default for content you do not control.
+
+This is not a criticism of `marked`. A parser's job is to parse. If you choose the HTML-string path, sanitization is part of your application. [Using marked in Svelte](/blog/using-marked-in-svelte) walks through that tradeoff in more detail.
+
+## What safe by default looks like
+
+`@humanspeak/svelte-markdown` applies its URL and attribute policy before tokens reach a renderer. You do not opt into the defaults:
+
+- `http:`, `https:`, `mailto:`, `tel:`, and relative URLs are allowed.
+- `javascript:`, `data:`, `vbscript:`, malformed URLs, and other protocols are blocked.
+- Every `on*` event-handler attribute is removed.
+- `srcdoc` is removed from iframes.
+- URL-bearing HTML attributes such as `href`, `src`, `action`, `formaction`, `cite`, `data`, and `poster` pass through the URL sanitizer.
+
+That means this is a complete, runnable baseline:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+
+    const untrusted = `
+[Click me](javascript:alert(document.domain))
+
+<img src="x" onerror="alert(document.domain)">
+`
+</script>
+
+<SvelteMarkdown source={untrusted} />
+```
+
+The link's dangerous destination is neutralized, and the image's `onerror` handler never reaches the renderer. The same policy applies to markdown links, markdown images, and raw HTML attributes.
+
+## The honest boundary
+
+These defaults are XSS hardening. They are not a complete DOM sanitizer, and the package does not claim to replace DOMPurify.
+
+That distinction matters. Inline styles are not comprehensively sanitized. Less-common URL containers such as `srcset` may need an application-specific rule. An iframe with a permitted HTTPS URL can still load a site you would rather not embed. HTML and browser behavior are broad enough that fully untrusted raw HTML deserves a dedicated sanitizer and a narrowly defined policy.
+
+For that case, combine the built-in markdown URL checks with DOMPurify or an equivalent sanitizer. The [security guide](/docs/advanced/security) covers the hooks and the defense-in-depth pattern. Sanitizing only the HTML-looking parts of a markdown string is not sufficient: a markdown-native link can carry `javascript:` without containing an HTML tag at all.
+
+## Tighten the allowed HTML surface
+
+If your product does not need arbitrary HTML, the simplest policy is often to render less of it. `allowHtmlOnly` creates a small allowlist:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown, { allowHtmlOnly } from '@humanspeak/svelte-markdown'
+
+    const renderers = {
+        html: allowHtmlOnly(['strong', 'em', 'a', 'code', 'br'])
+    }
+</script>
+
+<SvelteMarkdown source={untrusted} {renderers} />
+```
+
+If most HTML is useful but a few embedding elements are not, deny only those:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown, { excludeHtmlOnly } from '@humanspeak/svelte-markdown'
+
+    const renderers = {
+        html: excludeHtmlOnly(['iframe', 'form', 'embed', 'object'])
+    }
+</script>
+
+<SvelteMarkdown source={untrusted} {renderers} />
+```
+
+You can also compose with the defaults rather than replacing them. This example rejects every external URL while retaining the built-in protocol checks for relative links:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown, { defaultSanitizeUrl } from '@humanspeak/svelte-markdown'
+
+    function localUrlsOnly(url, context) {
+        const safe = defaultSanitizeUrl(url, context)
+        if (!safe) return ''
+        return safe.startsWith('/') || safe.startsWith('#') ? safe : ''
+    }
+</script>
+
+<SvelteMarkdown source={untrusted} sanitizeUrl={localUrlsOnly} />
+```
+
+The same approach works with `sanitizeAttributes` when your policy depends on the tag—for example, dropping `style` everywhere or removing all attributes from an iframe. See [HTML allow/deny strategies](/docs/advanced/allow-deny) for the full set of helpers.
+
+## Check the defaults, whichever renderer you use
+
+Markdown libraries make different trust assumptions. Some expose an allow-all URL prefix as their default; others return an HTML string and leave the entire policy to you. That can be reasonable for trusted documents and surprising for comments or chat.
+
+Before choosing a renderer, test its current defaults with a `javascript:` link, a `data:` image, an `onerror` handler, and an iframe with `srcdoc`. Do not infer the answer from the word “markdown.” If you are comparing editor-oriented tools, our [Milkdown comparison](/compare/vs-milkdown) is one useful starting point, but the renderer's own security documentation should be the final authority.
+
+## A short review checklist
+
+When rendering untrusted markdown, verify all four layers:
+
+- **Protocol allowlist:** dangerous link and image protocols are rejected.
+- **Attribute policy:** `on*` handlers and `srcdoc` are stripped.
+- **HTML policy:** iframe, form, embed, and other unnecessary tags are blocked.
+- **Layered sanitizer:** fully untrusted raw HTML passes through a maintained DOM sanitizer with your application's allowlist.
+
+Safe rendering is easier to maintain when the baseline is already present. Install the package with `pnpm add @humanspeak/svelte-markdown`, then follow the [getting-started guide](/docs/getting-started) to render untrusted markdown in one component.
+
+</BlogPostV2>

--- a/docs/src/routes/blog/rendering-agent-html-safely/+page.svx
+++ b/docs/src/routes/blog/rendering-agent-html-safely/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Rendering Agent HTML Safely
-date: 2026-05-13
+date: '2026-05-13T12:00:00-04:00'
 description: Render AI-generated HTML safely in Svelte 5 with @humanspeak/svelte-markdown, covering XSS defenses, sanitization hooks, examples, and known gaps.
 tags:
     - ai-agents
@@ -19,7 +19,7 @@ readingTime: 9
     const post: BlogPostMeta = {
         slug: 'rendering-agent-html-safely',
         title: 'Rendering Agent HTML Safely',
-        date: '2026-05-13',
+        date: '2026-05-13T12:00:00-04:00',
         description:
             'Render AI-generated HTML safely in Svelte 5 with @humanspeak/svelte-markdown, covering XSS defenses, sanitization hooks, examples, and known gaps.',
         tags: ['ai-agents', 'security', 'streaming', 'xss', 'svelte-5'],
@@ -42,16 +42,9 @@ This is good news for the kinds of outputs we want. It is less good news for who
 
 ## The shape of agent HTML output
 
-If you’ve been rendering markdown in your product and your agent has been emitting `**bold**` and `# headings`, the worst payload you could plausibly worry about is a malformed link. The whole input shape was opinionated about what could be expressed.
+Markdown limits what an agent can express. Once you accept HTML, the surface expands to browser navigation, event handlers, embedded documents, forms, styles, and every other capability exposed by an element or attribute.
 
-Once you accept HTML from an agent, the attack surface widens to roughly _everything a browser can do_:
-
-- `<a href="javascript:steal()">` — clickjacking via protocol abuse
-- `<img src=x onerror="...">` — event handlers on any element
-- `<iframe srcdoc="...">` — arbitrary HTML injection
-- `<form action="javascript:...">` — credentials redirected to attacker-controlled handlers
-- `<style>body{display:none}</style>` — visual hijacking
-- `<a href="data:text/html,...">` — data URIs that the browser dutifully renders
+The full payload taxonomy belongs in [Preventing Markdown XSS in Svelte](/blog/preventing-markdown-xss-in-svelte), including the easy-to-miss case where a markdown-native link carries a dangerous protocol without containing raw HTML. The agent-specific concern is how that same untrusted surface behaves while the document is still arriving.
 
 The agent isn’t malicious. _Prompt injection is._ A user pastes a webpage into the chat, the model dutifully echoes some of its HTML into the response, and now your renderer is asked to put attacker-controlled markup into the DOM.
 
@@ -69,12 +62,7 @@ Below is what each of those looks like in practice.
 
 ## Layer 1 — Defaults you don’t have to think about
 
-`<SvelteMarkdown source={agentResponse} />` already applies, before any token reaches a renderer or snippet:
-
-- **URL protocol allowlist** for `href`, `src`, `action`, `formaction`, `cite`, `data`, and `poster` — only `http:`, `https:`, `mailto:`, `tel:`, and relative URLs survive. `javascript:`, `vbscript:`, `data:`, and `blob:` are blocked, including mixed-case and leading-whitespace variants.
-- **Event-handler stripping** — every `on*` attribute is removed: `onclick`, `onerror`, `onload`, `onsubmit`, all of them.
-- **`srcdoc` stripping** — iframes can’t inject arbitrary HTML through the `srcdoc` attribute.
-- **No `<script>` or `<style>` renderer** — both tags fall through to a placeholder that renders them as visible escaped text. They’re inert.
+`<SvelteMarkdown source={agentResponse} />` applies the package's URL and attribute policy before any token reaches a renderer or snippet. The [XSS guide](/blog/preventing-markdown-xss-in-svelte#what-safe-by-default-looks-like) documents the complete default policy and its limits.
 
 This is the case for both static input and streaming input. Sanitization runs in the parser, not the renderer, which means it’s applied per token as chunks arrive:
 

--- a/docs/src/routes/blog/rendering-markdown-in-svelte/+page.svx
+++ b/docs/src/routes/blog/rendering-markdown-in-svelte/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Rendering Markdown in Svelte 5 (The Complete Guide)
-date: 2026-08-18
+date: '2026-08-18T12:00:00-04:00'
 description: A complete guide to rendering markdown in Svelte 5 — built-ins vs parsers vs preprocessors vs component renderers, custom renderers, security, and streaming.
 tags:
     - markdown
@@ -18,7 +18,7 @@ readingTime: 12
     const post: BlogPostMeta = {
         slug: 'rendering-markdown-in-svelte',
         title: 'Rendering Markdown in Svelte 5 (The Complete Guide)',
-        date: '2026-08-18',
+        date: '2026-08-18T12:00:00-04:00',
         description:
             'A complete guide to rendering markdown in Svelte 5 — built-ins vs parsers vs preprocessors vs component renderers, custom renderers, security, and streaming.',
         tags: ['markdown', 'rendering', 'svelte-5', 'guide'],

--- a/docs/src/routes/blog/rendering-markdown-in-svelte/+page.svx
+++ b/docs/src/routes/blog/rendering-markdown-in-svelte/+page.svx
@@ -1,0 +1,182 @@
+---
+title: Rendering Markdown in Svelte 5 (The Complete Guide)
+date: 2026-08-18
+description: A complete guide to rendering markdown in Svelte 5 — built-ins vs parsers vs preprocessors vs component renderers, custom renderers, security, and streaming.
+tags:
+    - markdown
+    - rendering
+    - svelte-5
+    - guide
+author: Jason Kummerl
+readingTime: 12
+---
+
+<script lang="ts">
+    import { BlogPostV2, type BlogPostMeta } from '@humanspeak/docs-kit/blog'
+    import { docsConfig } from '$lib/docs-config'
+
+    const post: BlogPostMeta = {
+        slug: 'rendering-markdown-in-svelte',
+        title: 'Rendering Markdown in Svelte 5 (The Complete Guide)',
+        date: '2026-08-18',
+        description:
+            'A complete guide to rendering markdown in Svelte 5 — built-ins vs parsers vs preprocessors vs component renderers, custom renderers, security, and streaming.',
+        tags: ['markdown', 'rendering', 'svelte-5', 'guide'],
+        author: 'Jason Kummerl',
+        readingTime: 12
+    }
+</script>
+
+<BlogPostV2 {post} config={docsConfig}>
+
+There is no markdown primitive built into Svelte. To render a markdown string, you need to decide where parsing happens and what the parser produces.
+
+That decision is more important than the package name. A documentation site built from files at deploy time has different needs from a chat interface receiving partial text at runtime. An HTML string is enough for some applications; others need every link and code block to be a real Svelte component.
+
+In practice, there are four useful approaches in Svelte 5. Here is the map before we look at the code.
+
+## Four ways to render markdown in Svelte
+
+| Approach | Dynamic at runtime | Svelte components per node | Safe by default | Streaming | Best fit |
+|---|---:|---:|---:|---:|---|
+| Svelte `{@html}` with existing HTML | Yes | No | No | No | Trusted HTML you already generated |
+| Parser such as `marked` or `markdown-it` | Yes | No; produces an HTML string | Parser-dependent; usually your responsibility | Not inherently | Simple transformations and trusted runtime content |
+| Build-time preprocessor such as mdsvex | No | Yes, at compilation | Content is trusted at build time | No | Authored pages, documentation, static blogs |
+| Runtime component renderer | Yes | Yes | Library-dependent; enabled by default here | Yes | CMS content, user input, previews, chat, application UI |
+
+The table is not a ranking. Each row is good at a different job. Problems begin when a build-time tool is forced to handle runtime content, or when an HTML-string shortcut quietly becomes the rendering path for untrusted input.
+
+### 1. Insert HTML with Svelte
+
+If your application already has a trusted HTML string, Svelte can render it directly:
+
+```svelte
+<article>{@html trustedHtml}</article>
+```
+
+This is insertion, not markdown parsing. It is also not sanitization. Svelte assumes `trustedHtml` is ready for the DOM. That is a reasonable contract for HTML produced by your own build process and a poor contract for a comment field or model response.
+
+### 2. Parse markdown into an HTML string
+
+Libraries such as `marked` and `markdown-it` turn markdown into HTML. A minimal Svelte integration looks like this:
+
+```svelte
+<script lang="ts">
+    import { marked } from 'marked'
+
+    let source = $state('# Hello from markdown')
+    let html = $derived(marked.parse(source))
+</script>
+
+{@html html}
+```
+
+This is compact and useful when an HTML string is the desired output. In a browser UI, however, you own sanitization and the result remains one opaque string rather than a set of components. [Using marked in Svelte](/blog/using-marked-in-svelte) shows the safe version of this pattern and explains when raw marked is still the right choice.
+
+### 3. Compile markdown at build time
+
+mdsvex treats markdown as source code. It lets authored `.svx` files contain Svelte components and compiles everything during the build. For a documentation site or static blog, that is excellent: content lives in the repository, failures happen during CI, and the output is normal Svelte.
+
+It is not designed to receive an arbitrary markdown string from an API after the app has loaded. If your content is known at build time, start with mdsvex. If it arrives at runtime, choose a runtime parser or renderer. Our [mdsvex comparison](/compare/vs-mdsvex) goes deeper on that boundary.
+
+### 4. Render runtime tokens as Svelte components
+
+A component renderer parses at runtime but does not collapse the result into a single HTML string. Headings, links, code blocks, lists, tables, and images render through components or snippets. That gives application code control at the node level.
+
+`@humanspeak/svelte-markdown` follows this model. It is runes-compatible, typed, SSR-friendly, and designed for both complete documents and incrementally arriving content.
+
+## Quick start
+
+Install the package:
+
+```bash
+pnpm add @humanspeak/svelte-markdown
+```
+
+Then pass a string to the `source` prop:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+
+    let source = $state(`
+# Shipping notes
+
+- Added the account page
+- Fixed the **billing** flow
+
+Read the [release notes](/releases/42).
+`)
+</script>
+
+<SvelteMarkdown {source} />
+```
+
+When `source` changes, the rendered document updates. No browser-only setup is required, so the same component works during server rendering and hydration. The [getting-started guide](/docs/getting-started) covers parser options, inline mode, and the full prop surface.
+
+## Customize a node without rebuilding the parser
+
+Per-node rendering is where a component model earns its keep. Suppose every external link needs a new tab, a security relationship, and a product class. A Svelte 5 snippet can override only the link renderer:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+
+    const source = 'Read [the Svelte docs](https://svelte.dev).'
+</script>
+
+<SvelteMarkdown {source}>
+    {#snippet link({ href, title, children })}
+        <a
+            {href}
+            {title}
+            class="external-link"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            {@render children?.()}
+        </a>
+    {/snippet}
+</SvelteMarkdown>
+```
+
+Everything else continues to use the defaults. For larger overrides, pass a Svelte component through the `renderers` prop—for example, `renderers={{ code: HighlightedCode }}`. The [snippet override guide](/docs/renderers/snippet-overrides) and [custom renderer guide](/docs/renderers/custom-renderers) document every renderer key and prop.
+
+## Security is part of the rendering choice
+
+The `{@html}` path is not automatically unsafe, but it creates a clear obligation: the application must sanitize any HTML it did not fully control. A markdown parser alone is not a DOM sanitizer.
+
+`@humanspeak/svelte-markdown` enables URL and attribute sanitization by default. It rejects dangerous URL protocols such as `javascript:`, `data:`, and `vbscript:`, strips `on*` handlers and `srcdoc`, and lets you narrow the allowed HTML tags. Those defaults are hardening, not a replacement for a full DOM sanitizer when you accept fully untrusted raw HTML. Read [Preventing Markdown XSS in Svelte](/blog/preventing-markdown-xss-in-svelte) for the complete boundary and practical policies.
+
+## Add syntax through marked extensions
+
+Standard markdown is often only the beginning. The renderer supports marked extensions and includes first-party integrations for common application content:
+
+- **KaTeX** renders inline and block mathematics.
+- **Mermaid** turns diagram fences into rendered diagrams.
+- **Shiki** provides grammar-aware syntax highlighting for code blocks.
+- **GitHub-style alerts** add note, tip, warning, and caution blocks.
+- **Footnotes** add references and a footnote section without hand-written HTML.
+
+Custom marked tokenizers work too. Their tokens can render through Svelte components or snippets rather than returning HTML fragments. See [marked extensions](/docs/advanced/marked-extensions) for the general model and [syntax highlighting](/docs/advanced/syntax-highlighting) for code-specific options.
+
+## What about streaming markdown?
+
+Streaming matters when text arrives a few characters or words at a time, usually from an AI endpoint. Re-parsing and replacing an entire document for every chunk can be expensive and can cause visible DOM churn.
+
+The component supports a streaming mode with an incremental parser, but it should not dictate your choice for an ordinary article or CMS page. Treat it as a capability for the applications that need it. The [LLM streaming guide](/docs/advanced/llm-streaming) covers the API, while [Rendering Agent HTML Safely](/blog/rendering-agent-html-safely) addresses the wider security surface when model output includes raw HTML.
+
+## Which approach should you use?
+
+Choose based on when content exists and what the output needs to become:
+
+- **Use `{@html}` directly** when you already have trusted, sanitized HTML and do not need component-level control.
+- **Use `marked` or `markdown-it` directly** when your desired result is an HTML string—for an export, email, server transformation, or small trusted integration.
+- **Use mdsvex** when authors write content in the repository and it can be compiled at build time.
+- **Use a runtime component renderer** when markdown comes from an API, CMS, user, preview, or chat, or when links and code blocks need Svelte behavior.
+
+If you are comparing runtime component libraries, see [Svelte Exmarkdown vs Svelte Markdown](/compare/vs-svelte-exmarkdown). If the parser itself is the decision, see [marked vs Svelte Markdown](/compare/vs-marked).
+
+There is no single correct tool for every markdown document. There is, however, a clean default for dynamic Svelte applications: one component, runtime markdown, per-node control, and security hardening already enabled. Start with the [getting-started guide](/docs/getting-started), then add only the rendering and extension behavior your application needs.
+
+</BlogPostV2>

--- a/docs/src/routes/blog/rendering-markdown-in-svelte/+page.svx
+++ b/docs/src/routes/blog/rendering-markdown-in-svelte/+page.svx
@@ -35,7 +35,7 @@ That decision is more important than the package name. A documentation site buil
 
 In practice, there are four useful approaches in Svelte 5. Here is the map before we look at the code.
 
-## Four ways to render markdown in Svelte
+## Four Svelte markdown approaches
 
 | Approach | Dynamic at runtime | Svelte components per node | Safe by default | Streaming | Best fit |
 |---|---:|---:|---:|---:|---|
@@ -152,9 +152,9 @@ The `{@html}` path is not automatically unsafe, but it creates a clear obligatio
 
 Standard markdown is often only the beginning. The renderer supports marked extensions and includes first-party integrations for common application content:
 
-- **KaTeX** renders inline and block mathematics.
-- **Mermaid** turns diagram fences into rendered diagrams.
-- **Shiki** provides grammar-aware syntax highlighting for code blocks.
+- **[KaTeX](/docs/advanced/marked-extensions#step-by-step-katex-math-rendering)** renders inline and block mathematics.
+- **[Mermaid](/docs/advanced/marked-extensions#step-by-step-mermaid-diagrams)** turns diagram fences into rendered diagrams.
+- **[Shiki](/docs/advanced/syntax-highlighting)** provides grammar-aware syntax highlighting for code blocks.
 - **GitHub-style alerts** add note, tip, warning, and caution blocks.
 - **Footnotes** add references and a footnote section without hand-written HTML.
 
@@ -175,7 +175,7 @@ Choose based on when content exists and what the output needs to become:
 - **Use mdsvex** when authors write content in the repository and it can be compiled at build time.
 - **Use a runtime component renderer** when markdown comes from an API, CMS, user, preview, or chat, or when links and code blocks need Svelte behavior.
 
-If you are comparing runtime component libraries, see [Svelte Exmarkdown vs Svelte Markdown](/compare/vs-svelte-exmarkdown). If the parser itself is the decision, see [marked vs Svelte Markdown](/compare/vs-marked).
+If you are comparing runtime component libraries, see [Svelte Exmarkdown vs Svelte Markdown](/compare/vs-svelte-exmarkdown). For an AI-focused renderer, compare [Svelte Streamdown vs Svelte Markdown](/compare/vs-svelte-streamdown). If the parser itself is the decision, see [marked vs Svelte Markdown](/compare/vs-marked).
 
 There is no single correct tool for every markdown document. There is, however, a clean default for dynamic Svelte applications: one component, runtime markdown, per-node control, and security hardening already enabled. Start with the [getting-started guide](/docs/getting-started), then add only the rendering and extension behavior your application needs.
 

--- a/docs/src/routes/blog/using-marked-in-svelte/+page.svx
+++ b/docs/src/routes/blog/using-marked-in-svelte/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: Using marked in Svelte (Safely)
-date: 2026-08-18
+date: '2026-08-18T12:00:00-04:00'
 description: How to use the marked parser in Svelte 5 — the {@html} footgun, why you get an HTML string instead of components, and how to render marked output safely.
 tags:
     - marked
@@ -18,7 +18,7 @@ readingTime: 7
     const post: BlogPostMeta = {
         slug: 'using-marked-in-svelte',
         title: 'Using marked in Svelte (Safely)',
-        date: '2026-08-18',
+        date: '2026-08-18T12:00:00-04:00',
         description:
             'How to use the marked parser in Svelte 5 — the {@html} footgun, why you get an HTML string instead of components, and how to render marked output safely.',
         tags: ['marked', 'markdown', 'svelte-5', 'security'],

--- a/docs/src/routes/blog/using-marked-in-svelte/+page.svx
+++ b/docs/src/routes/blog/using-marked-in-svelte/+page.svx
@@ -1,0 +1,197 @@
+---
+title: Using marked in Svelte (Safely)
+date: 2026-08-18
+description: How to use the marked parser in Svelte 5 — the {@html} footgun, why you get an HTML string instead of components, and how to render marked output safely.
+tags:
+    - marked
+    - markdown
+    - svelte-5
+    - security
+author: Jason Kummerl
+readingTime: 7
+---
+
+<script lang="ts">
+    import { BlogPostV2, type BlogPostMeta } from '@humanspeak/docs-kit/blog'
+    import { docsConfig } from '$lib/docs-config'
+
+    const post: BlogPostMeta = {
+        slug: 'using-marked-in-svelte',
+        title: 'Using marked in Svelte (Safely)',
+        date: '2026-08-18',
+        description:
+            'How to use the marked parser in Svelte 5 — the {@html} footgun, why you get an HTML string instead of components, and how to render marked output safely.',
+        tags: ['marked', 'markdown', 'svelte-5', 'security'],
+        author: 'Jason Kummerl',
+        readingTime: 7
+    }
+</script>
+
+<BlogPostV2 {post} config={docsConfig}>
+
+If you search for a quick way to render markdown in Svelte, the first useful answer is usually two lines long: parse the string with `marked`, then render the result with `{@html}`.
+
+It works. It is also the point where your application becomes responsible for the security and structure of the generated HTML.
+
+That does not make `marked` a bad choice. `@humanspeak/svelte-markdown` uses `marked` under the hood because it is a fast, capable parser with a mature extension system. The important question is whether you need an HTML string or a tree of Svelte components.
+
+## The 30-second implementation
+
+Install `marked`, parse your source, and insert the result:
+
+```svelte
+<script lang="ts">
+    import { marked } from 'marked'
+
+    let markdown = $state('# Hello\n\nThis is **markdown**.')
+    let html = $derived(marked.parse(markdown))
+</script>
+
+<article>{@html html}</article>
+```
+
+For trusted content, this can be entirely appropriate. The source is reactive, the code is small, and `marked` handles GitHub Flavored Markdown well.
+
+The trouble begins when `markdown` comes from somewhere else:
+
+```svelte
+<script lang="ts">
+    import { marked } from 'marked'
+
+    const markdown = `
+[Open the document](javascript:alert(document.domain))
+
+<img src="x" onerror="alert(document.domain)">
+`
+
+    const html = marked.parse(markdown)
+</script>
+
+{@html html}
+```
+
+`{@html}` performs no sanitization. It tells Svelte that the string is ready to become DOM. If the parser emits a dangerous URL or preserves an event handler, Svelte does not add another safety check.
+
+If you choose this approach for content you do not control, sanitize the generated HTML with a maintained tool such as DOMPurify and define an allowlist appropriate to your application. Also test markdown-native URLs, not only raw HTML tags. [Preventing Markdown XSS in Svelte](/blog/preventing-markdown-xss-in-svelte) covers that threat model in detail.
+
+## The second limitation: the result is one string
+
+The HTML-string model is convenient until individual nodes need application behavior.
+
+Suppose external links should open in a new tab with `rel="noopener noreferrer"`. Code blocks should go through a Shiki component. Images should use your lazy-loading component and report failures to telemetry. With raw `marked` output, you can configure a marked renderer, post-process the HTML, or manipulate the DOM after insertion. All three approaches work, but none gives you a normal Svelte component at each node.
+
+Post-processing HTML with regular expressions is especially brittle. HTML has nesting, quoting, optional attributes, and edge cases that a regex-based replacement will eventually mishandle. If per-element UI behavior is a requirement, it is usually cleaner to choose a component rendering layer at the start.
+
+## Marked extensions are still a strong reason to use it
+
+`marked` supports custom tokenizers, renderers, hooks, and extensions. That makes it useful well beyond the basic markdown specification. You can recognize domain-specific syntax, adjust parsing rules, or generate a specialized HTML string on the server.
+
+The distinction is output, not parsing power. A marked renderer ultimately returns strings. A custom tokenizer can add a new token type, but you still decide whether that token becomes an HTML fragment, is transformed into some other string, or is handed to another rendering layer.
+
+Raw `marked` is often the right tool when:
+
+- you need an HTML string for an email, feed, export, or server response;
+- the code is not running in Svelte;
+- you completely control the input and want the smallest direct integration;
+- you are building a string transformation rather than an interactive UI.
+
+In those cases, use it directly. There is no benefit in adding a component abstraction that your output does not need.
+
+## The same parser behind a component layer
+
+When the destination is a Svelte interface, `@humanspeak/svelte-markdown` keeps marked's parser and changes the rendering model:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+
+    let markdown = $state('# Hello\n\nThis is **markdown**.')
+</script>
+
+<SvelteMarkdown source={markdown} />
+```
+
+There is no `{@html}` call. Marked produces tokens, and those tokens render through Svelte components. URL and attribute sanitization are enabled by default, while links, images, code blocks, headings, tables, and the rest remain individually overridable.
+
+For example, an external-link policy can live next to the content instead of inside an HTML-string transformation:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+
+    const source = 'Read the [Svelte docs](https://svelte.dev).'
+</script>
+
+<SvelteMarkdown {source}>
+    {#snippet link({ href, title, children })}
+        <a {href} {title} target="_blank" rel="noopener noreferrer">
+            {@render children?.()}
+        </a>
+    {/snippet}
+</SvelteMarkdown>
+```
+
+That is ordinary Svelte markup. The same pattern can mount a stateful component, apply application context, or route a token to a syntax highlighter. See [snippet overrides](/docs/renderers/snippet-overrides) for the renderer names and props.
+
+## Passing marked options through
+
+Common marked behavior remains configurable through the `options` prop:
+
+```svelte
+<SvelteMarkdown
+    source={markdown}
+    options={{
+        gfm: true,
+        breaks: true
+    }}
+/>
+```
+
+Marked no longer generates heading IDs through `headerIds` or `headerPrefix`. If you use
+Marked directly and need GitHub-style heading IDs, add the `marked-gfm-heading-id` extension.
+`SvelteMarkdown` provides its own heading-ID support, but that is a renderer option rather than
+an option inherited from current versions of Marked.
+
+For custom syntax, pass marked extensions through the `extensions` prop. Extension token types can then render as components or named snippets:
+
+```svelte
+<script lang="ts">
+    import SvelteMarkdown from '@humanspeak/svelte-markdown'
+    import type { MarkedExtension } from 'marked'
+
+    const highlight: MarkedExtension = {
+        extensions: [
+            {
+                name: 'highlight',
+                level: 'inline',
+                start: (source) => source.indexOf('=='),
+                tokenizer(source) {
+                    const match = /^==([^=]+)==/.exec(source)
+                    if (!match) return
+                    return { type: 'highlight', raw: match[0], text: match[1] }
+                }
+            }
+        ]
+    }
+</script>
+
+<SvelteMarkdown source="This is ==important==." extensions={[highlight]}>
+    {#snippet highlight({ text })}
+        <mark>{text}</mark>
+    {/snippet}
+</SvelteMarkdown>
+```
+
+The package also ships first-party integrations for KaTeX, Mermaid, Shiki, GitHub-style alerts, and footnotes. The [marked extensions guide](/docs/advanced/marked-extensions) explains how extension tokens, caching, and renderer overrides fit together.
+
+## Which path should you take?
+
+Use raw `marked` when the product you want is an HTML string and you are prepared to own its sanitization. It is direct, flexible, and very good at that job.
+
+Use a component renderer when markdown is part of a Svelte interface: when nodes need behavior, when content is dynamic, or when safe defaults are valuable. You still get marked's parsing and extension ecosystem, but you are no longer treating the rendered document as one opaque blob.
+
+The [complete guide to rendering markdown in Svelte](/blog/rendering-markdown-in-svelte) places both options alongside mdsvex and other component renderers. For a feature-by-feature view, see [marked vs Svelte Markdown](/compare/vs-marked).
+
+To keep marked's parsing while dropping the `{@html}` boundary, install `@humanspeak/svelte-markdown` and follow the [getting-started guide](/docs/getting-started).
+
+</BlogPostV2>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.8.2
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))
+        specifier: github:humanspeak/docs-kit#2026.8.4
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/728b1f534ebcf10674a04839cbd987d7e000be16(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -675,8 +675,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41':
-    resolution: {gitHosted: true, integrity: sha512-QlyWkrBsd2ODfUyJC3+BtTM0bjhoHZJWahzQ6rFa/VMHBVeM9NUZhVhvumSAtt3XT7lfMW4etB66XXB6eG+g5w==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/728b1f534ebcf10674a04839cbd987d7e000be16':
+    resolution: {gitHosted: true, integrity: sha512-bK1cOrdlopJj/4K888CXeZpJjYWWOcq2LiEt7sEiKRGFqshRvYhrEOUEBk3w2mh5RgavO/wfcyesiFv4p2mdaw==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/728b1f534ebcf10674a04839cbd987d7e000be16}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4407,7 +4407,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/728b1f534ebcf10674a04839cbd987d7e000be16(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
     dependencies:
       '@humanspeak/svelte-motion': 0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.8(@typescript-eslint/types@8.66.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.8.1
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))
+        specifier: github:humanspeak/docs-kit#2026.8.2
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@humanspeak/svelte-markdown':
         specifier: workspace:*
         version: link:..
@@ -182,8 +182,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.1(jiti@2.7.0))
       '@humanspeak/svelte-motion':
-        specifier: ^0.8.2
-        version: 0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))
+        specifier: ^0.9.2
+        version: 0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@icons-pack/svelte-simple-icons':
         specifier: ^7.2.0
         version: 7.2.0(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))
@@ -675,8 +675,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41':
+    resolution: {gitHosted: true, integrity: sha512-QlyWkrBsd2ODfUyJC3+BtTM0bjhoHZJWahzQ6rFa/VMHBVeM9NUZhVhvumSAtt3XT7lfMW4etB66XXB6eG+g5w==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -696,8 +696,8 @@ packages:
     resolution: {integrity: sha512-6kmeqrCVThw4RYZsJ74l9cOdZQ84XHnGIzrv+Po49CZBNNVDEzi0CGsTx+KKmr/Hb6hY6yDGxeWTiz4VHkdsEg==}
     engines: {node: '>=20.19.0'}
 
-  '@humanspeak/svelte-motion@0.8.2':
-    resolution: {integrity: sha512-oK4mlqKuqT+GQb21ZgT88radVHZx+rq8I4QxHOMDaqdHjneozsnkjP9Hr1iCO7XSExbMUJgm3qsOUw+UZoUsoA==}
+  '@humanspeak/svelte-motion@0.9.2':
+    resolution: {integrity: sha512-66GHIqKcLtk5LmYHiPkpD8lLloLvSVhTTRfReFk9wnAs+jPxAK867KB6OKrWhsvvX928cR5k3+p5qRABtEK/wg==}
     peerDependencies:
       svelte: ^5.0.0
 
@@ -2424,15 +2424,12 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  framer-motion@12.43.0:
-    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
+  framer-motion@13.1.0:
+    resolution: {integrity: sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==}
     peerDependencies:
-      '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
       react:
         optional: true
       react-dom:
@@ -3077,21 +3074,18 @@ packages:
   moo@0.5.3:
     resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
 
-  motion-dom@12.43.0:
-    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
+  motion-dom@13.0.0:
+    resolution: {integrity: sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==}
 
-  motion-utils@12.39.0:
-    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+  motion-utils@13.0.0:
+    resolution: {integrity: sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==}
 
-  motion@12.43.0:
-    resolution: {integrity: sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==}
+  motion@13.1.0:
+    resolution: {integrity: sha512-qtvscq59uCPdWnNW4SdSkrxR+BS/QYsa923bx7ocA+4p+ZGNbbVQwkSnG4aukB81QWjtl3AxX36plxNyZLmHCA==}
     peerDependencies:
-      '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
       react:
         optional: true
       react-dom:
@@ -4413,9 +4407,9 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41(@humanspeak/svelte-markdown@)(@humanspeak/svelte-motion@0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)))(mode-watcher@1.1.0(svelte@5.56.8(@typescript-eslint/types@8.66.0)))(shiki@4.4.2)(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
     dependencies:
-      '@humanspeak/svelte-motion': 0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))
+      '@humanspeak/svelte-motion': 0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@lucide/svelte': 1.30.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       '@resvg/resvg-js': 2.6.2
@@ -4438,14 +4432,13 @@ snapshots:
 
   '@humanspeak/memory-cache@1.1.2': {}
 
-  '@humanspeak/svelte-motion@0.8.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
+  '@humanspeak/svelte-motion@0.9.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
     dependencies:
       acorn: 8.18.0
-      motion: 12.43.0
-      motion-dom: 12.43.0
+      motion: 13.1.0
+      motion-dom: 13.0.0
       svelte: 5.56.8(@typescript-eslint/types@8.66.0)
     transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
       - react
       - react-dom
 
@@ -6248,10 +6241,10 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@12.43.0:
+  framer-motion@13.1.0:
     dependencies:
-      motion-dom: 12.43.0
-      motion-utils: 12.39.0
+      motion-dom: 13.0.0
+      motion-utils: 13.0.0
       tslib: 2.8.1
 
   fsevents@2.3.2:
@@ -6883,15 +6876,15 @@ snapshots:
 
   moo@0.5.3: {}
 
-  motion-dom@12.43.0:
+  motion-dom@13.0.0:
     dependencies:
-      motion-utils: 12.39.0
+      motion-utils: 13.0.0
 
-  motion-utils@12.39.0: {}
+  motion-utils@13.0.0: {}
 
-  motion@12.43.0:
+  motion@13.1.0:
     dependencies:
-      framer-motion: 12.43.0
+      framer-motion: 13.1.0
       tslib: 2.8.1
 
   mprocs@0.9.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
     - docs
 
 allowBuilds:
-    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41': true
+    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/728b1f534ebcf10674a04839cbd987d7e000be16': true
     '@humanspeak/docs-kit': true
     esbuild: true
     sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
     - docs
 
 allowBuilds:
-    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8': true
+    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/3e332eb43d0dddd8a9033307755f35da5e886e41': true
     '@humanspeak/docs-kit': true
     esbuild: true
     sharp: true

--- a/src/lib/SvelteMarkdown.svelte
+++ b/src/lib/SvelteMarkdown.svelte
@@ -11,7 +11,7 @@
 
  <SvelteMarkdown
    source={markdownString}
-   options={{ headerIds: false }}
+   options={{ gfm: true, breaks: true }}
    renderers={{ link: CustomLink }}
  />
  ```


### PR DESCRIPTION
## Summary

Adds a focused Svelte markdown blog cluster for runtime rendering, Marked integration, and XSS prevention. It also improves comparison-page SEO, updates the shared docs UI dependencies, and refreshes the competitive-intelligence state that informed the content work.

## Changes

### 📚 Documentation

- Add complete guides for rendering markdown in Svelte 5, using Marked safely, and preventing markdown XSS
- Keep the XSS guide as the canonical threat model while linking the Marked, hub, and agent-HTML posts to it
- Add direct links to KaTeX, Mermaid, Shiki, streaming, and renderer comparisons
- Use explicit publish timestamps so authored dates do not shift across time zones
- Refresh comparison-page SEO titles and descriptions

### 🔒 Security

- Emphasize markdown-native dangerous URLs that bypass raw-HTML-only checks
- Document protocol, attribute, HTML allow/deny, and layered sanitizer boundaries
- Verify the custom sanitizer signatures and extension-snippet examples against the implementation

### 📦 Dependencies

- Upgrade `@humanspeak/docs-kit` to `2026.8.4` and pin its exact build hash
- Upgrade `@humanspeak/svelte-motion` to `0.9.2`
- Refresh the lockfile for the Humanspeak package updates

### 🔧 Competitive intelligence

- Refresh tracked competitor/release state for the August 18 run
- Add SEO configuration and ignore local GSC/report artifacts

### 🧪 Validation

- `trunk fmt`
- `trunk check`
- 973 Vitest tests passed
- Docs `svelte-check`: 0 errors (one pre-existing unused CSS warning)
- Verified all four blog posts render on the index with the intended publish dates

## Commits

- [`84deea1`](https://github.com/humanspeak/svelte-markdown/commit/84deea183a2ff717d8b723bf92399f91dc53cf03) chore(competitive-intel): update tracking state
- [`2b10452`](https://github.com/humanspeak/svelte-markdown/commit/2b10452eb9a603e40ecab73bd2879093f5dcc02c) feat(competitive-intel): add SEO tracking state
- [`c0e538a`](https://github.com/humanspeak/svelte-markdown/commit/c0e538a72e79e2ac9723fa4a331e9e95dcf2bc94) build(docs): update Humanspeak packages
- [`6874adc`](https://github.com/humanspeak/svelte-markdown/commit/6874adc45166572e9fc6d30c4944deedd810ce63) docs(compare): improve comparison SEO titles
- [`b36f782`](https://github.com/humanspeak/svelte-markdown/commit/b36f78255d47ba75c58a3fc9e9948f9c2ef7b6a6) build(docs): bump docs-kit to 2026.8.4
- [`f0d4e11`](https://github.com/humanspeak/svelte-markdown/commit/f0d4e11f25c80524342181dcf77e72db153cab38) docs(blog): add Svelte markdown guides
- [`2d9829e`](https://github.com/humanspeak/svelte-markdown/commit/2d9829e7cb9bfa1894269aab6123ec1478eff93f) docs(blog): sharpen security and discovery guidance
- [`d534afc`](https://github.com/humanspeak/svelte-markdown/commit/d534afc1c75a91f8adea5f3413ba62e186e1de6a) docs(blog): consolidate security guidance
