### PR TITLE
fix(streaming): code fence splitting and marked options pollution

### DIFF
--- a/src/lib/utils/incremental-parser.options-pollution.test.ts
+++ b/src/lib/utils/incremental-parser.options-pollution.test.ts
@@ -1,0 +1,42 @@
+import type { SvelteMarkdownOptions } from '$lib/types.js'
+import { describe, expect, it } from 'vitest'
+import { IncrementalParser } from './incremental-parser.js'
+import { lexAndClean } from './parse-and-cache.js'
+
+/**
+ * marked's Lexer writes its default tokenizer back onto the options object it
+ * receives. If that mutation leaks to caller-held options, any
+ * IncrementalParser constructed afterwards from the same object sees
+ * `options.tokenizer != null` and silently disables the tail window — every
+ * parser rebuild (resetStream, streamId change) then falls back to a full
+ * re-lex per chunk. `lexAndClean` guards this by lexing a shallow copy.
+ */
+describe('parser options are not polluted by marked', () => {
+    const createOptions = (): SvelteMarkdownOptions => ({ gfm: true })
+
+    it('lexAndClean does not mutate the options object', () => {
+        const options = createOptions()
+
+        lexAndClean('# Hello\n\nWorld', options, false)
+
+        expect(options.tokenizer).toBeUndefined()
+        expect(options.renderer).toBeUndefined()
+    })
+
+    it('keeps the tail window enabled for a parser rebuilt from the same options object', () => {
+        const options = createOptions()
+
+        // First parser lexes with these options — previously this installed
+        // marked's tokenizer onto them.
+        const first = new IncrementalParser(options)
+        first.update('# Hello\n\nWorld')
+
+        // A rebuilt parser (resetStream / streamId change reuses the same
+        // combinedOptions object) must still get the tail-window fast path.
+        const second = new IncrementalParser(options)
+        second.update('# Hello\n\n')
+        const result = second.update('# Hello\n\nWorld')
+
+        expect(result.usedTailWindow).toBe(true)
+    })
+})

--- a/src/lib/utils/incremental-parser.streaming-fence.test.ts
+++ b/src/lib/utils/incremental-parser.streaming-fence.test.ts
@@ -1,0 +1,108 @@
+import type { SvelteMarkdownOptions } from '$lib/types.js'
+import { describe, expect, it } from 'vitest'
+import { IncrementalParser } from './incremental-parser.js'
+import { lexAndClean } from './parse-and-cache.js'
+
+/**
+ * Red test for the broken home-page streaming demo (FIG-002).
+ *
+ * The demo streams word chunks (regex `\S+` plus trailing whitespace)
+ * append-only through `writeChunk`. Its content includes a fenced code block that contains a
+ * blank line:
+ *
+ * ```javascript
+ * import { writable } from 'svelte/store'
+ *                                          <-- blank line inside the fence
+ * const count = writable(0)
+ * ...
+ * ```
+ *
+ * When a flush lands right after that blank line, the lexer sees an
+ * unclosed fence whose `raw` ends with `\n\n`. The tail-window boundary
+ * then treats the half-open code token as a stable prefix token, freezes
+ * it, and lexes everything streamed afterwards in isolation — so the rest
+ * of the code block renders as a paragraph and the closing fence becomes
+ * a stray empty code block.
+ *
+ * The invariant under test: after any append-only update sequence, the
+ * final token array must match a fresh full parse of the same source.
+ */
+describe('IncrementalParser streaming across a fenced code block with a blank line', () => {
+    // Fresh options per use — cross-test pollution guarded by
+    // incremental-parser.options-pollution.test.ts.
+    const createOptions = (): SvelteMarkdownOptions => ({ gfm: true })
+
+    it('keeps an unclosed fence open when the stream pauses on a blank line inside it', () => {
+        const options = createOptions()
+        const parser = new IncrementalParser(options)
+
+        // Stream pauses exactly after the blank line inside the open fence —
+        // the word-chunk regex glues `\n\n` onto the preceding word, so this
+        // boundary occurs on the home page on every run.
+        parser.update("```javascript\nimport { writable } from 'svelte/store'\n\n")
+
+        const full =
+            "```javascript\nimport { writable } from 'svelte/store'\n\nconst count = writable(0)\n```\n"
+        const result = parser.update(full)
+
+        const expected = lexAndClean(full, createOptions(), false)
+        expect(result.tokens.map((t) => t.type)).toEqual(expected.map((t) => t.type))
+        expect(result.tokens.map((t) => t.raw)).toEqual(expected.map((t) => t.raw))
+    })
+
+    it('renders the home-page streaming demo content correctly after the final chunk', () => {
+        // Exact content of the FIG-002 streaming demo on docs/src/routes/+page.svelte
+        const streamContent = `# Understanding Reactive Systems
+
+Reactive programming is a **declarative paradigm** concerned with _data streams_ and the propagation of change.
+
+## Core Principles
+
+1. **Observables** — represent a stream of data over time
+2. **Operators** — transform, filter, and combine streams
+3. **Subscribers** — consume the final output
+
+> "The best way to predict the future is to invent it." — Alan Kay
+
+### A Simple Example
+
+\`\`\`javascript
+import { writable } from 'svelte/store'
+
+const count = writable(0)
+count.subscribe(value => {
+    console.log(\`Count: \${value}\`)
+})
+\`\`\`
+
+| Feature | Svelte | React |
+|---------|--------|-------|
+| Reactivity | Compile-time | Runtime |
+| Bundle Size | Small | Medium |
+
+The \`writable\` store notifies all subscribers when the value changes. This makes building **real-time UIs** straightforward.`
+
+        const parser = new IncrementalParser(createOptions())
+
+        // Same chunking as the demo: word chunks with trailing whitespace,
+        // applied append-only with a parse per flush.
+        const chunks = streamContent.match(/\S+\s*/g) ?? []
+        let accumulated = ''
+        let lastTokens: ReturnType<typeof lexAndClean> = []
+        for (const chunk of chunks) {
+            accumulated += chunk
+            lastTokens = parser.update(accumulated).tokens
+        }
+
+        expect(accumulated).toBe(streamContent)
+
+        const expected = lexAndClean(streamContent, createOptions(), false)
+        expect(lastTokens.map((t) => t.type)).toEqual(expected.map((t) => t.type))
+
+        // The fenced block must survive as ONE code token containing the
+        // full snippet — not get split at the blank line.
+        const codeTokens = lastTokens.filter((t) => t.type === 'code')
+        expect(codeTokens).toHaveLength(1)
+        expect((codeTokens[0] as { text?: string }).text).toContain('count.subscribe')
+    })
+})

--- a/src/lib/utils/incremental-parser.ts
+++ b/src/lib/utils/incremental-parser.ts
@@ -168,14 +168,20 @@ export class IncrementalParser {
 
     private isStableAtSourceEnd = (token: Token): boolean => {
         if (token.type === 'space') return false
+        // Code must be checked before the generic blank-line test: an
+        // UNCLOSED fence that pauses on a blank line inside the block also
+        // ends with `\n\n`, and treating it as stable freezes the half-open
+        // fence into the reused prefix — every later append then re-lexes in
+        // isolation and the rest of the block renders as plain markdown.
+        // (Indented code is conservatively unstable too: a further indented
+        // line after a blank line continues the same block.)
+        if (token.type === 'code') return CLOSED_FENCE_RE.test(token.raw)
         if (token.raw.endsWith('\n\n')) return true
 
         switch (token.type) {
             case 'heading':
             case 'hr':
                 return token.raw.endsWith('\n')
-            case 'code':
-                return CLOSED_FENCE_RE.test(token.raw)
             default:
                 return false
         }

--- a/src/lib/utils/parse-and-cache.ts
+++ b/src/lib/utils/parse-and-cache.ts
@@ -35,7 +35,13 @@ export const lexAndClean = (
     options: SvelteMarkdownOptions,
     isInline: boolean
 ): Token[] => {
-    const lexer = new Lexer(options)
+    // Shallow-copy: marked's Lexer writes its default tokenizer back onto the
+    // options object it receives. Passing the caller's object directly would
+    // pollute component-held options, and IncrementalParser reads
+    // `options.tokenizer` to decide whether the tail window is safe — a
+    // polluted object silently disables it on every parser rebuild
+    // (resetStream, streamId change).
+    const lexer = new Lexer({ ...options })
     const parsedTokens = isInline ? lexer.inlineTokens(source) : lexer.lex(source)
     return shrinkHtmlTokens(parsedTokens)
 }


### PR DESCRIPTION
## Summary

Fixes the home-page streaming demo rendering its fenced code block broken in half, and a related silent performance regression in streaming mode. Both bugs live in the incremental parser's tail-window optimization: the first froze an unclosed code fence into the reused token prefix, the second disabled the tail window entirely after any parser rebuild.

## Changes

- 🐛 **Unclosed code fences no longer split at blank lines during streaming.** An unclosed fence that pauses on a blank line inside the block has `raw` ending in `\n\n`, so the generic blank-line stability check marked it stable and froze the half-open fence into the tail-window prefix — everything streamed afterwards re-lexed in isolation (rest of the block became a paragraph, the closing fence a stray empty code block). Code tokens are now judged by `CLOSED_FENCE_RE` before the generic check; indented code is conservatively unstable too, since an indented line after a blank line continues the block.
- 🐛 **marked's Lexer no longer pollutes caller-held options.** marked writes its default tokenizer back onto the options object it receives, and `IncrementalParser` reads `options.tokenizer` to decide tail-window safety — so any parser rebuilt from the same object (`resetStream()`, `streamId` change) silently fell back to a full re-lex per chunk. In a chat UI that costs every message after the first. `lexAndClean` now lexes a shallow copy.
- 🧪 Red-first regression tests for both: word-chunk streaming of the exact home-page demo content across the fence boundary, and options non-mutation plus tail-window survival across a parser rebuild. Both suites fail without their fixes.

Verified: unit 977/977, Playwright E2E 565/565 (all browsers), svelte-check and trunk clean.

## Commits

- [`09622d4`](https://github.com/humanspeak/svelte-markdown/commit/09622d403c3a2c8976e0ef7be94ec1ebd64ef8f2) fix(streaming): keep unclosed code fences out of the tail-window prefix
- [`6f9db38`](https://github.com/humanspeak/svelte-markdown/commit/6f9db38df2473ac2495e1c470b411bd0ce3b6ceb) fix(parser): stop marked from polluting caller-held parser options

🤖 Generated with [Claude Code](https://claude.com/claude-code)
