### PR TITLE
fix: dispatch self-closing custom html tags from renderers.html

### DIFF
--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -28,6 +28,22 @@
      * allocating a fresh `{}` per dispatched token.
      */
     const NO_EXTRA_PROPS = Object.freeze({})
+
+    /**
+     * HTML tag names are case-insensitive. Copy a renderer/snippet map with
+     * lowercase aliases so `widget` and `Widget` resolve the same way on both
+     * the inline pairing path and the nested htmlparser2 path (issue #383).
+     * Exact-case keys already present are left in place and win.
+     */
+    const withLowercaseHtmlKeys = <T,>(src: Record<string, T> | undefined): Record<string, T> => {
+        if (!src) return {}
+        const out: Record<string, T> = { ...src }
+        for (const key of Object.keys(src)) {
+            const lower = key.toLowerCase()
+            if (!(lower in out)) out[lower] = src[key]
+        }
+        return out
+    }
 </script>
 
 <script lang="ts">
@@ -189,6 +205,9 @@
         !(renderers as Record<string, unknown>).space && !snippetOverrides.space
     )
 
+    const htmlRenderersByLower = $derived(withLowercaseHtmlKeys(renderers.html))
+    const htmlSnippetsByLower = $derived(withLowercaseHtmlKeys(htmlSnippetOverrides))
+
     // Sanitize rest props before they reach any renderer or snippet.
     // This is the single enforcement point — custom renderers cannot bypass it.
     const sanitizedRest = $derived.by(() => {
@@ -218,29 +237,30 @@
         attributes?: Record<string, string>
         tokens?: Token[]
     }}
+    {@const htmlTagName = htmlTok.tag?.toLowerCase()}
     {@const inlineHtmlOk =
         token.type === 'html' &&
-        !!htmlTok.tag &&
+        !!htmlTagName &&
         !!renderers.html &&
-        htmlTok.tag in Html &&
-        renderers.html[htmlTok.tag] === Html[htmlTok.tag] &&
-        !htmlSnippetOverrides[htmlTok.tag]}
+        htmlTagName in Html &&
+        htmlRenderersByLower[htmlTagName] === Html[htmlTagName] &&
+        !htmlSnippetsByLower[htmlTagName]}
     {#if token.type === 'space' && inlineSpaceOk}
         <!-- inlined: space tokens render nothing -->
     {:else if token.type === 'text' && inlineTextOk && !(token as Tokens.Text).tokens}
         {(token as Tokens.Text).text ?? token.raw}
-    {:else if inlineHtmlOk && htmlTok.tag}
+    {:else if inlineHtmlOk && htmlTagName}
         {@const sanitizedAttrs = htmlTok.attributes
             ? sanitizeAttributes(
                   htmlTok.attributes,
-                  { type: 'html', tag: htmlTok.tag },
+                  { type: 'html', tag: htmlTagName },
                   sanitizeUrl
               )
             : undefined}
-        {#if SELF_CLOSING_HTML.has(htmlTok.tag)}
-            <svelte:element this={htmlTok.tag} {...sanitizedAttrs} />
+        {#if SELF_CLOSING_HTML.has(htmlTagName)}
+            <svelte:element this={htmlTagName} {...sanitizedAttrs} />
         {:else}
-            <svelte:element this={htmlTok.tag} {...sanitizedAttrs}>
+            <svelte:element this={htmlTagName} {...sanitizedAttrs}>
                 {#if htmlTok.tokens && htmlTok.tokens.length}
                     {#each htmlTok.tokens as childToken, i (renderMetadata.getStableNodeKey(childToken, i))}
                         {@render dispatch(childToken, restProps)}
@@ -460,8 +480,8 @@
         {/if}
     {:else if type === 'html'}
         {@const { tag, ...localRest } = sanitizedRest}
-        {@const htmlTag = sanitizedRest.tag as keyof typeof Html}
-        {@const htmlSnippet = htmlSnippetOverrides[htmlTag as string]}
+        {@const htmlTag = ((sanitizedRest.tag as string) ?? '').toLowerCase()}
+        {@const htmlSnippet = htmlSnippetsByLower[htmlTag]}
         {@const localRestForChildren = Object.fromEntries(
             Object.entries(localRest).filter(([key]) => key !== 'attributes')
         )}
@@ -471,24 +491,20 @@
                     {#each tokens as childToken, index (renderMetadata.getStableNodeKey(childToken, index))}
                         {@render dispatch(childToken, localRestForChildren)}
                     {/each}
-                {:else}
-                    <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
                 {/if}
             {/snippet}
             {@render htmlSnippet({
                 attributes: sanitizedRest.attributes,
                 children: htmlSnippetChildren
             })}
-        {:else if renderers.html && htmlTag in renderers.html}
-            {@const HtmlComponent = renderers.html[htmlTag as keyof typeof renderers.html]}
+        {:else if htmlTag in htmlRenderersByLower}
+            {@const HtmlComponent = htmlRenderersByLower[htmlTag]}
             {#if HtmlComponent}
                 <HtmlComponent {...sanitizedRest}>
                     {#if tokens && (tokens as Token[]).length}
                         {#each tokens as childToken, index (renderMetadata.getStableNodeKey(childToken, index))}
                             {@render dispatch(childToken, localRestForChildren)}
                         {/each}
-                    {:else}
-                        <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
                     {/if}
                 </HtmlComponent>
             {/if}

--- a/src/lib/SvelteMarkdown.issue-383.test.ts
+++ b/src/lib/SvelteMarkdown.issue-383.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression coverage for issue #383.
+ *
+ * Custom tags registered in `renderers.html` were dropped when written as
+ * `<widget />`, looked up with inconsistent casing between the inline pairing
+ * path and nested htmlparser2 path, and leaked the raw opening tag as visible
+ * text when the paired element had no children.
+ *
+ * https://github.com/humanspeak/svelte-markdown/issues/383
+ */
+
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/svelte'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import SvelteMarkdown from './SvelteMarkdown.svelte'
+import ClickRenderer from './test/snippets/ClickRenderer.svelte'
+import { tokenCache } from './utils/token-cache.js'
+
+beforeEach(() => {
+    tokenCache.clearAllTokens()
+})
+
+const renderWidget = async (source: string, htmlKey: 'widget' | 'Widget' = 'widget') => {
+    const { container } = render(SvelteMarkdown, {
+        props: {
+            source,
+            renderers: { html: { [htmlKey]: ClickRenderer } }
+        }
+    })
+    await vi.runAllTimersAsync()
+    return container
+}
+
+describe('issue #383 custom html tag dispatch', () => {
+    test('renders a self-closing custom tag registered in renderers.html', async () => {
+        const container = await renderWidget('A <widget />')
+        const widget = container.querySelector('[data-testid="custom-tag-component"]')
+        expect(widget).toBeInTheDocument()
+        expect(widget?.textContent).toBe('')
+        expect(container.textContent).not.toContain('<widget')
+    })
+
+    test('resolves PascalCase source against a lowercase renderer key', async () => {
+        const container = await renderWidget('A <Widget>x</Widget>', 'widget')
+        const widget = container.querySelector('[data-testid="custom-tag-component"]')
+        expect(widget).toBeInTheDocument()
+        expect(widget).toHaveTextContent('x')
+    })
+
+    test('resolves nested PascalCase source against a PascalCase renderer key', async () => {
+        const container = await renderWidget('<div><Widget>x</Widget></div>', 'Widget')
+        const widget = container.querySelector('[data-testid="custom-tag-component"]')
+        expect(widget).toBeInTheDocument()
+        expect(widget).toHaveTextContent('x')
+        expect(container.querySelector('div')).toBeInTheDocument()
+    })
+
+    test('does not leak the raw opening tag from an empty paired custom element', async () => {
+        const container = await renderWidget('A <widget></widget>')
+        const widget = container.querySelector('[data-testid="custom-tag-component"]')
+        expect(widget).toBeInTheDocument()
+        expect(widget?.textContent).toBe('')
+        expect(container.textContent).not.toContain('<widget')
+        expect(container.textContent).not.toContain('&lt;widget')
+    })
+
+    test('renders a nested self-closing custom tag without leaking raw source', async () => {
+        const container = await renderWidget('<div><widget /></div>')
+        const widget = container.querySelector('[data-testid="custom-tag-component"]')
+        expect(widget).toBeInTheDocument()
+        expect(widget?.textContent).toBe('')
+        expect(container.textContent).not.toContain('<widget')
+    })
+})

--- a/src/lib/utils/token-cleanup.test.ts
+++ b/src/lib/utils/token-cleanup.test.ts
@@ -61,6 +61,11 @@ describe('Token Cleanup Utilities', () => {
             })
         })
 
+        it('should lowercase tag names so pairing matches the nested htmlparser2 path', () => {
+            expect(isHtmlOpenTag('<Widget>')).toEqual({ tag: 'widget', isOpening: true })
+            expect(isHtmlOpenTag('</Widget>')).toEqual({ tag: 'widget', isOpening: false })
+        })
+
         it('should correctly identify closing HTML tags', () => {
             expect(isHtmlOpenTag('</div>')).toEqual({ tag: 'div', isOpening: false })
             expect(isHtmlOpenTag('</custom-element>')).toEqual({
@@ -509,6 +514,72 @@ describe('Token Cleanup Utilities', () => {
             const result = shrinkHtmlTokens(tokens)
             expect(result).toHaveLength(1)
             expect(result[0]).toMatchObject({ type: 'html', raw: '<br/>' })
+        })
+
+        // Issue #383: custom tags written as `<widget />` must get structured
+        // `.tag`/`.attributes` so Parser can dispatch `renderers.html`. The
+        // void-element allowlist only decides whether to rewrite `>` to `/>`.
+        it('attaches tag and attributes on self-closing custom tags', () => {
+            const tokens: Token[] = [
+                {
+                    type: 'html',
+                    raw: '<widget id="w" foo="bar" />',
+                    text: '<widget id="w" foo="bar" />'
+                }
+            ]
+
+            const result = shrinkHtmlTokens(tokens)
+            expect(result).toHaveLength(1)
+            expect(result[0]).toMatchObject({
+                type: 'html',
+                raw: '<widget id="w" foo="bar" />',
+                tag: 'widget',
+                attributes: { id: 'w', foo: 'bar' }
+            })
+        })
+
+        it('lowercases self-closing custom tag names', () => {
+            const result = shrinkHtmlTokens([
+                { type: 'html', raw: '<Widget />', text: '<Widget />' }
+            ])
+            expect(result[0]).toMatchObject({ type: 'html', tag: 'widget' })
+        })
+
+        it('pairs mixed-case custom tags onto a lowercase tag name', () => {
+            const tokens: Token[] = [
+                { type: 'html', raw: '<Widget>', text: '<Widget>' },
+                { type: 'text', raw: 'x', text: 'x' },
+                { type: 'html', raw: '</widget>', text: '</widget>' }
+            ]
+
+            const result = shrinkHtmlTokens(tokens)
+            expect(result).toHaveLength(1)
+            expect(result[0]).toMatchObject({
+                type: 'html',
+                tag: 'widget',
+                tokens: [{ type: 'text', raw: 'x', text: 'x' }]
+            })
+        })
+
+        it('uses the same lowercase tag for inline pairing and nested htmlparser2', () => {
+            const inline = shrinkHtmlTokens([
+                { type: 'html', raw: '<Widget>', text: '<Widget>' },
+                { type: 'text', raw: 'x', text: 'x' },
+                { type: 'html', raw: '</Widget>', text: '</Widget>' }
+            ])
+            const nested = shrinkHtmlTokens([
+                {
+                    type: 'html',
+                    raw: '<div><Widget>x</Widget></div>',
+                    text: '<div><Widget>x</Widget></div>'
+                }
+            ])
+
+            expect((inline[0] as Token & { tag: string }).tag).toBe('widget')
+            const inner = (
+                nested[0] as Token & { tokens: Array<Token & { tag?: string }> }
+            ).tokens.find((token) => token.tag === 'widget')
+            expect(inner).toBeDefined()
         })
 
         it('should escape quotes in attribute values when parsing HTML blocks', () => {

--- a/src/lib/utils/token-cleanup.ts
+++ b/src/lib/utils/token-cleanup.ts
@@ -39,7 +39,10 @@ const SELF_CLOSING_TAGS =
 export const isHtmlOpenTag = (raw: string): { tag: string; isOpening: boolean } | null => {
     const match = htmlTagRegex.exec(raw)
     if (!match) return null
-    return { tag: match[1], isOpening: !raw.startsWith('</') }
+    // HTML tag names are case-insensitive. Lowercasing here keeps the inline
+    // pairing path aligned with htmlparser2 (`xmlMode: false`), which already
+    // lowercases nested markup (issue #383).
+    return { tag: match[1].toLowerCase(), isOpening: !raw.startsWith('</') }
 }
 
 /**
@@ -53,15 +56,23 @@ const formatSelfClosingHtmlToken = (token: Token): Token => {
     // Extract tag name from raw HTML
     const tagMatch = token.raw.match(/<\/?([a-zA-Z][a-zA-Z0-9-]*)/i)
     if (!tagMatch) return token
+    // Closing tags are paired separately via `isHtmlOpenTag`; they must not
+    // pick up `.tag` or they would dispatch as a second component instance.
+    if (token.raw.startsWith('</')) return token
 
-    const tagName = tagMatch[1]
-    if (!SELF_CLOSING_TAGS.test(tagName)) return token
+    const tagName = tagMatch[1].toLowerCase()
+    const isVoid = SELF_CLOSING_TAGS.test(tagName)
+    const isSelfClosingForm = token.raw.endsWith('/>')
 
-    // Self-closing tags get `.tag` and `.attributes` set so downstream
-    // code (pairing, dispatch, sanitization) has structured access. If
-    // the source already used the `<.../>` form we keep raw as-is;
-    // otherwise we normalize the `>` to `/>`.
-    const formattedRaw = token.raw.endsWith('/>') ? token.raw : token.raw.replace(/\s*>$/, '/>')
+    // The void-element allowlist decides HTML self-closing *rewrites*
+    // (`<br>` → `<br/>`). Structured `.tag`/`.attributes` must still be
+    // attached for custom tags written as `<widget />`, otherwise Parser
+    // cannot dispatch `renderers.html` and the token is silently dropped
+    // (issue #383). Unclosed openings skip this so pairing/streaming can
+    // still distinguish `<widget>` from `<widget />`.
+    if (!isVoid && !isSelfClosingForm) return token
+
+    const formattedRaw = isVoid && !isSelfClosingForm ? token.raw.replace(/\s*>$/, '/>') : token.raw
     return {
         ...token,
         raw: formattedRaw,


### PR DESCRIPTION
Custom tags registered in `renderers.html` were silently dropped when written as self-closing (`<widget />`), looked up with different casing on the inline pairing path vs nested htmlparser2, and leaked the raw opening tag when the paired element had no children.

- Attach structured `.tag` / `.attributes` for self-closing custom tags. The void-element allowlist only decides whether to rewrite `<br>` to `<br/>`.
- Lowercase tag names on the pairing path so they match htmlparser2 (`xmlMode: false`).
- Resolve `renderers.html` and html snippets case-insensitively.
- Do not emit raw tag source as children of a resolved HTML renderer.

Fixes #383