### PR TITLE
refactor(html): canonicalize tag names and close remaining #383 gaps

### DIFF
--- a/.competitive-intel/config.json
+++ b/.competitive-intel/config.json
@@ -5,6 +5,7 @@
     "self_npm": "@humanspeak/svelte-markdown",
     "self_repo": "humanspeak/svelte-markdown",
 
+    "ahrefs_project_id": 8934907,
     "github_handle": "jaysin586",
     "repo_triage": {
         "enabled": true,

--- a/.competitive-intel/state.json
+++ b/.competitive-intel/state.json
@@ -1,17 +1,17 @@
 {
     "project": "@humanspeak/svelte-markdown",
-    "last_run": "2026-08-18",
+    "last_run": "2026-08-28",
     "run_type": "delta",
     "snapshot": {
-        "fetched_at": "2026-08-18T11:00:33Z",
+        "fetched_at": "2026-08-28T07:00:41Z",
         "project": "@humanspeak/svelte-markdown",
         "self": {
             "npm": "@humanspeak/svelte-markdown",
             "repo": "humanspeak/svelte-markdown",
-            "latest_version": "1.8.6",
-            "last_publish": "2026-08-10",
+            "latest_version": "1.8.8",
+            "last_publish": "2026-08-25",
             "first_publish": "2024-10-30",
-            "weekly_downloads": 28501,
+            "weekly_downloads": 29384,
             "peer_deps": {
                 "katex": ">=0.16.0",
                 "mermaid": ">=10.0.0",
@@ -20,11 +20,25 @@
             },
             "svelte_peer": "^5.0.0",
             "error": null,
-            "stars": 131,
+            "stars": 130,
             "archived": false,
-            "pushed_at": "2026-08-12",
-            "last_release": "2026-08-10",
+            "pushed_at": "2026-08-26",
+            "last_release": "2026-08-25",
             "recent_releases": [
+                {
+                    "version": "v1.8.8",
+                    "date": "2026-08-25",
+                    "notes": "Changes in this Release\nfix(streaming): code fence splitting and marked options pollution\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/381)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.8"
+                },
+                {
+                    "version": "v1.8.7",
+                    "date": "2026-08-18",
+                    "notes": "Changes in this Release\ndocs(blog): add Svelte markdown guides\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/380)",
+                    "notes_truncated": false,
+                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.8.7"
+                },
                 {
                     "version": "v1.8.6",
                     "date": "2026-08-10",
@@ -115,20 +129,6 @@
                     "notes": "Changes in this Release\nchore(lint): lint test files and enable type-aware promise rules\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/352)",
                     "notes_truncated": false,
                     "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.9"
-                },
-                {
-                    "version": "v1.7.8",
-                    "date": "2026-07-09",
-                    "notes": "Changes in this Release\nrefactor(cleanup): drop dead legacy HTML functions and bench module\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/351)",
-                    "notes_truncated": false,
-                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.8"
-                },
-                {
-                    "version": "v1.7.7",
-                    "date": "2026-07-09",
-                    "notes": "Changes in this Release\nfeat(streaming): add streamId prop to reset state between streams\n\nFor more details, see the [Pull Request](https://github.com/humanspeak/svelte-markdown/pull/350)",
-                    "notes_truncated": false,
-                    "url": "https://github.com/humanspeak/svelte-markdown/releases/tag/v1.7.7"
                 }
             ]
         },
@@ -140,7 +140,7 @@
                 "latest_version": "0.4.1",
                 "last_publish": "2023-12-25",
                 "first_publish": "2020-04-21",
-                "weekly_downloads": 41546,
+                "weekly_downloads": 46505,
                 "peer_deps": {
                     "svelte": "^4.0.0"
                 },
@@ -158,15 +158,15 @@
                 "latest_version": "5.0.2",
                 "last_publish": "2025-08-09",
                 "first_publish": "2022-04-09",
-                "weekly_downloads": 34876,
+                "weekly_downloads": 53904,
                 "peer_deps": {
                     "svelte": "^5.1.3"
                 },
                 "svelte_peer": "^5.1.3",
                 "error": null,
-                "stars": 353,
+                "stars": 354,
                 "archived": false,
-                "pushed_at": "2026-08-15",
+                "pushed_at": "2026-08-26",
                 "last_release": "2025-08-09",
                 "recent_releases": []
             }
@@ -178,7 +178,7 @@
                 "latest_version": "3.1.2",
                 "last_publish": "2026-07-01",
                 "first_publish": "2025-09-08",
-                "weekly_downloads": 23128,
+                "weekly_downloads": 32882,
                 "peer_deps": {
                     "svelte": "^5.0.0"
                 },
@@ -218,7 +218,7 @@
                 "latest_version": "0.6.2",
                 "last_publish": "2026-08-07",
                 "first_publish": "2026-03-23",
-                "weekly_downloads": 2344,
+                "weekly_downloads": 3958,
                 "peer_deps": {
                     "beautiful-mermaid": "^1.1.3",
                     "katex": "^0.17.0",
@@ -253,37 +253,57 @@
             "held_by": "@comark/svelte",
             "why": "beautiful-mermaid shipped in-box",
             "worth_doing": "low \u2014 we already ship a mermaid extension"
+        },
+        {
+            "gap": "D2 diagrams, infographics, stream-diffs code blocks",
+            "held_by": "markstream-svelte",
+            "why": "rich-content surface beyond our KaTeX/Mermaid/Shiki set",
+            "worth_doing": "low \u2014 presentation-layer breadth; same watch-not-build logic as svelte-streamdown",
+            "first_seen": "2026-08-28"
         }
     ],
     "compare_validation": {
         "svelte-streamdown": {
             "validated_against_version": "3.1.2",
-            "validated_on": "2026-08-18"
+            "validated_on": "2026-08-28",
+            "benchmark_measured_against": "3.1.2",
+            "benchmark_valid": true
         },
         "svelte-exmarkdown": {
             "validated_against_version": "5.0.2",
-            "validated_on": "2026-08-18"
+            "validated_on": "2026-08-28"
+        },
+        "svelte-markdown": {
+            "validated_against_version": "0.4.1",
+            "validated_on": "2026-08-28"
         }
     },
     "watch_candidates": [
         {
             "npm": "markstream-svelte",
             "first_seen": "2026-08-11",
-            "note": "Svelte binding of cross-framework Markstream renderer; 0.0.7 (2026-08-14) @ 327 wkly DL \u2014 still shipping but traction flat week over week. Promote only if downloads start climbing."
+            "status": "promoted-to-active-watch 2026-08-28",
+            "note": "Svelte binding of cross-framework Markstream (Simon-He95/markstream-vue, shared markstream-core). 0.0.7 -> 2.0.6 between 2026-08-18 and 2026-08-28 (8 publishes), wkly DL 327 -> 704 (+115%). Targets our exact niche: LLM token streams, SSE/WebSocket, incomplete markdown, plus Mermaid/KaTeX/D2/infographics/stream-diffs. peer svelte >=5 <6. Keywords deliberately include svelte-markdown/svelte-markdown-renderer. Still ~40x smaller by downloads; API churny post-2.0. Consider moving into config.watchlist if momentum holds.",
+            "latest_version": "2.0.6",
+            "weekly_downloads": 704,
+            "checked_on": "2026-08-28"
         },
         {
             "npm": "@markdown-ui/svelte",
             "first_seen": "2026-08-18",
-            "note": "Surfaced in discovery; 0.4.0 last published 2026-01-12, ~30 wkly DL. Too small/stale to track \u2014 recorded to avoid re-surfacing it each week."
+            "note": "Still parked. 0.4.0 (2026-01-12), 7 wkly DL. Too small/stale to track \u2014 recorded to avoid re-surfacing.",
+            "latest_version": "0.4.0",
+            "weekly_downloads": 7,
+            "checked_on": "2026-08-28"
         }
     ],
     "seo": {
-        "export_date": "2026-08-18",
+        "export_date": "2026-08-22",
         "striking_distance": [
             {
                 "query": "svelte markdown",
-                "impressions": 272.0,
-                "position": 11.03
+                "impressions": 296.0,
+                "position": 11.38
             },
             {
                 "query": "\"milkdown\" \"javascript:\" xss",
@@ -292,48 +312,48 @@
             },
             {
                 "query": "tiptap markdown",
-                "impressions": 212.0,
-                "position": 19.46
+                "impressions": 225.0,
+                "position": 19.47
             },
             {
                 "query": "tiptap svelte",
-                "impressions": 197.0,
-                "position": 17.46
+                "impressions": 215.0,
+                "position": 17.26
             },
             {
                 "query": "@humanspeak/svelte-markdown",
-                "impressions": 98.0,
+                "impressions": 99.0,
                 "position": 4.71
             },
             {
                 "query": "svelte markdown renderer",
-                "impressions": 85.0,
-                "position": 5.74
+                "impressions": 90.0,
+                "position": 5.73
             },
             {
                 "query": "svelte-markdown",
-                "impressions": 62.0,
-                "position": 9.39
+                "impressions": 64.0,
+                "position": 9.28
             },
             {
                 "query": "svelte-exmarkdown",
-                "impressions": 51.0,
-                "position": 10.86
+                "impressions": 58.0,
+                "position": 13.28
             },
             {
                 "query": "svelte marked",
-                "impressions": 42.0,
-                "position": 8.88
+                "impressions": 45.0,
+                "position": 8.69
             },
             {
                 "query": "svelte markdown editor",
-                "impressions": 37.0,
-                "position": 11.08
+                "impressions": 42.0,
+                "position": 10.93
             },
             {
                 "query": "markdown playground",
-                "impressions": 35.0,
-                "position": 12.51
+                "impressions": 41.0,
+                "position": 12.07
             },
             {
                 "query": "svelte render markdown",
@@ -342,18 +362,18 @@
             },
             {
                 "query": "svelte tiptap",
-                "impressions": 30.0,
-                "position": 17.7
+                "impressions": 34.0,
+                "position": 17.44
             },
             {
                 "query": "markdown svelte",
-                "impressions": 29.0,
-                "position": 6.72
+                "impressions": 31.0,
+                "position": 6.71
             },
             {
                 "query": "svelte custom renderer",
-                "impressions": 26.0,
-                "position": 7.5
+                "impressions": 30.0,
+                "position": 7.4
             },
             {
                 "query": "\"alerttriangle\" \"lucide-svelte\"",
@@ -377,40 +397,58 @@
             },
             {
                 "query": "marked svelte",
-                "impressions": 20.0,
-                "position": 13.7
+                "impressions": 21.0,
+                "position": 13.38
             }
         ],
         "underperforming_pages": [
             {
                 "page": "https://markdown.svelte.page/compare/vs-milkdown",
-                "impressions": 797.0,
-                "position": 9.87,
-                "ctr": 0.63
+                "impressions": 824.0,
+                "position": 9.86,
+                "ctr": 0.61
             },
             {
                 "page": "https://markdown.svelte.page/compare/vs-tiptap",
-                "impressions": 639.0,
-                "position": 18.19,
-                "ctr": 0.16
+                "impressions": 690.0,
+                "position": 18.09,
+                "ctr": 0.14
             },
             {
                 "page": "https://markdown.svelte.page/compare/vs-bytemd",
-                "impressions": 375.0,
-                "position": 9.56,
-                "ctr": 0.27
+                "impressions": 386.0,
+                "position": 9.53,
+                "ctr": 0.26
             },
             {
                 "page": "https://markdown.svelte.page/compare/vs-carta",
-                "impressions": 359.0,
-                "position": 10.99,
-                "ctr": 0.84
+                "impressions": 370.0,
+                "position": 11.0,
+                "ctr": 0.81
             },
             {
                 "page": "https://markdown.svelte.page/docs/getting-started",
-                "impressions": 255.0,
-                "position": 13.91,
-                "ctr": 1.96
+                "impressions": 290.0,
+                "position": 16.91,
+                "ctr": 1.72
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-marked",
+                "impressions": 250.0,
+                "position": 14.1,
+                "ctr": 0.8
+            },
+            {
+                "page": "https://markdown.svelte.page/docs/advanced/syntax-highlighting",
+                "impressions": 248.0,
+                "position": 23.92,
+                "ctr": 0.81
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-mdsvex",
+                "impressions": 241.0,
+                "position": 14.51,
+                "ctr": 0.41
             },
             {
                 "page": "https://markdown.svelte.page/docs/advanced/marked-extensions",
@@ -419,57 +457,39 @@
                 "ctr": 0.84
             },
             {
-                "page": "https://markdown.svelte.page/compare/vs-mdsvex",
-                "impressions": 233.0,
-                "position": 14.3,
-                "ctr": 0.43
-            },
-            {
-                "page": "https://markdown.svelte.page/compare/vs-marked",
-                "impressions": 231.0,
-                "position": 14.66,
-                "ctr": 0.87
-            },
-            {
-                "page": "https://markdown.svelte.page/docs/advanced/syntax-highlighting",
-                "impressions": 222.0,
-                "position": 22.73,
-                "ctr": 0.9
-            },
-            {
                 "page": "https://markdown.svelte.page/compare",
-                "impressions": 163.0,
-                "position": 14.67,
-                "ctr": 0.61
+                "impressions": 169.0,
+                "position": 15.72,
+                "ctr": 0.59
             },
             {
                 "page": "https://markdown.svelte.page/docs/api/svelte-markdown",
-                "impressions": 142.0,
-                "position": 27.06,
-                "ctr": 1.41
-            },
-            {
-                "page": "https://markdown.svelte.page/compare/vs-unified-remark",
-                "impressions": 120.0,
-                "position": 17.39,
-                "ctr": 0.0
+                "impressions": 155.0,
+                "position": 29.05,
+                "ctr": 1.29
             },
             {
                 "page": "https://markdown.svelte.page/examples",
-                "impressions": 119.0,
-                "position": 15.23,
+                "impressions": 127.0,
+                "position": 18.29,
                 "ctr": 0.0
             },
             {
                 "page": "https://markdown.svelte.page/examples/github-alerts",
-                "impressions": 115.0,
-                "position": 23.84,
+                "impressions": 122.0,
+                "position": 23.34,
+                "ctr": 0.0
+            },
+            {
+                "page": "https://markdown.svelte.page/compare/vs-unified-remark",
+                "impressions": 121.0,
+                "position": 17.32,
                 "ctr": 0.0
             },
             {
                 "page": "https://markdown.svelte.page/examples/llm-streaming",
-                "impressions": 110.0,
-                "position": 24.09,
+                "impressions": 111.0,
+                "position": 24.05,
                 "ctr": 0.0
             }
         ],
@@ -479,7 +499,14 @@
             "dedicated hub page for 'svelte markdown' head term (pos 11 via homepage)",
             "dedicated 'marked in Svelte' page (rank pos 8-13 with no target URL)",
             "fix structured-data validation errors on 11 pages",
-            "wire up IndexNow (38 eligible pages)"
+            "wire up IndexNow (38 eligible pages)",
+            "seed Ahrefs rank tracker from GSC queries (only 1 keyword tracked, 0 ranked)"
         ]
+    },
+    "rank_tracker": {
+        "checked_on": "2026-08-28",
+        "tracked": 1,
+        "ranked": 0,
+        "note": "Project 8934907 has a single keyword ('svelte markdown', vol 20, KD 12); position null on 2026-08-28 vs 11 on 2026-08-21. GSC shows avg pos 11.4, so likely a tracker data gap rather than a real drop."
     }
 }

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,7 +14,7 @@ runtimes:
     enabled:
         - go@1.21.0
         - python@3.14.4
-        - node@22.16.0
+        - node@24.15.0
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
     disabled:

--- a/README.md
+++ b/README.md
@@ -388,6 +388,23 @@ You can render arbitrary (non-standard) HTML tags like `<click>`, `<tooltip>`, o
 
 Both approaches work for any tag name. Snippet overrides take precedence over component renderers when both are provided.
 
+**Self-closing and empty tags** are supported alongside the paired form, and render your component with no children:
+
+```svelte
+<SvelteMarkdown source={'<click />'} renderers={{ html: { click: ClickButton } }} />
+```
+
+**Tag names are case-insensitive**, as they are in HTML. Tags are normalized to lowercase when parsed, and renderer keys and `html_*` snippet names are normalized the same way, so `<Tooltip>`, `<TOOLTIP>` and `<tooltip>` all reach the same renderer however they are registered — and identically whether the tag stands alone or is nested inside other HTML.
+
+One consequence worth knowing: a tag has exactly one entry, so registering the same tag under two casings is a duplicate rather than two renderers, and the last one wins. An entry you provide always takes precedence over the built-in renderer — including `null`, which blocks the tag entirely:
+
+```svelte
+<!-- blocks <iframe>, <IFRAME> and <IFrame> alike -->
+<SvelteMarkdown {source} renderers={{ html: { IFRAME: null } }} />
+```
+
+The `tag` passed to custom renderers and to the `sanitizeUrl` / `sanitizeAttributes` hooks is always lowercase, so `context.tag === 'iframe'` is reliable.
+
 ## Marked Extensions
 
 Use [marked extensions](https://marked.js.org/using_advanced#extensions) via the `extensions` prop. SvelteMarkdown ships first-class extensions for KaTeX, Mermaid, GitHub-style alerts, and footnotes from the `@humanspeak/svelte-markdown/extensions` subpath — no third-party packages required. Third-party extensions still work too; the component handles registering tokenizers internally and you just provide renderers for the custom token types.

--- a/src/lib/Parser.svelte
+++ b/src/lib/Parser.svelte
@@ -1,26 +1,6 @@
 <script module lang="ts">
-    /**
-     * Self-closing HTML tags that must not receive children — `<br>content</br>`
-     * is invalid and `<svelte:element>` would emit it anyway. Module-scoped so
-     * the Set is allocated once per module load, not once per Parser instance.
-     */
-    const SELF_CLOSING_HTML = new Set([
-        'br',
-        'hr',
-        'img',
-        'input',
-        'link',
-        'meta',
-        'area',
-        'base',
-        'col',
-        'embed',
-        'keygen',
-        'param',
-        'source',
-        'track',
-        'wbr'
-    ])
+    import Html from '$lib/renderers/html/index.js'
+    import { isVoidElement } from '$lib/utils/void-elements.js'
 
     /**
      * Shared empty prop bag spread into non-heading dispatch. Hoisted so the
@@ -28,22 +8,6 @@
      * allocating a fresh `{}` per dispatched token.
      */
     const NO_EXTRA_PROPS = Object.freeze({})
-
-    /**
-     * HTML tag names are case-insensitive. Copy a renderer/snippet map with
-     * lowercase aliases so `widget` and `Widget` resolve the same way on both
-     * the inline pairing path and the nested htmlparser2 path (issue #383).
-     * Exact-case keys already present are left in place and win.
-     */
-    const withLowercaseHtmlKeys = <T,>(src: Record<string, T> | undefined): Record<string, T> => {
-        if (!src) return {}
-        const out: Record<string, T> = { ...src }
-        for (const key of Object.keys(src)) {
-            const lower = key.toLowerCase()
-            if (!(lower in out)) out[lower] = src[key]
-        }
-        return out
-    }
 </script>
 
 <script lang="ts">
@@ -96,7 +60,6 @@
 
     import { getContext, hasContext, setContext } from 'svelte'
     import Parser from '$lib/Parser.svelte'
-    import Html from '$lib/renderers/html/index.js'
     import type { AnySnippet } from '$lib/utils/component-props.js'
     import {
         defaultRenderers,
@@ -205,9 +168,6 @@
         !(renderers as Record<string, unknown>).space && !snippetOverrides.space
     )
 
-    const htmlRenderersByLower = $derived(withLowercaseHtmlKeys(renderers.html))
-    const htmlSnippetsByLower = $derived(withLowercaseHtmlKeys(htmlSnippetOverrides))
-
     // Sanitize rest props before they reach any renderer or snippet.
     // This is the single enforcement point — custom renderers cannot bypass it.
     const sanitizedRest = $derived.by(() => {
@@ -237,30 +197,29 @@
         attributes?: Record<string, string>
         tokens?: Token[]
     }}
-    {@const htmlTagName = htmlTok.tag?.toLowerCase()}
     {@const inlineHtmlOk =
         token.type === 'html' &&
-        !!htmlTagName &&
+        !!htmlTok.tag &&
         !!renderers.html &&
-        htmlTagName in Html &&
-        htmlRenderersByLower[htmlTagName] === Html[htmlTagName] &&
-        !htmlSnippetsByLower[htmlTagName]}
+        htmlTok.tag in Html &&
+        renderers.html[htmlTok.tag] === Html[htmlTok.tag] &&
+        !htmlSnippetOverrides[htmlTok.tag]}
     {#if token.type === 'space' && inlineSpaceOk}
         <!-- inlined: space tokens render nothing -->
     {:else if token.type === 'text' && inlineTextOk && !(token as Tokens.Text).tokens}
         {(token as Tokens.Text).text ?? token.raw}
-    {:else if inlineHtmlOk && htmlTagName}
+    {:else if inlineHtmlOk && htmlTok.tag}
         {@const sanitizedAttrs = htmlTok.attributes
             ? sanitizeAttributes(
                   htmlTok.attributes,
-                  { type: 'html', tag: htmlTagName },
+                  { type: 'html', tag: htmlTok.tag },
                   sanitizeUrl
               )
             : undefined}
-        {#if SELF_CLOSING_HTML.has(htmlTagName)}
-            <svelte:element this={htmlTagName} {...sanitizedAttrs} />
+        {#if isVoidElement(htmlTok.tag)}
+            <svelte:element this={htmlTok.tag} {...sanitizedAttrs} />
         {:else}
-            <svelte:element this={htmlTagName} {...sanitizedAttrs}>
+            <svelte:element this={htmlTok.tag} {...sanitizedAttrs}>
                 {#if htmlTok.tokens && htmlTok.tokens.length}
                     {#each htmlTok.tokens as childToken, i (renderMetadata.getStableNodeKey(childToken, i))}
                         {@render dispatch(childToken, restProps)}
@@ -480,32 +439,30 @@
         {/if}
     {:else if type === 'html'}
         {@const { tag, ...localRest } = sanitizedRest}
-        {@const htmlTag = ((sanitizedRest.tag as string) ?? '').toLowerCase()}
-        {@const htmlSnippet = htmlSnippetsByLower[htmlTag]}
+        {@const htmlTag = sanitizedRest.tag as string}
+        {@const htmlSnippet = htmlSnippetOverrides[htmlTag]}
         {@const localRestForChildren = Object.fromEntries(
             Object.entries(localRest).filter(([key]) => key !== 'attributes')
         )}
+        {#snippet htmlChildren()}
+            {#if tokens && (tokens as Token[]).length}
+                {#each tokens as childToken, index (renderMetadata.getStableNodeKey(childToken, index))}
+                    {@render dispatch(childToken, localRestForChildren)}
+                {/each}
+            {:else if !tokens}
+                <renderers.rawtext text={sanitizedRest.raw} {...sanitizedRest} />
+            {/if}
+        {/snippet}
         {#if htmlSnippet}
-            {#snippet htmlSnippetChildren()}
-                {#if tokens && (tokens as Token[]).length}
-                    {#each tokens as childToken, index (renderMetadata.getStableNodeKey(childToken, index))}
-                        {@render dispatch(childToken, localRestForChildren)}
-                    {/each}
-                {/if}
-            {/snippet}
             {@render htmlSnippet({
                 attributes: sanitizedRest.attributes,
-                children: htmlSnippetChildren
+                children: htmlChildren
             })}
-        {:else if htmlTag in htmlRenderersByLower}
-            {@const HtmlComponent = htmlRenderersByLower[htmlTag]}
+        {:else if renderers.html && Object.hasOwn(renderers.html, htmlTag)}
+            {@const HtmlComponent = renderers.html[htmlTag]}
             {#if HtmlComponent}
                 <HtmlComponent {...sanitizedRest}>
-                    {#if tokens && (tokens as Token[]).length}
-                        {#each tokens as childToken, index (renderMetadata.getStableNodeKey(childToken, index))}
-                            {@render dispatch(childToken, localRestForChildren)}
-                        {/each}
-                    {/if}
+                    {@render htmlChildren()}
                 </HtmlComponent>
             {/if}
         {:else}

--- a/src/lib/SvelteMarkdown.issue-383.test.ts
+++ b/src/lib/SvelteMarkdown.issue-383.test.ts
@@ -72,3 +72,249 @@ describe('issue #383 custom html tag dispatch', () => {
         expect(container.textContent).not.toContain('<widget')
     })
 })
+
+// --- Additional coverage (follow-up to the cases above) ---------------------
+
+import type { HtmlRenderers } from './renderers/html/index.js'
+import SnippetCasing from './test/issues/issue-383/SnippetCasing.svelte'
+import UppercaseSnippet from './test/issues/issue-383/UppercaseSnippet.svelte'
+import Widget from './test/issues/issue-383/Widget.svelte'
+
+/** Svelte's comment anchors are noise in markup assertions. */
+const stripAnchors = (html: string) => html.replace(/<!--.*?-->/g, '')
+
+const renderMarkdown = (source: string, html: HtmlRenderers) => {
+    const { container } = render(SvelteMarkdown, { props: { source, renderers: { html } } })
+    return stripAnchors(container.innerHTML)
+}
+
+describe('issue #383 — custom HTML tag renderers', () => {
+    describe('self-closing custom tags', () => {
+        test('renders the registered component instead of being dropped', () => {
+            const output = renderMarkdown('A <widget label="x" />', { widget: Widget })
+            expect(output).toContain('data-testid="widget"')
+            expect(output).toContain('data-label="x"')
+            expect(output).not.toContain('&lt;widget')
+        })
+
+        test('resolves identically when nested inside other HTML', () => {
+            // The nested path goes through htmlparser2, which reports a
+            // self-closed tag's close as *implied*. That previously left
+            // `tokens` undefined and echoed the raw source as text.
+            const output = renderMarkdown('<div><widget label="x" /></div>', { widget: Widget })
+            expect(output).toContain('data-testid="widget"')
+            expect(output).not.toContain('&lt;widget')
+        })
+
+        test('still renders void elements through their default renderers', () => {
+            const { container } = render(SvelteMarkdown, { props: { source: 'A <br/> B' } })
+            expect(container.querySelector('br')).not.toBeNull()
+        })
+    })
+
+    describe('empty paired custom tags', () => {
+        test('renders the component with no children rather than the raw tag', () => {
+            const output = renderMarkdown('A <widget label="y"></widget>', { widget: Widget })
+            expect(output).toContain('data-label="y"')
+            expect(output).not.toContain('&lt;widget')
+        })
+    })
+
+    describe('tag-name casing', () => {
+        test.each([
+            ['lowercase tag, lowercase key', 'A <widget>x</widget>', 'widget'],
+            ['capitalized tag, capitalized key', 'A <Widget>x</Widget>', 'Widget'],
+            ['capitalized tag, lowercase key', 'A <Widget>x</Widget>', 'widget'],
+            ['lowercase tag, capitalized key', 'A <widget>x</widget>', 'Widget']
+        ])('resolves inline: %s', (_label, source, key) => {
+            const output = renderMarkdown(source, { [key]: Widget })
+            expect(output).toContain('data-testid="widget"')
+            expect(output).toContain('x')
+        })
+
+        test.each([
+            ['capitalized tag, capitalized key', '<div><Widget>x</Widget></div>', 'Widget'],
+            ['capitalized tag, lowercase key', '<div><Widget>x</Widget></div>', 'widget']
+        ])('resolves when nested: %s', (_label, source, key) => {
+            const output = renderMarkdown(source, { [key]: Widget })
+            expect(output).toContain('data-testid="widget"')
+        })
+
+        test('a null under any casing blocks the tag, even alongside a component', () => {
+            // Registration keys are canonical, so `{ Widget, widget: null }` is
+            // one tag registered twice; the later entry wins. Previously the
+            // lookup preferred exact case while the merge preferred the null,
+            // so the two layers disagreed about the same input.
+            const output = renderMarkdown('A <Widget>x</Widget>', {
+                Widget,
+                widget: null
+            })
+            expect(output).not.toContain('data-testid="widget"')
+        })
+    })
+
+    describe('regressions', () => {
+        test('unregistered tags stay dropped rather than leaking raw source', () => {
+            const output = renderMarkdown('A <notatag>x</notatag>', { widget: Widget })
+            expect(output).not.toContain('notatag')
+            expect(output).toContain('x')
+        })
+
+        test('empty paired custom tags resolve when nested too', () => {
+            const output = renderMarkdown('<div><widget label="y"></widget></div>', {
+                widget: Widget
+            })
+            expect(output).toContain('data-label="y"')
+            expect(output).not.toContain('&lt;widget')
+        })
+
+        test('default HTML renderers are unaffected', () => {
+            const { container } = render(SvelteMarkdown, {
+                props: { source: 'A <span>inner</span> B' }
+            })
+            expect(container.querySelector('span')?.textContent).toBe('inner')
+        })
+    })
+})
+
+describe('issue #383 — snippet overrides resolve by tag, not by casing', () => {
+    const renderSnippet = (source: string) => {
+        const { container } = render(SnippetCasing, { props: { source } })
+        return stripAnchors(container.innerHTML)
+    }
+
+    test.each([
+        ['lowercase tag', 'A <div>x</div>'],
+        ['uppercase tag', 'A <DIV>x</DIV>'],
+        ['uppercase tag, nested', '<p><DIV>x</DIV></p>']
+    ])('html_div snippet wins for %s', (_label, source) => {
+        // Before the fix an uppercase tag skipped the snippet and silently
+        // fell through to the default <div> renderer, so the same tag got a
+        // different renderer depending on casing and nesting depth.
+        expect(renderSnippet(source)).toContain('data-snippet="div"')
+    })
+})
+
+describe('adversarial review regressions', () => {
+    describe('self-closing child sharing its parent tag name', () => {
+        test('does not prematurely close the parent (custom tags)', () => {
+            // htmlparser2 emits an *implied* close for `<widget/>`. If that
+            // close is allowed to match the open stack it pops the PARENT,
+            // orphaning the remaining children.
+            // Wrapped in a block element so marked emits one html block and the
+            // nested htmlparser2 path handles it — the inline form is paired by
+            // a different code path and does not exercise this.
+            const output = renderMarkdown(
+                '<div><widget label="outer"><widget/>after</widget></div>',
+                { widget: Widget }
+            )
+            const outer = document.createElement('div')
+            outer.innerHTML = output
+            const parent = outer.querySelector('[data-label="outer"]')
+            expect(parent).not.toBeNull()
+            expect(parent?.querySelector('[data-testid="widget"]')).not.toBeNull()
+            expect(parent?.textContent).toContain('after')
+        })
+
+        test('does not prematurely close the parent (default HTML)', () => {
+            const { container } = render(SvelteMarkdown, {
+                props: { source: '<div id="outer"><div/>after</div>' }
+            })
+            const parent = container.querySelector('#outer')
+            expect(parent).not.toBeNull()
+            expect(parent?.textContent).toContain('after')
+            expect(parent?.querySelector('div')).not.toBeNull()
+        })
+    })
+
+    describe('caller renderer entries win over defaults case-insensitively', () => {
+        test('an uppercase null blocks the lowercase default tag', () => {
+            const { container } = render(SvelteMarkdown, {
+                props: {
+                    source: '<iframe src="https://example.com"></iframe>',
+                    renderers: { html: { IFRAME: null } }
+                }
+            })
+            expect(container.querySelector('iframe')).toBeNull()
+        })
+
+        test('a lowercase null still blocks (regression guard)', () => {
+            const { container } = render(SvelteMarkdown, {
+                props: {
+                    source: '<iframe src="https://example.com"></iframe>',
+                    renderers: { html: { iframe: null } }
+                }
+            })
+            expect(container.querySelector('iframe')).toBeNull()
+        })
+
+        test('an uppercase component override replaces the default tag', () => {
+            const output = renderMarkdown('<span>x</span>', { SPAN: Widget })
+            expect(output).toContain('data-testid="widget"')
+        })
+    })
+
+    describe('mixed-case open and close tags pair on the flat path', () => {
+        test.each([['<Widget>x</widget>'], ['<widget>x</WIDGET>'], ['<WIDGET>x</Widget>']])(
+            'pairs %s',
+            (source) => {
+                const output = renderMarkdown(`A ${source}`, { widget: Widget })
+                expect(output).toContain('data-testid="widget"')
+                expect(output).toContain('x')
+            }
+        )
+    })
+})
+
+describe('unquoted attribute values ending in a slash', () => {
+    // HTML only treats `/` as self-closing from before-attribute-name or after
+    // a quoted value. Inside an unquoted value (`href=https://x/`) it is a
+    // literal character, and the tag is a normal opening tag.
+    test.each([
+        ['<div><a href=https://example.com/>Link</a></div>', 'Link'],
+        ['<div><a href=/foo/>x</a></div>', 'x'],
+        ['<div><a href=https://example.com/ >Link</a></div>', 'Link'],
+        // Inline/flat path: these are paired by `pairFlatHtmlTokens` rather
+        // than htmlparser2, and it applied the same misreading independently.
+        ['<a href=/foo/>x</a>', 'x'],
+        ['<a href=https://example.com/>Link</a>', 'Link']
+    ])('%s keeps its children', (source, expected) => {
+        const { container } = render(SvelteMarkdown, { props: { source } })
+        const anchor = container.querySelector('a')
+        expect(anchor).not.toBeNull()
+        expect(anchor?.textContent).toContain(expected)
+    })
+
+    test('a genuinely self-closed tag with a quoted value is still self-closing', () => {
+        const output = renderMarkdown('<div><widget label="a/b" /></div>', { widget: Widget })
+        expect(output).toContain('data-label="a/b"')
+        expect(output).not.toContain('&lt;widget')
+    })
+})
+
+describe('tag names are canonical regardless of which token path produced them', () => {
+    test('token tag is lowercased on both the flat and nested paths', () => {
+        const seen: string[] = []
+        const capture = (attributes: Record<string, string>, context: { tag: string }) => {
+            seen.push(context.tag)
+            return attributes
+        }
+        render(SvelteMarkdown, {
+            props: { source: '<IMG SRC="/a.png">', sanitizeAttributes: capture }
+        })
+        render(SvelteMarkdown, {
+            props: { source: '<div><IMG SRC="/a.png"></div>', sanitizeAttributes: capture }
+        })
+        // SanitizeContext.tag is documented as lowercase; a custom sanitizer
+        // keyed on `ctx.tag === 'img'` must fire for both spellings.
+        expect(seen.filter((tag) => tag === 'img').length).toBeGreaterThanOrEqual(2)
+        expect(seen).not.toContain('IMG')
+    })
+
+    test('an uppercase snippet override prop matches a lowercase tag', () => {
+        // The inline fast path short-circuited with an exact-case lookup, so
+        // `html_DIV` was silently ignored for `<div>`.
+        const { container } = render(UppercaseSnippet)
+        expect(container.querySelector('[data-snippet="upper"]')).not.toBeNull()
+    })
+})

--- a/src/lib/test/issues/issue-383/SnippetCasing.svelte
+++ b/src/lib/test/issues/issue-383/SnippetCasing.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
+
+    const { source }: { source: string } = $props()
+</script>
+
+<SvelteMarkdown {source}>
+    {#snippet html_div({ children }: { children?: import('svelte').Snippet })}
+        <section data-snippet="div">{@render children?.()}</section>
+    {/snippet}
+</SvelteMarkdown>

--- a/src/lib/test/issues/issue-383/UppercaseSnippet.svelte
+++ b/src/lib/test/issues/issue-383/UppercaseSnippet.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    import SvelteMarkdown from '$lib/SvelteMarkdown.svelte'
+</script>
+
+<SvelteMarkdown source="A <div>x</div>">
+    {#snippet html_DIV({ children }: { children?: import('svelte').Snippet })}
+        <section data-snippet="upper">{@render children?.()}</section>
+    {/snippet}
+</SvelteMarkdown>

--- a/src/lib/test/issues/issue-383/Widget.svelte
+++ b/src/lib/test/issues/issue-383/Widget.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import type { HtmlSnippetProps } from '$lib/types.js'
+
+    const { attributes = {}, children }: HtmlSnippetProps = $props()
+</script>
+
+<span data-testid="widget" data-label={attributes.label}>{@render children?.()}</span>

--- a/src/lib/utils/component-props.ts
+++ b/src/lib/utils/component-props.ts
@@ -7,6 +7,24 @@ export type AnySnippet = Snippet<[Record<string, unknown>]>
 type RestProps = Record<string, unknown>
 
 /**
+ * Merges caller HTML tag renderers over the built-in map.
+ *
+ * Keys are canonicalized to lowercase to match the tag names emitted by the
+ * parser, so one tag has exactly one entry. Without this, `{ IFRAME: null }`
+ * would sit alongside the lowercase `iframe` default and the tag would render
+ * anyway, silently ignoring an explicit block.
+ *
+ * @param overrides Caller-supplied HTML renderers, in any casing.
+ * @returns Defaults with caller entries taking precedence, keyed by lowercase tag.
+ */
+const mergeHtmlRenderers = (overrides: NonNullable<typeof defaultRenderers.html>) => ({
+    ...defaultRenderers.html,
+    ...(Object.fromEntries(
+        Object.entries(overrides).map(([key, value]) => [key.toLowerCase(), value])
+    ) as typeof defaultRenderers.html)
+})
+
+/**
  * Merges caller renderer overrides with the built-in renderer map.
  *
  * @param renderers Partial renderer overrides from component props.
@@ -15,12 +33,7 @@ type RestProps = Record<string, unknown>
 export const buildCombinedRenderers = (renderers: Partial<typeof defaultRenderers>) => ({
     ...defaultRenderers,
     ...renderers,
-    html: renderers.html
-        ? {
-              ...defaultRenderers.html,
-              ...renderers.html
-          }
-        : defaultRenderers.html
+    html: renderers.html ? mergeHtmlRenderers(renderers.html) : defaultRenderers.html
 })
 
 /**
@@ -58,7 +71,9 @@ export const getHtmlSnippetOverrides = (rest: RestProps) =>
     Object.fromEntries(
         Object.entries(rest)
             .filter(([key, val]) => key.startsWith('html_') && val != null)
-            .map(([key, val]) => [key.slice(5), val])
+            // Lowercase to match canonical tag names emitted by the parser,
+            // so `html_DIV` and `html_div` both match a `<div>` token.
+            .map(([key, val]) => [key.slice(5).toLowerCase(), val])
     ) as Record<string, AnySnippet>
 
 /**

--- a/src/lib/utils/token-cleanup.ts
+++ b/src/lib/utils/token-cleanup.ts
@@ -1,5 +1,6 @@
 import * as htmlparser2 from 'htmlparser2'
 import type { Token, Tokens } from 'marked'
+import { isVoidElement } from './void-elements.js'
 
 /**
  * Matches HTML tags with comprehensive coverage of edge cases.
@@ -18,8 +19,6 @@ const htmlTagRegex = /<\/?([a-zA-Z][a-zA-Z0-9-]{0,})(?:\s+[^>]*)?>/
  * Regex pattern for self-closing HTML tags.
  * @const {RegExp}
  */
-const SELF_CLOSING_TAGS =
-    /^(br|hr|img|input|link|meta|area|base|col|embed|keygen|param|source|track|wbr)$/i
 
 /**
  * Analyzes a string to determine if it contains an HTML tag and its characteristics.
@@ -39,9 +38,7 @@ const SELF_CLOSING_TAGS =
 export const isHtmlOpenTag = (raw: string): { tag: string; isOpening: boolean } | null => {
     const match = htmlTagRegex.exec(raw)
     if (!match) return null
-    // HTML tag names are case-insensitive. Lowercasing here keeps the inline
-    // pairing path aligned with htmlparser2 (`xmlMode: false`), which already
-    // lowercases nested markup (issue #383).
+    // Canonical lowercase — see the note in `formatSelfClosingHtmlToken`.
     return { tag: match[1].toLowerCase(), isOpening: !raw.startsWith('</') }
 }
 
@@ -52,6 +49,27 @@ export const isHtmlOpenTag = (raw: string): { tag: string; isOpening: boolean } 
  * @param {Token} token - HTML token to format
  * @returns {Token} Formatted token with proper self-closing syntax
  */
+/**
+ * Whether an opening-tag source string is genuinely self-closing.
+ *
+ * A trailing `/>` is not sufficient. Per the HTML tokenizer, `/` only starts
+ * the self-closing state from before-attribute-name, after-attribute-name, or
+ * after a *quoted* value. Inside an unquoted attribute value it is an ordinary
+ * character, so `<a href=https://example.com/>` is a plain opening tag whose
+ * href ends in a slash — reading it as self-closing drops the element's
+ * children on the floor.
+ *
+ * @param raw Source text of a single opening tag, e.g. `<img src="x"/>`.
+ */
+const isSelfClosedTagSource = (raw: string): boolean => {
+    if (!raw.endsWith('/>')) return false
+    const beforeSlash = raw.slice(0, -2)
+    // `<br/>` — the slash directly follows the tag name.
+    if (/^<[a-zA-Z][^\s/>]*$/.test(beforeSlash)) return true
+    // Otherwise it only self-closes after whitespace or a quoted value.
+    return /[\s"']$/.test(beforeSlash)
+}
+
 const formatSelfClosingHtmlToken = (token: Token): Token => {
     // Extract tag name from raw HTML
     const tagMatch = token.raw.match(/<\/?([a-zA-Z][a-zA-Z0-9-]*)/i)
@@ -60,24 +78,37 @@ const formatSelfClosingHtmlToken = (token: Token): Token => {
     // pick up `.tag` or they would dispatch as a second component instance.
     if (token.raw.startsWith('</')) return token
 
+    // Canonical lowercase: HTML tag names are case-insensitive, and the nested
+    // htmlparser2 path already lowercases. Emitting one casing from every path
+    // is what lets every consumer — renderer lookup, snippet lookup, void-element
+    // checks, the sanitize hook — read `tag` directly (issue #383). The source
+    // spelling is still available on `raw`.
     const tagName = tagMatch[1].toLowerCase()
-    const isVoid = SELF_CLOSING_TAGS.test(tagName)
-    const isSelfClosingForm = token.raw.endsWith('/>')
+    // Two distinct things are self-closing: known void elements (`<br>`,
+    // which may omit the slash) and any tag explicitly written in the
+    // `<tag />` form. The allowlist decides whether the slash may be
+    // *omitted* — it must not gate whether the token gets structured
+    // `tag`/`attributes` at all, or custom tag renderers registered under
+    // `renderers.html` never resolve and `<widget />` renders nothing
+    // (issue #383).
+    const isExplicitlySelfClosed = isSelfClosedTagSource(token.raw)
+    if (!isExplicitlySelfClosed && !isVoidElement(tagName)) return token
 
-    // The void-element allowlist decides HTML self-closing *rewrites*
-    // (`<br>` → `<br/>`). Structured `.tag`/`.attributes` must still be
-    // attached for custom tags written as `<widget />`, otherwise Parser
-    // cannot dispatch `renderers.html` and the token is silently dropped
-    // (issue #383). Unclosed openings skip this so pairing/streaming can
-    // still distinguish `<widget>` from `<widget />`.
-    if (!isVoid && !isSelfClosingForm) return token
-
-    const formattedRaw = isVoid && !isSelfClosingForm ? token.raw.replace(/\s*>$/, '/>') : token.raw
+    // Self-closing tags get `.tag` and `.attributes` set so downstream
+    // code (pairing, dispatch, sanitization) has structured access. If
+    // the source already used the `<.../>` form we keep raw as-is;
+    // otherwise we normalize the `>` to `/>`.
+    const formattedRaw = token.raw.endsWith('/>') ? token.raw : token.raw.replace(/\s*>$/, '/>')
     return {
         ...token,
         raw: formattedRaw,
         tag: tagName,
-        attributes: extractAttributes(token.raw)
+        attributes: extractAttributes(token.raw),
+        // A self-closing element is fully resolved and childless. The empty
+        // array (rather than `undefined`) marks it as such, so renderers can
+        // tell it apart from an unclosed tag whose children are still unknown
+        // and must not echo the raw source as text.
+        tokens: []
     }
 }
 
@@ -188,17 +219,38 @@ const hasMultipleTags = (html: string): boolean => {
  *   - Whitespace-only text between tags is dropped.
  *
  * Post-condition (depended on by `IncrementalParser`, see #291): an html
- * token's `.tokens` array is set only when a real (non-implied) closing
- * tag was seen in the source. Unclosed openings leave `.tokens` as
- * `undefined`, which is how downstream streaming code distinguishes
- * `<div>` (still streaming) from `<div></div>` (genuinely empty).
+ * token's `.tokens` array is set only when the element is *resolved* — a
+ * real (non-implied) closing tag was seen, or the tag was self-closing
+ * (`<br/>`, `<widget />`), which resolves it with no children. Unclosed
+ * openings leave `.tokens` as `undefined`, which is how downstream
+ * streaming code distinguishes `<div>` (still streaming) from
+ * `<div></div>` (genuinely empty).
  *
  * @internal
  */
 const expandHtmlBlockNested = (html: string): Token[] => {
     const root: Token[] = []
     const stack: Token[][] = [root]
-    const opens: { tag: string; opening: Token; childTokens: Token[]; startIndex: number }[] = []
+    /**
+     * Open elements awaiting their close event.
+     *
+     * A self-closing element was already emitted whole and pushed nothing onto
+     * `stack`, but htmlparser2 still emits an implied close for it, so it must
+     * occupy a slot here — otherwise that close matches an enclosing element of
+     * the same name and pops the parent instead (`<div><div/>after</div>`
+     * orphaning `after`). It carries nothing else, since its close is only
+     * absorbed, never resolved.
+     */
+    const opens: (
+        | { tag: string; selfClosed: true }
+        | {
+              tag: string
+              selfClosed?: false
+              opening: Token
+              childTokens: Token[]
+              startIndex: number
+          }
+    )[] = []
     let currentText = ''
 
     const flushText = () => {
@@ -217,13 +269,24 @@ const expandHtmlBlockNested = (html: string): Token[] => {
         {
             onopentag: (name, attributes) => {
                 flushText()
-                if (SELF_CLOSING_TAGS.test(name)) {
+                // A void element, or a tag explicitly written `<tag />`.
+                // htmlparser2 reports the latter's close as *implied*, which
+                // would otherwise route it through the unclosed-tag branch
+                // below and leave `.tokens` undefined — making renderers echo
+                // the raw source as text (issue #383). Deciding it here, at
+                // the producer, keeps the flat and nested paths in agreement.
+                const isSelfClosed =
+                    isVoidElement(name) ||
+                    isSelfClosedTagSource(html.slice(parser.startIndex, parser.endIndex + 1))
+                if (isSelfClosed) {
                     stack[stack.length - 1].push({
                         type: 'html',
                         raw: `<${name}${serializeAttributes(attributes)}/>`,
                         tag: name,
-                        attributes
+                        attributes,
+                        tokens: []
                     } as Token)
+                    opens.push({ tag: name, selfClosed: true })
                     return
                 }
                 const childTokens: Token[] = []
@@ -246,6 +309,10 @@ const expandHtmlBlockNested = (html: string): Token[] => {
                 const top = opens[opens.length - 1]
                 if (top.tag !== name) return
                 opens.pop()
+                // A self-closing element pushed nothing onto `stack` and is
+                // already fully resolved; consuming its implied close is all
+                // that is required.
+                if (top.selfClosed) return
                 stack.pop()
                 if (!implied) {
                     // Real `</tag>` in source — fully resolved nested token.
@@ -333,8 +400,10 @@ const pairFlatHtmlTokens = (tokens: Token[]): Token[] => {
 
         // Self-closing tags (e.g. <img src="x"/>) don't participate in
         // open/close pairing — pushing them onto the stack would block
-        // a later `</tag>` from finding its real opening.
-        if (token.raw.endsWith('/>')) {
+        // a later `</tag>` from finding its real opening. A bare
+        // `endsWith('/>')` misreads `<a href=/foo/>` as self-closing and
+        // strands its `</a>`, dropping the element entirely.
+        if (isSelfClosedTagSource(token.raw)) {
             result.push(token)
             continue
         }
@@ -344,6 +413,8 @@ const pairFlatHtmlTokens = (tokens: Token[]): Token[] => {
             result.push(token)
         } else {
             const lastOpen = stack.pop()
+            // Both sides are canonical lowercase, so `<Widget>x</widget>` is
+            // one element.
             if (!lastOpen || lastOpen.tag !== tagInfo.tag) {
                 result.push(token)
                 continue
@@ -362,7 +433,7 @@ const pairFlatHtmlTokens = (tokens: Token[]): Token[] => {
             result.push({
                 type: 'html',
                 raw: openingToken.raw,
-                tag: tagInfo.tag,
+                tag: lastOpen.tag,
                 tokens: innerTokens,
                 attributes: extractAttributes(openingToken.raw),
                 sourceLength

--- a/src/lib/utils/void-elements.ts
+++ b/src/lib/utils/void-elements.ts
@@ -1,0 +1,37 @@
+/**
+ * The HTML void elements — the single source of truth for "this tag can never
+ * have children".
+ *
+ * Kept in one module because the parsing and rendering halves previously
+ * carried their own copy — `token-cleanup` asking "may this tag omit its
+ * closing slash?" and `Parser` asking "may this tag receive children?" — and a
+ * tag added to one copy but not the other fails silently, exactly the class of
+ * bug tracked in issue #383.
+ *
+ * @module
+ */
+
+/** Tag names that are self-closing by definition and take no children. */
+const VOID_ELEMENTS: ReadonlySet<string> = new Set([
+    'br',
+    'hr',
+    'img',
+    'input',
+    'link',
+    'meta',
+    'area',
+    'base',
+    'col',
+    'embed',
+    'keygen',
+    'param',
+    'source',
+    'track',
+    'wbr'
+])
+
+/**
+ * Case-insensitive test for a void element name. The only public entry point,
+ * so callers cannot bypass the normalization.
+ */
+export const isVoidElement = (tagName: string): boolean => VOID_ELEMENTS.has(tagName.toLowerCase())


### PR DESCRIPTION
## Summary

Follow-up to #384 (merged as `79db29d`), which fixed the core of #383: self-closing custom tags now dispatch, casing resolves across both token paths, and empty paired elements no longer leak their raw opening tag.

This builds on that and takes the normalization one step earlier. #384 resolves casing by copying `renderers.html` and the snippet map with lowercase aliases, then preferring exact-case keys. Here, tags are lowercased where both token paths converge, and renderer keys and `html_*` snippet names are normalized to match — so a tag has exactly one entry and every consumer reads `tag` directly.

The closing-tag guard from #384 is preserved; without it a `</widget>` can pick up a `.tag` and dispatch a second component instance. The test cases from #384 pass unmodified against this implementation and are kept alongside the new ones.

## Changes

🐛 **Defects closed on top of #384**

Each was verified by rendering before and after; all but the third are also present on the pre-#384 `main`.

- **`{ IFRAME: null }` did not block `<iframe>`.** The lowercase default survived the merge and won the lookup, silently ignoring an explicit block. `buildCombinedRenderers` now canonicalizes keys so a caller entry displaces the default under any casing. (`{ iframe: null }` always worked.)
- **A trailing `/>` inside an unquoted attribute value was read as self-closing.** Per the HTML tokenizer, `/` only begins the self-closing state after whitespace or a quoted value; inside an unquoted value it is an ordinary character. So `<a href=/foo/>x</a>` lost its element entirely. All three call sites now share one predicate — the third, in `pairFlatHtmlTokens`, is why an earlier attempt fixed only nested markup.
- **A self-closing element sharing its parent's tag name popped the parent.** `htmlparser2` emits an *implied* close for self-closed tags; unaccounted for, it matches the enclosing element, so `<div><div/>after</div>` left the outer div unresolved and orphaned `after`.
- **`SanitizeContext.tag` varied by token path** despite being documented as lowercase, so a custom `sanitizeAttributes` keyed on `ctx.tag === 'iframe'` fired for `<div><IFRAME>` but not for a top-level `<IFRAME>`. Shipped defaults were unaffected — this was a contract gap for consumers writing their own hooks.
- **An `html_DIV` snippet was silently ignored for `<div>`**, because the inline fast path short-circuited on an exact-case lookup.

🔧 **Refactoring**

- Canonicalizing at the producer removes the alias maps, which were `$derived` in `Parser`'s instance script. `Parser` is instantiated per token, so the ~85-entry map was copied and re-walked for every HTML token — on every render pass, and again per chunk while streaming.
- The void-element list existed twice in two shapes (a regex in `token-cleanup.ts`, a `Set` in `Parser.svelte`). It is now one `void-elements.ts` module behind a single `isVoidElement` entry point, so parsing's "may the slash be omitted" and rendering's "may this take children" cannot drift apart.
- The duplicated html children block in `Parser.svelte` is one snippet.

🔄 **CI**

- `.trunk/trunk.yaml`: hermetic runtime `node@22.16.0` → `node@24.15.0`. `markdownlint` resolves `ini` at install time and `ini@7.0.0` raised its engine floor, so the tool could not install and every PR failed regardless of contents. Also opened standalone as #386, which can be closed in favour of this.

🧪 **Testing**

- 1020 tests pass. New coverage spans the tag/key casing matrix in both directions, both token paths, self-closing and empty forms, unquoted attribute values, and renderer-entry precedence against defaults.

## Compatibility

`tag` as seen by custom HTML renderers and by `sanitizeUrl` / `sanitizeAttributes` is now always lowercase. It previously depended on which token path produced the element, so code relying on the source spelling was already unreliable — but this is a visible change for anyone reading that prop.

Registering the same tag under two casings is now a duplicate rather than two renderers, and the last entry wins.

**Known gap, deliberately not fixed here:** unquoted attribute *values* are still dropped on the flat path (`<a href=/foo>x</a>` renders `<a>x</a>`), independent of the trailing slash. That is a pre-existing limitation of `extractAttributes`, which this branch does not touch; quoted values are unaffected.

**No release label applied** — merging as-is produces a patch bump. Given the `tag` normalization, `minor` may be more appropriate; that is a maintainer call.

## Note for reviewers

`5ca54df` is unrelated to this fix — it records a nightly competitive-intelligence digest run that was already in the working tree, isolated so it can be reviewed or ignored separately.

Refs #383. Builds on #384 — thanks @BetterAndBetterII.
