### PR TITLE
ci(trunk): bump hermetic node runtime to 24.15.0

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,7 +14,7 @@ runtimes:
     enabled:
         - go@1.21.0
         - python@3.14.4
-        - node@22.16.0
+        - node@24.15.0
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
     disabled:


### PR DESCRIPTION
## Summary

Trunk's hermetic install of `markdownlint` started failing on every pull request, so no PR in this repo can go green regardless of its contents. Bumps the Trunk hermetic Node runtime from `22.16.0` to `24.15.0`.

## Root cause

```
Error while executing: Installing hermetic tool markdownlint v0.49.1
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.16.0"}
```

`markdownlint` resolves `ini` at install time rather than from a lockfile, so the recent `ini@7.0.0` release — which raised its engine floor — left the pinned `node@22.16.0` runtime unable to install the tool. A tool that fails to install fails the whole check, which is why this presents as an unrelated lint failure on unrelated PRs.

Nothing in the repository changed to cause this; it is an upstream release landing on a pinned runtime.

## Changes

🔄 **CI**

- `.trunk/trunk.yaml`: hermetic runtime `node@22.16.0` → `node@24.15.0`, matching the Volta pin already used for local development.

This is only the runtime Trunk uses to execute linters. It is independent of the Node versions the test matrix targets, and `engines.node` (`>=22`) is unchanged.

## Verification

Cleared the cached tool locally and reinstalled under the new runtime: `markdownlint` installs cleanly, and `trunk check --all` passes across 624 files (one pre-existing non-blocking note in `src/lib/utils/token-cache.ts`, untouched here).

## Impact

Unblocks the currently open PRs, both of which are red solely because of this:

- #384
- #385
