### PR TITLE
ci: move off Blacksmith runners to GitHub-hosted

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     cleanup:
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         steps:
             - name: Cleanup
               env:

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -28,7 +28,7 @@ on:
 jobs:
     deploy:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         environment: docs
         name: Deploy
         steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ on:
 jobs:
     analyze:
         name: Analyze
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository
 
         steps:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
     build:
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         environment: ci
         strategy:
             matrix:
@@ -57,7 +57,7 @@ jobs:
 
     finish-coverage:
         needs: build
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         if: ${{ always() }}
         steps:
             - name: Coveralls Finished

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,7 +47,7 @@ on:
 
 jobs:
     check-if-merged:
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         outputs:
             should_run: ${{ steps.check.outputs.should_run }}
             has_skip_label: ${{ steps.check.outputs.has_skip_label }}
@@ -119,7 +119,7 @@ jobs:
     debug-check:
         needs: check-if-merged
         if: needs.check-if-merged.outputs.should_run == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         environment: ci
         steps:
             - name: Checkout
@@ -260,7 +260,7 @@ jobs:
     build:
         needs: [check-if-merged, debug-check]
         if: needs.check-if-merged.outputs.should_run == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         environment: ci
         strategy:
             matrix:
@@ -318,7 +318,7 @@ jobs:
         needs: [check-if-merged, debug-check]
         if: needs.check-if-merged.outputs.should_run == 'true' && needs.check-if-merged.outputs.has_skip_label != 'true'
         timeout-minutes: 60
-        runs-on: blacksmith-4vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         environment: ci
         steps:
             - uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
@@ -368,7 +368,7 @@ jobs:
             needs.check-if-merged.outputs.should_run == 'true' &&
             needs.build.result == 'success' &&
             (needs.playwright-tests.result == 'success' || needs.playwright-tests.result == 'skipped')
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         steps:
             - name: Coveralls Finished
               uses: coverallsapp/github-action@v2 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
     check-labels:
         if: github.event_name == 'pull_request'
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         outputs:
             skip_e2e: ${{ steps.check.outputs.skip_e2e }}
         steps:
@@ -38,7 +38,7 @@ jobs:
               run: echo "skip_e2e=$HAS_SKIP_LABEL" >> $GITHUB_OUTPUT
 
     unit-tests:
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
             - name: Checkout
@@ -96,7 +96,7 @@ jobs:
     e2e-tests:
         needs: [unit-tests, check-labels]
         if: needs.check-labels.outputs.skip_e2e != 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         timeout-minutes: 25
         strategy:
             fail-fast: false

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     stale:
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
 
         steps:
             - uses: actions/stale@v11 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
     trunk_check:
         name: Trunk Code Quality Runner
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         permissions:
             checks: write # For trunk to post annotations
             contents: read # For repo checkout

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
     validate:
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Moves CI off Blacksmith's hosted runners and onto the standard GitHub-hosted ones.

## What changed

- Every `blacksmith-*vcpu-ubuntu-*` label → `ubuntu-latest`.
- Jobs that genuinely need another OS (iOS/TestFlight, Electron packaging) map to the GitHub-hosted equivalent rather than Ubuntu: `blacksmith-*-macos-latest` → `macos-latest`, `blacksmith-2vcpu-windows-2025` → `windows-2025`.
- Dropped the trailing `# trunk-ignore(actionlint/runner-label)` suppressions — those existed only because actionlint doesn't know Blacksmith's labels, and the standard labels need no suppression.
- Removed the `useblacksmith/setup-docker-builder` steps where present.

## Note on the Docker builds

The Blacksmith builder step only provided its remote layer cache. On GitHub-hosted runners `docker build` already goes through BuildKit via the default docker driver, so `--secret` mounts still work and built images still land in the local image store — which the follow-on `docker tag` / `docker image push` steps rely on. Deliberately **not** swapped for `docker/setup-buildx-action`, since that provisions a `docker-container` builder whose output doesn't land in the local store without `--load` and would break those pushes.

Expect Docker-heavy builds to be slower on the first run now that the remote layer cache is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)